### PR TITLE
feat: Add explicit storage TTL/expiration policy for transient keys

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,6 +1,16 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    Symbol, Vec,
+};
+
+mod ttl;
+
+pub use ttl::{
+    LEDGERS_PER_DAY, PENDING_APPROVAL_BUMP_THRESHOLD, PENDING_APPROVAL_TTL_LEDGERS,
+    PENDING_MIGRATION_BUMP_THRESHOLD, PENDING_MIGRATION_TTL_LEDGERS,
+};
 
 #[contract]
 pub struct Escrow;
@@ -13,6 +23,11 @@ pub enum EscrowError {
     InvalidMilestoneAmount = 3,
     InvalidDepositAmount = 4,
     InvalidMilestone = 5,
+    PendingApprovalExists = 6,
+    PendingApprovalNotFound = 7,
+    PendingMigrationExists = 8,
+    PendingMigrationNotFound = 9,
+    Unauthorized = 10,
 }
 
 #[contracttype]
@@ -24,10 +39,30 @@ pub struct ContractData {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingApproval {
+    pub approver: Address,
+    pub contract_id: u32,
+    pub requested_at_ledger: u32,
+    pub expires_at_ledger: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingMigration {
+    pub proposer: Address,
+    pub new_wasm_hash: BytesN<32>,
+    pub requested_at_ledger: u32,
+    pub expires_at_ledger: u32,
+}
+
+#[contracttype]
 #[derive(Clone)]
 enum DataKey {
     NextId,
     Contract(u32),
+    PendingApproval(u32),
+    PendingMigration,
 }
 
 #[contractimpl]
@@ -86,6 +121,167 @@ impl Escrow {
     pub fn release_milestone(env: Env, contract_id: u32, milestone_index: u32) -> bool {
         let _ = (env, contract_id, milestone_index);
         true
+    }
+
+    pub fn request_approval(env: Env, approver: Address, contract_id: u32) -> PendingApproval {
+        approver.require_auth();
+
+        let key = DataKey::PendingApproval(contract_id);
+        if ttl::has_transient(&env, &key) {
+            env.panic_with_error(EscrowError::PendingApprovalExists);
+        }
+
+        let requested_at_ledger = env.ledger().sequence();
+        let expires_at_ledger = ttl::compute_expiry(&env, PENDING_APPROVAL_TTL_LEDGERS);
+
+        let pending = PendingApproval {
+            approver: approver.clone(),
+            contract_id,
+            requested_at_ledger,
+            expires_at_ledger,
+        };
+
+        ttl::store_with_ttl(&env, &key, &pending, PENDING_APPROVAL_TTL_LEDGERS);
+
+        env.events().publish(
+            (symbol_short!("ttl"), symbol_short!("requested")),
+            (
+                symbol_short!("approval"),
+                contract_id,
+                approver,
+                requested_at_ledger,
+                expires_at_ledger,
+            ),
+        );
+
+        pending
+    }
+
+    pub fn cancel_approval(env: Env, approver: Address, contract_id: u32) {
+        approver.require_auth();
+
+        let key = DataKey::PendingApproval(contract_id);
+        let pending: PendingApproval = ttl::read_if_live(&env, &key)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PendingApprovalNotFound));
+
+        if pending.approver != approver {
+            env.panic_with_error(EscrowError::Unauthorized);
+        }
+
+        ttl::remove_transient(&env, &key);
+
+        env.events().publish(
+            (symbol_short!("ttl"), symbol_short!("cancelled")),
+            (symbol_short!("approval"), contract_id, approver),
+        );
+    }
+
+    pub fn get_pending_approval(env: Env, contract_id: u32) -> Option<PendingApproval> {
+        ttl::read_if_live(&env, &DataKey::PendingApproval(contract_id))
+    }
+
+    pub fn extend_pending_approval(env: Env, approver: Address, contract_id: u32) -> bool {
+        approver.require_auth();
+
+        let key = DataKey::PendingApproval(contract_id);
+        ttl::extend_if_below_threshold(
+            &env,
+            &key,
+            PENDING_APPROVAL_BUMP_THRESHOLD,
+            PENDING_APPROVAL_TTL_LEDGERS,
+        )
+    }
+
+    pub fn request_migration(
+        env: Env,
+        proposer: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> PendingMigration {
+        proposer.require_auth();
+
+        let key = DataKey::PendingMigration;
+        if ttl::has_transient(&env, &key) {
+            env.panic_with_error(EscrowError::PendingMigrationExists);
+        }
+
+        let requested_at_ledger = env.ledger().sequence();
+        let expires_at_ledger = ttl::compute_expiry(&env, PENDING_MIGRATION_TTL_LEDGERS);
+
+        let pending = PendingMigration {
+            proposer: proposer.clone(),
+            new_wasm_hash: new_wasm_hash.clone(),
+            requested_at_ledger,
+            expires_at_ledger,
+        };
+
+        ttl::store_with_ttl(&env, &key, &pending, PENDING_MIGRATION_TTL_LEDGERS);
+
+        env.events().publish(
+            (symbol_short!("ttl"), symbol_short!("requested")),
+            (
+                symbol_short!("migration"),
+                proposer,
+                new_wasm_hash,
+                requested_at_ledger,
+                expires_at_ledger,
+            ),
+        );
+
+        pending
+    }
+
+    pub fn confirm_migration(env: Env, confirmer: Address) {
+        confirmer.require_auth();
+
+        let key = DataKey::PendingMigration;
+        let pending: PendingMigration = ttl::read_if_live(&env, &key)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PendingMigrationNotFound));
+
+        ttl::remove_transient(&env, &key);
+
+        env.events().publish(
+            (symbol_short!("ttl"), symbol_short!("confirmed")),
+            (
+                symbol_short!("migration"),
+                confirmer,
+                pending.new_wasm_hash,
+            ),
+        );
+    }
+
+    pub fn cancel_migration(env: Env, proposer: Address) {
+        proposer.require_auth();
+
+        let key = DataKey::PendingMigration;
+        let pending: PendingMigration = ttl::read_if_live(&env, &key)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PendingMigrationNotFound));
+
+        if pending.proposer != proposer {
+            env.panic_with_error(EscrowError::Unauthorized);
+        }
+
+        ttl::remove_transient(&env, &key);
+
+        env.events().publish(
+            (symbol_short!("ttl"), symbol_short!("cancelled")),
+            (symbol_short!("migration"), proposer),
+        );
+    }
+
+    pub fn get_pending_migration(env: Env) -> Option<PendingMigration> {
+        ttl::read_if_live(&env, &DataKey::PendingMigration)
+    }
+
+    pub fn extend_pending_migration(env: Env, proposer: Address) -> bool {
+        proposer.require_auth();
+
+        let key = DataKey::PendingMigration;
+        ttl::extend_if_below_threshold(
+            &env,
+            &key,
+            PENDING_MIGRATION_BUMP_THRESHOLD,
+            PENDING_MIGRATION_TTL_LEDGERS,
+        )
     }
 }
 

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
 
 use crate::{Escrow, EscrowClient};
 
+mod ttl_tests;
+
 #[test]
 fn test_hello() {
     let env = Env::default();

--- a/contracts/escrow/src/test/ttl_tests.rs
+++ b/contracts/escrow/src/test/ttl_tests.rs
@@ -1,0 +1,221 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env,
+};
+
+use crate::{
+    Escrow, EscrowClient, PENDING_APPROVAL_BUMP_THRESHOLD, PENDING_APPROVAL_TTL_LEDGERS,
+    PENDING_MIGRATION_TTL_LEDGERS,
+};
+
+fn new_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.max_entry_ttl = PENDING_MIGRATION_TTL_LEDGERS * 4;
+        li.min_persistent_entry_ttl = PENDING_MIGRATION_TTL_LEDGERS * 4;
+    });
+    env
+}
+
+fn advance_sequence(env: &Env, by: u32) {
+    env.ledger().with_mut(|li| {
+        li.sequence_number = li.sequence_number.saturating_add(by);
+    });
+}
+
+fn register_client(env: &Env) -> EscrowClient<'_> {
+    let contract_id = env.register(Escrow, ());
+    EscrowClient::new(env, &contract_id)
+}
+
+fn sample_wasm_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[7u8; 32])
+}
+
+#[test]
+fn pending_approval_readable_before_expiry() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+    let starting_sequence = env.ledger().sequence();
+
+    client.request_approval(&approver, &1);
+    advance_sequence(&env, PENDING_APPROVAL_TTL_LEDGERS - 1);
+
+    let pending = client.get_pending_approval(&1);
+    assert!(pending.is_some(), "approval should be live before expiry");
+    let pending = pending.unwrap();
+    assert_eq!(pending.approver, approver);
+    assert_eq!(pending.contract_id, 1);
+    assert_eq!(pending.requested_at_ledger, starting_sequence);
+    assert_eq!(
+        pending.expires_at_ledger,
+        starting_sequence + PENDING_APPROVAL_TTL_LEDGERS
+    );
+}
+
+#[test]
+fn pending_approval_evicted_after_expiry() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+
+    client.request_approval(&approver, &1);
+    advance_sequence(&env, PENDING_APPROVAL_TTL_LEDGERS + 1);
+
+    assert!(client.get_pending_approval(&1).is_none());
+}
+
+#[test]
+fn pending_migration_readable_before_expiry() {
+    let env = new_env();
+    let client = register_client(&env);
+    let proposer = Address::generate(&env);
+    let hash = sample_wasm_hash(&env);
+    let starting_sequence = env.ledger().sequence();
+
+    client.request_migration(&proposer, &hash);
+    advance_sequence(&env, PENDING_MIGRATION_TTL_LEDGERS - 1);
+
+    let pending = client.get_pending_migration();
+    assert!(pending.is_some());
+    let pending = pending.unwrap();
+    assert_eq!(pending.proposer, proposer);
+    assert_eq!(pending.new_wasm_hash, hash);
+    assert_eq!(
+        pending.expires_at_ledger,
+        starting_sequence + PENDING_MIGRATION_TTL_LEDGERS
+    );
+}
+
+#[test]
+fn pending_migration_evicted_after_expiry() {
+    let env = new_env();
+    let client = register_client(&env);
+    let proposer = Address::generate(&env);
+
+    client.request_migration(&proposer, &sample_wasm_hash(&env));
+    advance_sequence(&env, PENDING_MIGRATION_TTL_LEDGERS + 1);
+
+    assert!(client.get_pending_migration().is_none());
+}
+
+#[test]
+fn extend_if_below_threshold_bumps_when_near_expiry() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+
+    client.request_approval(&approver, &1);
+
+    advance_sequence(
+        &env,
+        PENDING_APPROVAL_TTL_LEDGERS - PENDING_APPROVAL_BUMP_THRESHOLD + 1,
+    );
+
+    let extended = client.extend_pending_approval(&approver, &1);
+    assert!(extended);
+
+    advance_sequence(&env, PENDING_APPROVAL_BUMP_THRESHOLD + 1);
+    assert!(
+        client.get_pending_approval(&1).is_some(),
+        "entry should survive past original expiry after extension"
+    );
+}
+
+#[test]
+fn extend_if_below_threshold_noop_when_fresh() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+
+    client.request_approval(&approver, &1);
+    let ok = client.extend_pending_approval(&approver, &1);
+    assert!(ok, "call succeeds even when already fresh");
+
+    advance_sequence(&env, PENDING_APPROVAL_TTL_LEDGERS - 1);
+    assert!(client.get_pending_approval(&1).is_some());
+}
+
+#[test]
+fn extend_returns_false_when_key_absent() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+
+    let result = client.extend_pending_approval(&approver, &42);
+    assert!(!result);
+}
+
+#[test]
+fn deterministic_expiry() {
+    let env_a = new_env();
+    let env_b = new_env();
+    let client_a = register_client(&env_a);
+    let client_b = register_client(&env_b);
+
+    let approver_a = Address::generate(&env_a);
+    let approver_b = Address::generate(&env_b);
+
+    let a = client_a.request_approval(&approver_a, &7);
+    let b = client_b.request_approval(&approver_b, &7);
+
+    assert_eq!(a.requested_at_ledger, b.requested_at_ledger);
+    assert_eq!(a.expires_at_ledger, b.expires_at_ledger);
+    assert_eq!(
+        a.expires_at_ledger,
+        a.requested_at_ledger + PENDING_APPROVAL_TTL_LEDGERS
+    );
+}
+
+#[test]
+fn cancel_removes_pending_approval() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+
+    client.request_approval(&approver, &1);
+    assert!(client.get_pending_approval(&1).is_some());
+
+    client.cancel_approval(&approver, &1);
+    assert!(client.get_pending_approval(&1).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn duplicate_request_approval_rejects() {
+    let env = new_env();
+    let client = register_client(&env);
+    let approver = Address::generate(&env);
+
+    client.request_approval(&approver, &1);
+    client.request_approval(&approver, &1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn duplicate_request_migration_rejects() {
+    let env = new_env();
+    let client = register_client(&env);
+    let proposer = Address::generate(&env);
+    let hash = sample_wasm_hash(&env);
+
+    client.request_migration(&proposer, &hash);
+    client.request_migration(&proposer, &hash);
+}
+
+#[test]
+fn confirm_migration_clears_pending() {
+    let env = new_env();
+    let client = register_client(&env);
+    let proposer = Address::generate(&env);
+    let confirmer = Address::generate(&env);
+
+    client.request_migration(&proposer, &sample_wasm_hash(&env));
+    client.confirm_migration(&confirmer);
+
+    assert!(client.get_pending_migration().is_none());
+}

--- a/contracts/escrow/src/ttl.rs
+++ b/contracts/escrow/src/ttl.rs
@@ -1,0 +1,72 @@
+//! Deterministic TTL / expiration policy for transient storage.
+//!
+//! All TTL values are denominated in ledgers (Soroban-native, ~5s per ledger
+//! on Stellar mainnet). Pending approvals and pending migrations are stored
+//! in `env.storage().temporary()`; Soroban auto-evicts entries whose TTL has
+//! elapsed, so `read_if_live` returns `None` for both "never set" and
+//! "expired".
+
+use soroban_sdk::{Env, IntoVal, TryFromVal, Val};
+
+pub const LEDGERS_PER_DAY: u32 = 17_280;
+
+pub const PENDING_APPROVAL_TTL_LEDGERS: u32 = LEDGERS_PER_DAY * 7;
+pub const PENDING_APPROVAL_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY;
+
+pub const PENDING_MIGRATION_TTL_LEDGERS: u32 = LEDGERS_PER_DAY * 21;
+pub const PENDING_MIGRATION_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY * 3;
+
+pub fn compute_expiry(env: &Env, ttl_ledgers: u32) -> u32 {
+    env.ledger()
+        .sequence()
+        .saturating_add(ttl_ledgers)
+}
+
+pub fn store_with_ttl<K, V>(env: &Env, key: &K, value: &V, ttl_ledgers: u32)
+where
+    K: IntoVal<Env, Val>,
+    V: IntoVal<Env, Val>,
+{
+    let storage = env.storage().temporary();
+    storage.set(key, value);
+    storage.extend_ttl(key, ttl_ledgers, ttl_ledgers);
+}
+
+pub fn read_if_live<K, V>(env: &Env, key: &K) -> Option<V>
+where
+    K: IntoVal<Env, Val>,
+    V: TryFromVal<Env, Val>,
+{
+    env.storage().temporary().get(key)
+}
+
+pub fn extend_if_below_threshold<K>(
+    env: &Env,
+    key: &K,
+    threshold: u32,
+    extend_to: u32,
+) -> bool
+where
+    K: IntoVal<Env, Val>,
+{
+    let storage = env.storage().temporary();
+    if !storage.has(key) {
+        return false;
+    }
+    storage.extend_ttl(key, threshold, extend_to);
+    true
+}
+
+pub fn remove_transient<K>(env: &Env, key: &K)
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().temporary().remove(key);
+}
+
+pub fn has_transient<K>(env: &Env, key: &K) -> bool
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().temporary().has(key)
+}

--- a/docs/escrow/state-persistence.md
+++ b/docs/escrow/state-persistence.md
@@ -2,6 +2,8 @@
 
 This document maps the escrow contract's persisted storage to the lifecycle invariants reviewers should verify.
 
+For transient keys (pending approvals, pending migrations) and their TTL / expiration policy, see [storage-ttl.md](./storage-ttl.md).
+
 ## Storage Keys
 
 | Key | Value | Purpose |

--- a/docs/escrow/storage-ttl.md
+++ b/docs/escrow/storage-ttl.md
@@ -1,0 +1,126 @@
+# Storage TTL / Expiration Policy
+
+This document defines the deterministic, auditable TTL (time-to-live) policy for **transient** storage entries in the escrow contract. It exists to prevent unbounded state growth from orphaned pending approvals and pending migrations that are never resolved by counterparties.
+
+See also: [state-persistence.md](./state-persistence.md) for the persistent storage model; [upgradeable-storage.md](./upgradeable-storage.md) for upgrade semantics.
+
+## Scope
+
+Applies to keys stored in `env.storage().temporary()`. Persistent keys (e.g. `Contract(id)`, `NextId`) are unaffected — their TTL management is covered in [architecture.md](./architecture.md).
+
+## Units
+
+All TTL values are denominated in **ledgers**, the Soroban-native unit. One ledger is ~5 seconds on Stellar mainnet. This avoids any coupling to wall-clock timestamps and keeps expiry deterministic as a function of `env.ledger().sequence()`.
+
+| Named constant | Ledgers | Rough duration |
+| --- | ---: | --- |
+| `LEDGERS_PER_DAY` | 17 280 | 1 day |
+| `PENDING_APPROVAL_TTL_LEDGERS` | 120 960 | 7 days |
+| `PENDING_APPROVAL_BUMP_THRESHOLD` | 17 280 | 1 day |
+| `PENDING_MIGRATION_TTL_LEDGERS` | 362 880 | 21 days |
+| `PENDING_MIGRATION_BUMP_THRESHOLD` | 51 840 | 3 days |
+
+Constants live in [contracts/escrow/src/ttl.rs](../../contracts/escrow/src/ttl.rs).
+
+## Transient Keys
+
+| Key | Value type | TTL | Bump threshold | Rationale |
+| --- | --- | ---: | ---: | --- |
+| `PendingApproval(contract_id: u32)` | `PendingApproval` | 7 days | 1 day | Counterparties are expected to respond within one business week; short enough to reclaim state on abandonment, long enough to tolerate holidays. |
+| `PendingMigration` | `PendingMigration` | 21 days | 3 days | Migrations are rarer and more consequential; reviewers need more lead time and explicit bump windows. |
+
+`PendingMigration` is a **single-slot** key: at most one migration may be pending at any time, which is enforced by `PendingMigrationExists` (error code 8).
+
+## Value Schema
+
+Each transient value stores its own expiry metadata alongside Soroban's internal TTL. This is intentional redundancy so that on-chain readers and event indexers can audit expiry independently of Soroban's TTL ledger metadata.
+
+```rust
+pub struct PendingApproval {
+    pub approver: Address,
+    pub contract_id: u32,
+    pub requested_at_ledger: u32,
+    pub expires_at_ledger: u32,
+}
+
+pub struct PendingMigration {
+    pub proposer: Address,
+    pub new_wasm_hash: BytesN<32>,
+    pub requested_at_ledger: u32,
+    pub expires_at_ledger: u32,
+}
+```
+
+## Determinism
+
+Expiry is computed at write time as:
+
+```
+expires_at_ledger = requested_at_ledger + TTL
+                  = env.ledger().sequence() + TTL
+```
+
+Given the same ledger sequence and the same TTL constant, two runs produce identical `expires_at_ledger` values. Covered by test `deterministic_expiry` in [contracts/escrow/src/test/ttl_tests.rs](../../contracts/escrow/src/test/ttl_tests.rs).
+
+## Expiry Semantics
+
+- Soroban auto-evicts temporary storage entries once their TTL has elapsed.
+- `read_if_live` (used by `get_pending_approval` / `get_pending_migration`) returns `Option<_>`; after expiry it returns `None`.
+- The contract **does not distinguish** "never set" from "expired on read". Consumers must treat `None` as "no active pending record" in both cases.
+- No on-chain event is emitted at the moment of auto-eviction — Soroban does not expose an eviction hook. Off-chain indexers should compute eviction by comparing the stored `expires_at_ledger` against the current ledger sequence.
+
+## Extending (Bumping) TTL
+
+`extend_pending_approval` / `extend_pending_migration` wrap `env.storage().temporary().extend_ttl(key, threshold, extend_to)`:
+
+- If remaining TTL is **below** the bump threshold, the entry's TTL is extended to the full policy value.
+- If the entry is already fresh, the call is a no-op.
+- If the entry is absent or already evicted, the helper returns `false` and performs no write.
+
+Callers must still be authorised (`approver.require_auth()` / `proposer.require_auth()`).
+
+## Events (Audit Trail)
+
+All state-changing TTL operations publish a structured event:
+
+| Topic 0 | Topic 1 | Data tuple |
+| --- | --- | --- |
+| `ttl` | `requested` | `(subject, identifier..., actor, requested_at_ledger, expires_at_ledger)` |
+| `ttl` | `cancelled` | `(subject, identifier..., actor)` |
+| `ttl` | `confirmed` | `(subject, identifier..., actor)` |
+
+`subject` is `approval` or `migration`. For approvals, `identifier` is the `contract_id`; for migrations, `identifier` is the `new_wasm_hash` (on request) or absent (on cancel).
+
+Auto-eviction emits no event. See *Expiry Semantics* above.
+
+## Error Codes
+
+| Variant | Code | Meaning |
+| --- | ---: | --- |
+| `PendingApprovalExists` | 6 | An approval is already pending for this contract. |
+| `PendingApprovalNotFound` | 7 | No live approval to cancel. |
+| `PendingMigrationExists` | 8 | A migration is already pending. |
+| `PendingMigrationNotFound` | 9 | No live migration to cancel or confirm. |
+| `Unauthorized` | 10 | Caller is not the original requester. |
+
+## Testing
+
+Expiry is exercised by advancing `LedgerInfo.sequence_number` via `env.ledger().with_mut(...)`. See [contracts/escrow/src/test/ttl_tests.rs](../../contracts/escrow/src/test/ttl_tests.rs) for the full matrix:
+
+- `pending_{approval,migration}_readable_before_expiry`
+- `pending_{approval,migration}_evicted_after_expiry`
+- `extend_if_below_threshold_bumps_when_near_expiry`
+- `extend_if_below_threshold_noop_when_fresh`
+- `extend_returns_false_when_key_absent`
+- `deterministic_expiry`
+- `cancel_removes_pending_approval`
+- `duplicate_request_{approval,migration}_rejects`
+- `confirm_migration_clears_pending`
+
+## Reviewer Checklist
+
+1. Every new transient key has an entry in the table above.
+2. Every write uses `ttl::store_with_ttl` (no direct `.temporary().set` bypass).
+3. Every read path uses `ttl::read_if_live` and handles `None` as "absent or expired".
+4. Expiry metadata on the value matches the constant applied at write time.
+5. A corresponding TTL test exists when a new transient key is introduced.


### PR DESCRIPTION
Added explicit storage TTL/expiration policy for transient keys (pending approvals/migrations).

Closes: #231 