### PR TITLE
test: extend escrow gas/performance baselines

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -87,6 +87,21 @@ impl Escrow {
         let _ = (env, contract_id, milestone_index);
         true
     }
+
+    pub fn refund(env: Env, contract_id: u32, milestone_index: u32) -> bool {
+        let _ = (env, contract_id, milestone_index);
+        true
+    }
+
+    pub fn cancel(env: Env, contract_id: u32) -> bool {
+        let _ = (env, contract_id);
+        true
+    }
+
+    pub fn dispute(env: Env, contract_id: u32) -> bool {
+        let _ = (env, contract_id);
+        true
+    }
 }
 
 #[cfg(test)]

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -4,6 +4,25 @@ use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
 
 use crate::{Escrow, EscrowClient};
 
+mod performance;
+
+fn register_client(env: &Env) -> EscrowClient {
+    let id = env.register(Escrow, ());
+    EscrowClient::new(env, &id)
+}
+
+fn create_contract(env: &Env, client: &EscrowClient) -> (Address, Address, u32) {
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+    let milestones = vec![env, 200_0000000_i128, 400_0000000_i128, 600_0000000_i128];
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    (client_addr, freelancer_addr, contract_id)
+}
+
+fn total_milestone_amount() -> i128 {
+    200_0000000 + 400_0000000 + 600_0000000
+}
+
 #[test]
 fn test_hello() {
     let env = Env::default();

--- a/contracts/escrow/src/test/performance.rs
+++ b/contracts/escrow/src/test/performance.rs
@@ -52,6 +52,36 @@ const RELEASE_MILESTONE_BASELINE: ResourceBaseline = ResourceBaseline {
     max_fee_total: 2_100_000,
 };
 
+const REFUND_BASELINE: ResourceBaseline = ResourceBaseline {
+    max_instructions: 10_000_000,
+    max_mem_bytes: 1_000_000,
+    max_read_entries: 4,
+    max_write_entries: 3,
+    max_read_bytes: 4_096,
+    max_write_bytes: 12_288,
+    max_fee_total: 2_000_000,
+};
+
+const CANCEL_BASELINE: ResourceBaseline = ResourceBaseline {
+    max_instructions: 9_000_000,
+    max_mem_bytes: 900_000,
+    max_read_entries: 3,
+    max_write_entries: 2,
+    max_read_bytes: 4_096,
+    max_write_bytes: 8_192,
+    max_fee_total: 1_900_000,
+};
+
+const DISPUTE_BASELINE: ResourceBaseline = ResourceBaseline {
+    max_instructions: 9_000_000,
+    max_mem_bytes: 900_000,
+    max_read_entries: 3,
+    max_write_entries: 2,
+    max_read_bytes: 4_096,
+    max_write_bytes: 8_192,
+    max_fee_total: 1_900_000,
+};
+
 fn measure_last_invocation(env: &Env) -> (MeasuredResources, i64) {
     let resources = env.cost_estimate().resources();
     let fee = env.cost_estimate().fee();
@@ -178,4 +208,45 @@ fn release_milestone_resource_baseline() {
         fee_total,
         RELEASE_MILESTONE_BASELINE,
     );
+}
+
+#[test]
+fn refund_resource_baseline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (_, _, contract_id) = create_contract(&env, &client);
+    let _ = client.deposit_funds(&contract_id, &total_milestone_amount());
+    let _ = client.refund(&contract_id, &0);
+
+    let (resources, fee_total) = measure_last_invocation(&env);
+    assert_within_baseline("refund", resources, fee_total, REFUND_BASELINE);
+}
+
+#[test]
+fn cancel_resource_baseline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (_, _, contract_id) = create_contract(&env, &client);
+    let _ = client.cancel(&contract_id);
+
+    let (resources, fee_total) = measure_last_invocation(&env);
+    assert_within_baseline("cancel", resources, fee_total, CANCEL_BASELINE);
+}
+
+#[test]
+fn dispute_resource_baseline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (_, _, contract_id) = create_contract(&env, &client);
+    let _ = client.deposit_funds(&contract_id, &total_milestone_amount());
+    let _ = client.dispute(&contract_id);
+
+    let (resources, fee_total) = measure_last_invocation(&env);
+    assert_within_baseline("dispute", resources, fee_total, DISPUTE_BASELINE);
 }

--- a/docs/escrow/performance-baselines.md
+++ b/docs/escrow/performance-baselines.md
@@ -9,6 +9,9 @@ Baselines are enforced by tests in `contracts/escrow/src/test/performance.rs` fo
 - `create_contract`
 - `deposit_funds`
 - `release_milestone`
+- `refund`
+- `cancel`
+- `dispute`
 - end-to-end sequence (`create_contract` -> `deposit_funds` -> `release_milestone`)
 
 ## Methodology
@@ -50,6 +53,36 @@ Note: Soroban resource estimates in unit tests are approximations and can differ
 - max read bytes: `2,048`
 - max write bytes: `10,240`
 - max fee total (stroops): `1,550,000`
+
+### refund
+
+- max instructions: `10,000,000`
+- max memory bytes: `1,000,000`
+- max read entries: `4`
+- max write entries: `3`
+- max read bytes: `4,096`
+- max write bytes: `12,288`
+- max fee total (stroops): `2,000,000`
+
+### cancel
+
+- max instructions: `9,000,000`
+- max memory bytes: `900,000`
+- max read entries: `3`
+- max write entries: `2`
+- max read bytes: `4,096`
+- max write bytes: `8,192`
+- max fee total (stroops): `1,900,000`
+
+### dispute
+
+- max instructions: `9,000,000`
+- max memory bytes: `900,000`
+- max read entries: `3`
+- max write entries: `2`
+- max read bytes: `4,096`
+- max write bytes: `8,192`
+- max fee total (stroops): `1,900,000`
 
 ### end-to-end sequence
 


### PR DESCRIPTION
### Description:

Extends performance regression tests to cover all key escrow operations ahead of mainnet deployment.

Changes:
- Added stub contract functions for refund, cancel, and dispute to lib.rs
- Wired test/performance.rs into the test module and added shared test helpers to test.rs
- Added resource baseline constants and test functions for refund, cancel, and dispute in performance.rs, following the existing pattern for create_contract, deposit_funds, and release_milestone
- Documented the new baseline ceilings in docs/escrow/performance-baselines.md

Testing: All performance baseline tests pass via cargo test test::performance -p escrow.

Closes #226 