### PR TITLE
feat: allow withdrawal of leftover escrow after finalization

### DIFF
--- a/contracts/escrow/README.md
+++ b/contracts/escrow/README.md
@@ -10,8 +10,39 @@ This is a Rust smart contract for the **Soroban** platform that implements a sim
 - Define multiple **milestones**, each with a set payment amount.  
 - Deposit funds into escrow (only the client can do this).  
 - Release milestone payments to the freelancer once verified.  
+- Finalize contracts to enable leftover fund withdrawals.  
+- **Withdraw leftover funds** after contract finalization (client only).  
 - Issue a reputation score or credential to the freelancer after the contract is completed.  
 - Fully tested with unit tests to ensure contract correctness.
+
+---
+
+## Leftover Fund Withdrawal
+
+After a contract is finalized, the client can withdraw any remaining funds that were not released as milestone payments. This feature includes strict security invariants:
+
+- **Only allowed after contract finalization**
+- **Only the client can withdraw leftover funds**
+- **Cannot withdraw more than available balance**
+- **Prevents double withdrawals**
+- **Emits events for transparency**
+
+### Usage Example
+
+```rust
+// Create contract and deposit funds
+let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+client.deposit_funds(&contract_id, &1000, &client_addr);
+
+// Release some milestones
+client.release_milestone(&contract_id, &0, &client_addr);
+
+// Finalize the contract
+client.finalize_contract(&contract_id, &client_addr);
+
+// Withdraw remaining funds
+let leftover = client.withdraw_leftover(&contract_id, &client_addr);
+```
 
 ---
 
@@ -23,5 +54,6 @@ This is a Rust smart contract for the **Soroban** platform that implements a sim
 - Non-existent contracts are safely handled to prevent panics.  
 - Token transfers are skipped during testing to avoid unnecessary errors.  
 - Always verify the addresses used when calling contract methods.  
+- **Leftover withdrawals are protected by strict invariants** to prevent unauthorized access.  
 
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -13,6 +13,11 @@ pub enum EscrowError {
     InvalidMilestoneAmount = 3,
     InvalidDepositAmount = 4,
     InvalidMilestone = 5,
+    ContractNotFinalized = 6,
+    UnauthorizedClient = 7,
+    NoLeftoverFunds = 8,
+    AlreadyWithdrawn = 9,
+    InsufficientBalance = 10,
 }
 
 #[contracttype]
@@ -21,6 +26,19 @@ pub struct ContractData {
     pub client: Address,
     pub freelancer: Address,
     pub milestones: Vec<i128>,
+    pub deposited: i128,
+    pub released: i128,
+    pub refunded: i128,
+    pub finalized: bool,
+    pub leftover_withdrawn: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LeftoverWithdrawnEvent {
+    pub contract_id: u32,
+    pub client: Address,
+    pub amount: i128,
 }
 
 #[contracttype]
@@ -66,6 +84,11 @@ impl Escrow {
             client,
             freelancer,
             milestones,
+            deposited: 0,
+            released: 0,
+            refunded: 0,
+            finalized: false,
+            leftover_withdrawn: false,
         };
 
         env.storage()
@@ -76,16 +99,98 @@ impl Escrow {
         id
     }
 
-    pub fn deposit_funds(env: Env, _contract_id: u32, amount: i128) -> bool {
+    pub fn deposit_funds(env: Env, contract_id: u32, amount: i128, from: Address) -> bool {
         if amount <= 0 {
             env.panic_with_error(EscrowError::InvalidDepositAmount);
         }
+        
+        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
+        
+        if data.client != from {
+            env.panic_with_error(EscrowError::UnauthorizedClient);
+        }
+        
+        data.deposited += amount;
+        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
         true
     }
 
-    pub fn release_milestone(env: Env, contract_id: u32, milestone_index: u32) -> bool {
-        let _ = (env, contract_id, milestone_index);
+    pub fn release_milestone(env: Env, contract_id: u32, milestone_index: u32, from: Address) -> bool {
+        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
+        
+        if data.client != from {
+            env.panic_with_error(EscrowError::UnauthorizedClient);
+        }
+        
+        if milestone_index >= data.milestones.len() as u32 {
+            env.panic_with_error(EscrowError::InvalidMilestone);
+        }
+        
+        let milestone_amount = data.milestones.get(milestone_index as u32).unwrap();
+        if data.released + milestone_amount > data.deposited {
+            env.panic_with_error(EscrowError::InsufficientBalance);
+        }
+        
+        data.released += milestone_amount;
+        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
         true
+    }
+
+    pub fn finalize_contract(env: Env, contract_id: u32, from: Address) -> bool {
+        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
+        
+        if data.client != from {
+            env.panic_with_error(EscrowError::UnauthorizedClient);
+        }
+        
+        if data.finalized {
+            return true; // Already finalized
+        }
+        
+        data.finalized = true;
+        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
+        true
+    }
+
+    pub fn withdraw_leftover(env: Env, contract_id: u32, from: Address) -> i128 {
+        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
+        
+        // Strict invariants
+        if data.client != from {
+            env.panic_with_error(EscrowError::UnauthorizedClient);
+        }
+        
+        if !data.finalized {
+            env.panic_with_error(EscrowError::ContractNotFinalized);
+        }
+        
+        if data.leftover_withdrawn {
+            env.panic_with_error(EscrowError::AlreadyWithdrawn);
+        }
+        
+        let leftover = data.deposited - data.released - data.refunded;
+        
+        if leftover <= 0 {
+            env.panic_with_error(EscrowError::NoLeftoverFunds);
+        }
+        
+        // Update state
+        data.leftover_withdrawn = true;
+        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
+        
+        // Emit event
+        let event = LeftoverWithdrawnEvent {
+            contract_id,
+            client: data.client,
+            amount: leftover,
+        };
+        env.events().publish(("LeftoverWithdrawn", "withdraw"), event);
+        
+        leftover
     }
 }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -103,93 +103,119 @@ impl Escrow {
         if amount <= 0 {
             env.panic_with_error(EscrowError::InvalidDepositAmount);
         }
-        
-        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+
+        let mut data = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&DataKey::Contract(contract_id))
             .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
-        
+
         if data.client != from {
             env.panic_with_error(EscrowError::UnauthorizedClient);
         }
-        
+
         data.deposited += amount;
-        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &data);
         true
     }
 
-    pub fn release_milestone(env: Env, contract_id: u32, milestone_index: u32, from: Address) -> bool {
-        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+    pub fn release_milestone(
+        env: Env,
+        contract_id: u32,
+        milestone_index: u32,
+        from: Address,
+    ) -> bool {
+        let mut data = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&DataKey::Contract(contract_id))
             .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
-        
+
         if data.client != from {
             env.panic_with_error(EscrowError::UnauthorizedClient);
         }
-        
+
         if milestone_index >= data.milestones.len() as u32 {
             env.panic_with_error(EscrowError::InvalidMilestone);
         }
-        
+
         let milestone_amount = data.milestones.get(milestone_index as u32).unwrap();
         if data.released + milestone_amount > data.deposited {
             env.panic_with_error(EscrowError::InsufficientBalance);
         }
-        
+
         data.released += milestone_amount;
-        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &data);
         true
     }
 
     pub fn finalize_contract(env: Env, contract_id: u32, from: Address) -> bool {
-        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+        let mut data = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&DataKey::Contract(contract_id))
             .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
-        
+
         if data.client != from {
             env.panic_with_error(EscrowError::UnauthorizedClient);
         }
-        
+
         if data.finalized {
             return true; // Already finalized
         }
-        
+
         data.finalized = true;
-        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &data);
         true
     }
 
     pub fn withdraw_leftover(env: Env, contract_id: u32, from: Address) -> i128 {
-        let mut data = env.storage().persistent().get::<_, ContractData>(&DataKey::Contract(contract_id))
+        let mut data = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&DataKey::Contract(contract_id))
             .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidMilestone));
-        
+
         // Strict invariants
         if data.client != from {
             env.panic_with_error(EscrowError::UnauthorizedClient);
         }
-        
+
         if !data.finalized {
             env.panic_with_error(EscrowError::ContractNotFinalized);
         }
-        
+
         if data.leftover_withdrawn {
             env.panic_with_error(EscrowError::AlreadyWithdrawn);
         }
-        
+
         let leftover = data.deposited - data.released - data.refunded;
-        
+
         if leftover <= 0 {
             env.panic_with_error(EscrowError::NoLeftoverFunds);
         }
-        
+
         // Update state
         data.leftover_withdrawn = true;
-        env.storage().persistent().set(&DataKey::Contract(contract_id), &data);
-        
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &data);
+
         // Emit event
         let event = LeftoverWithdrawnEvent {
             contract_id,
             client: data.client,
             amount: leftover,
         };
-        env.events().publish(("LeftoverWithdrawn", "withdraw"), event);
-        
+        env.events()
+            .publish(("LeftoverWithdrawn", "withdraw"), event);
+
         leftover
     }
 }

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -34,7 +34,12 @@ fn test_deposit_funds() {
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
-    let result = client.deposit_funds(&1, &1_000_0000000);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128, 600_0000000_i128];
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+
+    let result = client.deposit_funds(&contract_id, &1_000_0000000, &client_addr);
     assert!(result);
 }
 
@@ -44,6 +49,116 @@ fn test_release_milestone() {
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
-    let result = client.release_milestone(&1, &0);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128, 600_0000000_i128];
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+
+    assert!(client.deposit_funds(&contract_id, &1_200_0000000, &client_addr));
+    let result = client.release_milestone(&contract_id, &0, &client_addr);
     assert!(result);
+}
+
+#[test]
+fn test_withdraw_leftover_success() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128]; // Total: 600
+
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    assert!(client.deposit_funds(&contract_id, &1_000_0000000, &client_addr)); // Deposit: 1000
+    assert!(client.release_milestone(&contract_id, &0, &client_addr)); // Release: 200
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    // Leftover should be: 1000 - 200 = 800
+    let withdrawn = client.withdraw_leftover(&contract_id, &client_addr);
+    assert_eq!(withdrawn, 800_0000000);
+}
+
+#[test]
+#[should_panic]
+fn test_withdraw_leftover_before_finalization() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128];
+
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    assert!(client.deposit_funds(&contract_id, &1_000_0000000, &client_addr));
+    assert!(client.release_milestone(&contract_id, &0, &client_addr));
+
+    // Try to withdraw without finalization
+    client.withdraw_leftover(&contract_id, &client_addr);
+}
+
+#[test]
+#[should_panic]
+fn test_withdraw_leftover_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let unauthorized_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128];
+
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    assert!(client.deposit_funds(&contract_id, &1_000_0000000, &client_addr));
+    assert!(client.release_milestone(&contract_id, &0, &client_addr));
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    // Try to withdraw as unauthorized user
+    client.withdraw_leftover(&contract_id, &unauthorized_addr);
+}
+
+#[test]
+#[should_panic]
+fn test_withdraw_leftover_no_funds() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128]; // Total: 600
+
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    assert!(client.deposit_funds(&contract_id, &600_0000000, &client_addr)); // Deposit exactly 600
+    assert!(client.release_milestone(&contract_id, &0, &client_addr)); // Release: 200
+    assert!(client.release_milestone(&contract_id, &1, &client_addr)); // Release: 400
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    // No leftover should remain
+    client.withdraw_leftover(&contract_id, &client_addr);
+}
+
+#[test]
+#[should_panic]
+fn test_withdraw_leftover_double_withdraw() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128];
+
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    assert!(client.deposit_funds(&contract_id, &1_000_0000000, &client_addr));
+    assert!(client.release_milestone(&contract_id, &0, &client_addr));
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    // First withdrawal should succeed
+    let _withdrawn = client.withdraw_leftover(&contract_id, &client_addr);
+    
+    // Second withdrawal should fail
+    client.withdraw_leftover(&contract_id, &client_addr);
 }

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -158,7 +158,7 @@ fn test_withdraw_leftover_double_withdraw() {
 
     // First withdrawal should succeed
     let _withdrawn = client.withdraw_leftover(&contract_id, &client_addr);
-    
+
     // Second withdrawal should fail
     client.withdraw_leftover(&contract_id, &client_addr);
 }


### PR DESCRIPTION
Add withdraw_leftover method with strict invariants:
- Only allowed after contract finalization
- Only client can withdraw leftover funds
- Cannot exceed available balance
- Prevents double withdrawals
- Emits events for transparency

Includes comprehensive test coverage for edge cases:
- Unauthorized access attempts
- Withdrawal before finalization
- Zero leftover scenarios
- Double withdrawal prevention

Updated documentation with usage examples and security notes.

Closes #242