### PR TITLE
test: add proptest suite for escrow invariants

### DIFF
--- a/contracts/escrow/proptest-regressions/proptest.txt
+++ b/contracts/escrow/proptest-regressions/proptest.txt
@@ -1,0 +1,6 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,38 +1,70 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec,
+};
 
 #[contract]
 pub struct Escrow;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
 pub enum EscrowError {
     InvalidParticipant = 1,
     EmptyMilestones = 2,
     InvalidMilestoneAmount = 3,
-    InvalidDepositAmount = 4,
-    InvalidMilestone = 5,
+    ContractNotFound = 4,
+    InvalidDepositAmount = 5,
+    DepositExceedsTotal = 6,
+    InvalidMilestone = 7,
+    MilestoneAlreadyReleased = 8,
+    MilestoneAlreadyRefunded = 9,
+    InsufficientEscrowBalance = 10,
+    InvalidStatus = 11,
+    EmptyRefundRequest = 12,
+    DuplicateMilestone = 13,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ContractStatus {
+    Created = 0,
+    Funded = 1,
+    Completed = 2,
+    Refunded = 3,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ContractData {
+pub struct Milestone {
+    pub amount: i128,
+    pub released: bool,
+    pub refunded: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowContractData {
     pub client: Address,
     pub freelancer: Address,
-    pub milestones: Vec<i128>,
+    pub status: ContractStatus,
+    pub total_amount: i128,
+    pub funded_amount: i128,
+    pub released_amount: i128,
+    pub refunded_amount: i128,
 }
 
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
-    NextId,
     Contract(u32),
+    Milestones(u32),
+    ContractCount,
 }
 
 #[contractimpl]
 impl Escrow {
-    /// Hello-world style function for testing and CI.
     pub fn hello(_env: Env, to: Symbol) -> Symbol {
         to
     }
@@ -41,53 +73,238 @@ impl Escrow {
         env: Env,
         client: Address,
         freelancer: Address,
-        milestones: Vec<i128>,
+        milestone_amounts: Vec<i128>,
     ) -> u32 {
+        client.require_auth();
+
         if client == freelancer {
             env.panic_with_error(EscrowError::InvalidParticipant);
         }
-        if milestones.is_empty() {
+        if milestone_amounts.is_empty() {
             env.panic_with_error(EscrowError::EmptyMilestones);
         }
 
-        for amount in milestones.iter() {
+        let mut total_amount: i128 = 0;
+        let mut milestones: Vec<Milestone> = Vec::new(&env);
+        for amount in milestone_amounts.iter() {
             if amount <= 0 {
                 env.panic_with_error(EscrowError::InvalidMilestoneAmount);
             }
+            total_amount += amount;
+            milestones.push_back(Milestone {
+                amount,
+                released: false,
+                refunded: false,
+            });
         }
 
-        let id = env
+        let id: u32 = env
             .storage()
             .persistent()
-            .get::<_, u32>(&DataKey::NextId)
-            .unwrap_or(0);
+            .get(&DataKey::ContractCount)
+            .unwrap_or(0u32);
 
-        let data = ContractData {
+        let data = EscrowContractData {
             client,
             freelancer,
-            milestones,
+            status: ContractStatus::Created,
+            total_amount,
+            funded_amount: 0,
+            released_amount: 0,
+            refunded_amount: 0,
         };
 
+        env.storage().persistent().set(&DataKey::Contract(id), &data);
         env.storage()
             .persistent()
-            .set(&DataKey::Contract(id), &data);
-        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+            .set(&DataKey::Milestones(id), &milestones);
+        env.storage().persistent().set(&DataKey::ContractCount, &(id + 1));
 
         id
     }
 
-    pub fn deposit_funds(env: Env, _contract_id: u32, amount: i128) -> bool {
+    pub fn deposit_funds(env: Env, contract_id: u32, amount: i128) -> bool {
         if amount <= 0 {
             env.panic_with_error(EscrowError::InvalidDepositAmount);
         }
+
+        let mut data = Self::load_contract(&env, contract_id);
+        data.client.require_auth();
+        Self::assert_open(&env, data.status);
+
+        let new_funded = data.funded_amount + amount;
+        if new_funded > data.total_amount {
+            env.panic_with_error(EscrowError::DepositExceedsTotal);
+        }
+
+        data.funded_amount = new_funded;
+        if data.status == ContractStatus::Created {
+            data.status = ContractStatus::Funded;
+        }
+        Self::save_contract(&env, contract_id, &data);
         true
     }
 
     pub fn release_milestone(env: Env, contract_id: u32, milestone_index: u32) -> bool {
-        let _ = (env, contract_id, milestone_index);
+        let mut data = Self::load_contract(&env, contract_id);
+        data.client.require_auth();
+        Self::assert_open(&env, data.status);
+
+        let mut milestones = Self::load_milestones(&env, contract_id);
+        if milestone_index >= milestones.len() {
+            env.panic_with_error(EscrowError::InvalidMilestone);
+        }
+        let mut m = milestones.get(milestone_index).unwrap();
+
+        if m.released {
+            env.panic_with_error(EscrowError::MilestoneAlreadyReleased);
+        }
+        if m.refunded {
+            env.panic_with_error(EscrowError::MilestoneAlreadyRefunded);
+        }
+        if Self::available_balance(&data) < m.amount {
+            env.panic_with_error(EscrowError::InsufficientEscrowBalance);
+        }
+
+        m.released = true;
+        data.released_amount += m.amount;
+        milestones.set(milestone_index, m);
+
+        data.status = Self::derive_status(&data, &milestones);
+        Self::save_contract(&env, contract_id, &data);
+        Self::save_milestones(&env, contract_id, &milestones);
         true
+    }
+
+    pub fn refund_unreleased_milestones(
+        env: Env,
+        contract_id: u32,
+        milestone_ids: Vec<u32>,
+    ) -> i128 {
+        if milestone_ids.is_empty() {
+            env.panic_with_error(EscrowError::EmptyRefundRequest);
+        }
+
+        let mut data = Self::load_contract(&env, contract_id);
+        data.client.require_auth();
+        Self::assert_open(&env, data.status);
+
+        let mut milestones = Self::load_milestones(&env, contract_id);
+        let mut total_refund: i128 = 0;
+        let mut seen: Vec<u32> = Vec::new(&env);
+
+        for id in milestone_ids.iter() {
+            if seen.contains(&id) {
+                env.panic_with_error(EscrowError::DuplicateMilestone);
+            }
+            seen.push_back(id);
+
+            if id >= milestones.len() {
+                env.panic_with_error(EscrowError::InvalidMilestone);
+            }
+            let m = milestones.get(id).unwrap();
+            if m.released {
+                env.panic_with_error(EscrowError::MilestoneAlreadyReleased);
+            }
+            if m.refunded {
+                env.panic_with_error(EscrowError::MilestoneAlreadyRefunded);
+            }
+            total_refund += m.amount;
+        }
+
+        if Self::available_balance(&data) < total_refund {
+            env.panic_with_error(EscrowError::InsufficientEscrowBalance);
+        }
+
+        for id in seen.iter() {
+            let mut m = milestones.get(id).unwrap();
+            m.refunded = true;
+            milestones.set(id, m);
+        }
+        data.refunded_amount += total_refund;
+
+        data.status = Self::derive_status(&data, &milestones);
+        Self::save_contract(&env, contract_id, &data);
+        Self::save_milestones(&env, contract_id, &milestones);
+
+        total_refund
+    }
+
+    pub fn get_contract(env: Env, contract_id: u32) -> EscrowContractData {
+        Self::load_contract(&env, contract_id)
+    }
+
+    pub fn get_milestones(env: Env, contract_id: u32) -> Vec<Milestone> {
+        Self::load_milestones(&env, contract_id)
+    }
+
+    fn load_contract(env: &Env, contract_id: u32) -> EscrowContractData {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound))
+    }
+
+    fn load_milestones(env: &Env, contract_id: u32) -> Vec<Milestone> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Milestones(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound))
+    }
+
+    fn save_contract(env: &Env, contract_id: u32, data: &EscrowContractData) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), data);
+    }
+
+    fn save_milestones(env: &Env, contract_id: u32, milestones: &Vec<Milestone>) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Milestones(contract_id), milestones);
+    }
+
+    fn assert_open(env: &Env, status: ContractStatus) {
+        match status {
+            ContractStatus::Created | ContractStatus::Funded => {}
+            _ => env.panic_with_error(EscrowError::InvalidStatus),
+        }
+    }
+
+    fn available_balance(data: &EscrowContractData) -> i128 {
+        data.funded_amount - data.released_amount - data.refunded_amount
+    }
+
+    fn derive_status(
+        data: &EscrowContractData,
+        milestones: &Vec<Milestone>,
+    ) -> ContractStatus {
+        let mut any_refunded = false;
+        let mut all_settled = true;
+        for m in milestones.iter() {
+            if m.refunded {
+                any_refunded = true;
+            }
+            if !m.released && !m.refunded {
+                all_settled = false;
+            }
+        }
+        if all_settled {
+            if any_refunded {
+                ContractStatus::Refunded
+            } else {
+                ContractStatus::Completed
+            }
+        } else if data.funded_amount > 0 {
+            ContractStatus::Funded
+        } else {
+            ContractStatus::Created
+        }
     }
 }
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod proptest;

--- a/contracts/escrow/src/proptest.rs
+++ b/contracts/escrow/src/proptest.rs
@@ -1,78 +1,472 @@
-use crate::{ContractStatus, Escrow, EscrowClient};
+#![cfg(test)]
+
+//! Property-based tests for escrow invariants across random milestone schedules
+//! and random sequences of deposits, releases, refunds, and approvals.
+//!
+//! Determinism:
+//! - Default 256 cases per property; override via `PROPTEST_CASES` env var at
+//!   build time (proptest reads it via `option_env!`).
+//! - Seed reproduction: `PROPTEST_SEED=<hex> cargo test -p escrow proptest::...`.
+//! - Failing counter-examples auto-persist to `contracts/escrow/proptest-regressions/`.
+
+extern crate std;
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::vec::Vec as StdVec;
+
 use proptest::prelude::*;
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{testutils::Address as _, vec as sorovec, Address, Env, Vec as SorobanVec};
+
+use crate::{ContractStatus, Escrow, EscrowClient, Milestone};
+
+// ---------------------------------------------------------------------------
+// Strategy helpers
+// ---------------------------------------------------------------------------
+
+const MAX_MILESTONES: usize = 8;
+const MAX_AMOUNT: i128 = 1_000_000_000_000; // 10^12 stroops — well below i128 overflow on any realistic sum.
+const MAX_OPS: usize = 24;
+
+fn milestone_amounts_strategy() -> impl Strategy<Value = StdVec<i128>> {
+    prop::collection::vec(1i128..=MAX_AMOUNT, 1..=MAX_MILESTONES)
+}
+
+#[derive(Clone, Debug)]
+enum Op {
+    Deposit(i128),
+    Release(u32),
+    Refund(StdVec<u32>),
+}
+
+fn op_strategy(n_milestones: usize, total: i128) -> impl Strategy<Value = Op> {
+    let n = n_milestones as u32;
+    let overshoot_cap = total.saturating_mul(2).max(1);
+    prop_oneof![
+        (1i128..=overshoot_cap).prop_map(Op::Deposit),
+        // Allow n (one past the end) to exercise out-of-bounds panic.
+        (0u32..=n).prop_map(Op::Release),
+        prop::collection::vec(0u32..=n, 1..=MAX_MILESTONES).prop_map(Op::Refund),
+    ]
+}
+
+fn op_sequence_strategy(
+    n_milestones: usize,
+    total: i128,
+) -> impl Strategy<Value = StdVec<Op>> {
+    prop::collection::vec(op_strategy(n_milestones, total), 0..=MAX_OPS)
+}
+
+// ---------------------------------------------------------------------------
+// Shadow model — mirrors the contract's decision logic to decide whether each
+// op should succeed, without depending on the contract's output.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Shadow {
+    total_amount: i128,
+    funded_amount: i128,
+    released_amount: i128,
+    refunded_amount: i128,
+    released: StdVec<bool>,
+    refunded: StdVec<bool>,
+    status: ContractStatus,
+}
+
+impl Shadow {
+    fn new(amounts: &[i128]) -> Self {
+        Self {
+            total_amount: amounts.iter().copied().sum(),
+            funded_amount: 0,
+            released_amount: 0,
+            refunded_amount: 0,
+            released: std::vec![false; amounts.len()],
+            refunded: std::vec![false; amounts.len()],
+            status: ContractStatus::Created,
+        }
+    }
+
+    fn available(&self) -> i128 {
+        self.funded_amount - self.released_amount - self.refunded_amount
+    }
+
+    fn is_open(&self) -> bool {
+        matches!(self.status, ContractStatus::Created | ContractStatus::Funded)
+    }
+
+    fn recompute_status(&mut self) {
+        let mut any_refunded = false;
+        let mut all_settled = true;
+        for i in 0..self.released.len() {
+            if self.refunded[i] {
+                any_refunded = true;
+            }
+            if !self.released[i] && !self.refunded[i] {
+                all_settled = false;
+            }
+        }
+        self.status = if all_settled {
+            if any_refunded {
+                ContractStatus::Refunded
+            } else {
+                ContractStatus::Completed
+            }
+        } else if self.funded_amount > 0 {
+            ContractStatus::Funded
+        } else {
+            ContractStatus::Created
+        };
+    }
+
+    /// Returns true if the op should succeed against this model.
+    fn apply(&mut self, op: &Op, amounts: &[i128]) -> bool {
+        if !self.is_open() {
+            return false;
+        }
+        match op {
+            Op::Deposit(amount) => {
+                if *amount <= 0 {
+                    return false;
+                }
+                let new_funded = self.funded_amount + *amount;
+                if new_funded > self.total_amount {
+                    return false;
+                }
+                self.funded_amount = new_funded;
+                self.recompute_status();
+                true
+            }
+            Op::Release(idx) => {
+                let idx = *idx as usize;
+                if idx >= amounts.len() {
+                    return false;
+                }
+                if self.released[idx] || self.refunded[idx] {
+                    return false;
+                }
+                if self.available() < amounts[idx] {
+                    return false;
+                }
+                self.released[idx] = true;
+                self.released_amount += amounts[idx];
+                self.recompute_status();
+                true
+            }
+            Op::Refund(ids) => {
+                if ids.is_empty() {
+                    return false;
+                }
+                let mut seen: StdVec<u32> = StdVec::new();
+                let mut sum: i128 = 0;
+                for id in ids {
+                    if seen.contains(id) {
+                        return false;
+                    }
+                    seen.push(*id);
+                    let idx = *id as usize;
+                    if idx >= amounts.len() {
+                        return false;
+                    }
+                    if self.released[idx] || self.refunded[idx] {
+                        return false;
+                    }
+                    sum += amounts[idx];
+                }
+                if self.available() < sum {
+                    return false;
+                }
+                for id in &seen {
+                    self.refunded[*id as usize] = true;
+                }
+                self.refunded_amount += sum;
+                self.recompute_status();
+                true
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harness helpers
+// ---------------------------------------------------------------------------
+
+struct Harness<'a> {
+    env: Env,
+    client: EscrowClient<'a>,
+    client_addr: Address,
+    freelancer_addr: Address,
+}
+
+fn fresh_harness<'a>() -> Harness<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+    let addr = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &addr);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    Harness {
+        env,
+        client,
+        client_addr,
+        freelancer_addr,
+    }
+}
+
+fn ids_to_sorovec(env: &Env, v: &[u32]) -> SorobanVec<u32> {
+    let mut out = SorobanVec::new(env);
+    for x in v {
+        out.push_back(*x);
+    }
+    out
+}
+
+fn do_deposit(h: &Harness, id: u32, amount: i128) -> Result<bool, ()> {
+    catch_unwind(AssertUnwindSafe(|| h.client.deposit_funds(&id, &amount))).map_err(|_| ())
+}
+
+fn do_release(h: &Harness, id: u32, idx: u32) -> Result<bool, ()> {
+    catch_unwind(AssertUnwindSafe(|| h.client.release_milestone(&id, &idx))).map_err(|_| ())
+}
+
+fn do_refund(h: &Harness, id: u32, ids: &[u32]) -> Result<i128, ()> {
+    let env_ids = ids_to_sorovec(&h.env, ids);
+    catch_unwind(AssertUnwindSafe(|| {
+        h.client.refund_unreleased_milestones(&id, &env_ids)
+    }))
+    .map_err(|_| ())
+}
+
+fn sum_vec(amounts: &[i128]) -> i128 {
+    amounts.iter().copied().sum()
+}
+
+fn amounts_sorovec(env: &Env, amounts: &[i128]) -> SorobanVec<i128> {
+    let mut out = sorovec![env];
+    for a in amounts {
+        out.push_back(*a);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CASES: u32 = match option_env!("PROPTEST_CASES") {
+    Some(s) => parse_u32_const(s),
+    None => 256,
+};
+
+// `option_env!` returns a `&'static str`; we need a `const fn` parse because
+// `ProptestConfig` expects a `u32` value we can bake into the proptest! macro.
+const fn parse_u32_const(s: &str) -> u32 {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut acc: u32 = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b < b'0' || b > b'9' {
+            return 256;
+        }
+        acc = acc * 10 + (b - b'0') as u32;
+        i += 1;
+    }
+    if acc == 0 {
+        256
+    } else {
+        acc
+    }
+}
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(50))]
+    #![proptest_config(ProptestConfig {
+        cases: DEFAULT_CASES,
+        .. ProptestConfig::default()
+    })]
 
     #[test]
-    fn test_balance_and_status_invariants(
-        amounts in proptest::collection::vec(1..1000_0000000i128, 1..5),
-        deposit_extra in 0..1000_0000000i128,
-        release_indices in proptest::collection::vec(0..5u32, 0..10)
-    ) {
-        let env = Env::default();
-        let env_ref = &env;
-        let contract_id = env.register(Escrow, ());
-        let client = EscrowClient::new(env_ref, &contract_id);
+    fn prop_creation_invariants(amounts in milestone_amounts_strategy()) {
+        let h = fresh_harness();
+        let ms = amounts_sorovec(&h.env, &amounts);
+        let id = h.client.create_contract(&h.client_addr, &h.freelancer_addr, &ms);
+        prop_assert_eq!(id, 0);
 
-        let client_addr = Address::generate(env_ref);
-        let freelancer_addr = Address::generate(env_ref);
+        let data = h.client.get_contract(&id);
+        prop_assert_eq!(data.total_amount, sum_vec(&amounts));
+        prop_assert_eq!(data.funded_amount, 0);
+        prop_assert_eq!(data.released_amount, 0);
+        prop_assert_eq!(data.refunded_amount, 0);
+        prop_assert_eq!(data.status, ContractStatus::Created);
 
-        let mut total_milestone_amount = 0;
-        let mut milestone_vec = vec![env_ref];
-        for a in &amounts {
-            total_milestone_amount += a;
-            milestone_vec.push_back(*a);
+        let ms_on_chain: SorobanVec<Milestone> = h.client.get_milestones(&id);
+        prop_assert_eq!(ms_on_chain.len() as usize, amounts.len());
+        for (i, m) in ms_on_chain.iter().enumerate() {
+            prop_assert_eq!(m.amount, amounts[i]);
+            prop_assert!(!m.released);
+            prop_assert!(!m.refunded);
         }
+    }
 
-        let esc_id = client.create_contract(&client_addr, &freelancer_addr, &milestone_vec);
-        prop_assert_eq!(esc_id, 1);
+    #[test]
+    fn prop_id_monotonicity_across_multiple_contracts(
+        schedules in prop::collection::vec(milestone_amounts_strategy(), 1..=6)
+    ) {
+        let h = fresh_harness();
+        for (expected_id, amounts) in schedules.iter().enumerate() {
+            let ms = amounts_sorovec(&h.env, amounts);
+            let id = h.client.create_contract(&h.client_addr, &h.freelancer_addr, &ms);
+            prop_assert_eq!(id, expected_id as u32);
 
-        // Not funded yet
-        let state_before = client.get_state(&esc_id);
-        prop_assert_eq!(state_before.status, ContractStatus::Created);
-        prop_assert_eq!(state_before.balance, 0);
+            let data = h.client.get_contract(&id);
+            prop_assert_eq!(data.total_amount, sum_vec(amounts));
+            prop_assert_eq!(data.funded_amount, 0);
+            prop_assert_eq!(data.status, ContractStatus::Created);
+        }
+    }
 
-        let deposit_amount = total_milestone_amount + deposit_extra;
-        let deposit_result = client.deposit_funds(&esc_id, &deposit_amount);
-        prop_assert!(deposit_result);
+    #[test]
+    fn prop_balance_and_status_invariant_under_random_ops(
+        (amounts, ops) in milestone_amounts_strategy().prop_flat_map(|amounts| {
+            let total = sum_vec(&amounts);
+            let n = amounts.len();
+            (Just(amounts), op_sequence_strategy(n, total))
+        })
+    ) {
+        let h = fresh_harness();
+        let ms = amounts_sorovec(&h.env, &amounts);
+        let id = h.client.create_contract(&h.client_addr, &h.freelancer_addr, &ms);
 
-        let mut expected_balance = deposit_amount;
-        let mut expected_status = ContractStatus::Funded;
-        let mut released_total = 0;
-        let mut released_tracker = [false; 5];
+        let mut shadow = Shadow::new(&amounts);
+        let mut prev_status = shadow.status;
 
-        for idx in release_indices {
-            let res = client.release_milestone(&esc_id, &idx);
-            let idx_usize = idx as usize;
-            if expected_status == ContractStatus::Funded && idx_usize < amounts.len() && !released_tracker[idx_usize] {
-                prop_assert!(res);
-                released_tracker[idx_usize] = true;
-                expected_balance -= amounts[idx_usize];
-                released_total += amounts[idx_usize];
-
-                let mut all_released = true;
-                for i in 0..amounts.len() {
-                    if !released_tracker[i] {
-                        all_released = false;
-                        break;
-                    }
-                }
-
-                if all_released {
-                    expected_status = ContractStatus::Completed;
-                }
-            } else {
-                prop_assert!(!res); // Should fail if already released, out of bounds, or not Funded
+        for op in &ops {
+            let expected_ok = {
+                let mut fork = shadow.clone();
+                fork.apply(op, &amounts)
+            };
+            let actual_ok = match op {
+                Op::Deposit(a) => do_deposit(&h, id, *a).is_ok(),
+                Op::Release(i) => do_release(&h, id, *i).is_ok(),
+                Op::Refund(ids) => do_refund(&h, id, ids).is_ok(),
+            };
+            prop_assert_eq!(
+                actual_ok, expected_ok,
+                "shadow/contract disagree on op={:?}", op
+            );
+            if actual_ok {
+                shadow.apply(op, &amounts);
             }
 
-            let current_state = client.get_state(&esc_id);
-            prop_assert_eq!(current_state.balance, expected_balance);
-            prop_assert_eq!(current_state.status, expected_status);
+            // Invariants on the live contract state.
+            let data = h.client.get_contract(&id);
+            let ms_chain: SorobanVec<Milestone> = h.client.get_milestones(&id);
 
-            // Invariant: balance + released == deposit_amount
-            prop_assert_eq!(current_state.balance + released_total, deposit_amount);
+            prop_assert!(data.funded_amount >= 0);
+            prop_assert!(data.released_amount >= 0);
+            prop_assert!(data.refunded_amount >= 0);
+            prop_assert!(data.funded_amount <= data.total_amount);
+            prop_assert!(
+                data.released_amount + data.refunded_amount <= data.funded_amount,
+                "negative available balance"
+            );
+
+            let mut sum_released: i128 = 0;
+            let mut sum_refunded: i128 = 0;
+            for (i, m) in ms_chain.iter().enumerate() {
+                prop_assert!(
+                    !(m.released && m.refunded),
+                    "milestone {} is both released and refunded", i
+                );
+                if m.released { sum_released += m.amount; }
+                if m.refunded { sum_refunded += m.amount; }
+            }
+            prop_assert_eq!(sum_released, data.released_amount);
+            prop_assert_eq!(sum_refunded, data.refunded_amount);
+
+            // Status transitions: never go backwards.
+            let ok_transition = match (prev_status, data.status) {
+                (a, b) if a == b => true,
+                (ContractStatus::Created, ContractStatus::Funded) => true,
+                (ContractStatus::Funded, ContractStatus::Completed) => true,
+                (ContractStatus::Funded, ContractStatus::Refunded) => true,
+                _ => false,
+            };
+            prop_assert!(
+                ok_transition,
+                "illegal status transition {:?} -> {:?}", prev_status, data.status
+            );
+            prev_status = data.status;
+        }
+    }
+
+    #[test]
+    fn prop_release_then_refund_exclusivity(
+        amounts in milestone_amounts_strategy(),
+        target_raw in 0u32..MAX_MILESTONES as u32,
+    ) {
+        let n = amounts.len() as u32;
+        prop_assume!(n > 0);
+        let target = target_raw % n;
+        let h = fresh_harness();
+        let ms = amounts_sorovec(&h.env, &amounts);
+        let id = h.client.create_contract(&h.client_addr, &h.freelancer_addr, &ms);
+        h.client.deposit_funds(&id, &sum_vec(&amounts));
+        h.client.release_milestone(&id, &target);
+
+        let before = h.client.get_contract(&id);
+        let refund_res = do_refund(&h, id, &[target]);
+        prop_assert!(refund_res.is_err(), "refund of already-released milestone must panic");
+        let after = h.client.get_contract(&id);
+        prop_assert_eq!(before, after);
+    }
+
+    #[test]
+    fn prop_refund_then_release_exclusivity(
+        amounts in milestone_amounts_strategy(),
+        target_raw in 0u32..MAX_MILESTONES as u32,
+    ) {
+        let n = amounts.len() as u32;
+        prop_assume!(n > 0);
+        let target = target_raw % n;
+        let h = fresh_harness();
+        let ms = amounts_sorovec(&h.env, &amounts);
+        let id = h.client.create_contract(&h.client_addr, &h.freelancer_addr, &ms);
+        h.client.deposit_funds(&id, &sum_vec(&amounts));
+        h.client.refund_unreleased_milestones(&id, &ids_to_sorovec(&h.env, &[target]));
+
+        let before = h.client.get_contract(&id);
+        let release_res = do_release(&h, id, target);
+        prop_assert!(release_res.is_err(), "release of already-refunded milestone must panic");
+        let after = h.client.get_contract(&id);
+        prop_assert_eq!(before, after);
+    }
+
+    #[test]
+    fn prop_total_balance_conservation(
+        (amounts, ops) in milestone_amounts_strategy().prop_flat_map(|amounts| {
+            let total = sum_vec(&amounts);
+            let n = amounts.len();
+            (Just(amounts), op_sequence_strategy(n, total))
+        })
+    ) {
+        let h = fresh_harness();
+        let ms = amounts_sorovec(&h.env, &amounts);
+        let id = h.client.create_contract(&h.client_addr, &h.freelancer_addr, &ms);
+
+        for op in &ops {
+            let _ = match op {
+                Op::Deposit(a) => do_deposit(&h, id, *a).ok().map(|_| ()),
+                Op::Release(i) => do_release(&h, id, *i).ok().map(|_| ()),
+                Op::Refund(ids) => do_refund(&h, id, ids).ok().map(|_| ()),
+            };
+
+            let data = h.client.get_contract(&id);
+            let balance = data.funded_amount - data.released_amount - data.refunded_amount;
+            prop_assert!(balance >= 0, "escrow balance went negative");
+            prop_assert_eq!(
+                data.released_amount + data.refunded_amount + balance,
+                data.funded_amount,
+                "conservation violated"
+            );
         }
     }
 }

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -2,11 +2,17 @@
 
 use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
 
-use crate::{Escrow, EscrowClient};
+use crate::{ContractStatus, Escrow, EscrowClient};
+
+fn new_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
 
 #[test]
 fn test_hello() {
-    let env = Env::default();
+    let env = new_env();
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
@@ -16,7 +22,7 @@ fn test_hello() {
 
 #[test]
 fn test_create_contract() {
-    let env = Env::default();
+    let env = new_env();
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
@@ -26,24 +32,49 @@ fn test_create_contract() {
 
     let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
     assert_eq!(id, 0);
+
+    let data = client.get_contract(&id);
+    assert_eq!(data.total_amount, 1_200_0000000_i128);
+    assert_eq!(data.funded_amount, 0);
+    assert_eq!(data.status, ContractStatus::Created);
+    assert_eq!(client.get_milestones(&id).len(), 3);
 }
 
 #[test]
 fn test_deposit_funds() {
-    let env = Env::default();
+    let env = new_env();
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
-    let result = client.deposit_funds(&1, &1_000_0000000);
-    assert!(result);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 500_0000000_i128, 500_0000000_i128];
+    let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+
+    assert!(client.deposit_funds(&id, &400_0000000_i128));
+    let data = client.get_contract(&id);
+    assert_eq!(data.funded_amount, 400_0000000_i128);
+    assert_eq!(data.status, ContractStatus::Funded);
 }
 
 #[test]
 fn test_release_milestone() {
-    let env = Env::default();
+    let env = new_env();
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
-    let result = client.release_milestone(&1, &0);
-    assert!(result);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 300_0000000_i128, 700_0000000_i128];
+    let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+
+    client.deposit_funds(&id, &1_000_0000000_i128);
+    assert!(client.release_milestone(&id, &0));
+    let data = client.get_contract(&id);
+    assert_eq!(data.released_amount, 300_0000000_i128);
+    assert_eq!(data.status, ContractStatus::Funded);
+
+    client.release_milestone(&id, &1);
+    assert_eq!(client.get_contract(&id).status, ContractStatus::Completed);
 }
+


### PR DESCRIPTION
Closes: #251

- Restore minimal stateful Escrow (ContractStatus, Milestone with released/refunded flags, funded/released/refunded bookkeeping, refund_unreleased_milestones, get_contract, get_milestones) — just enough surface to express the invariants the issue asks about.
- Rewrite proptest.rs with six properties over random milestone schedules and random Deposit/Release/Refund op sequences:
    * prop_creation_invariants
    * prop_id_monotonicity_across_multiple_contracts
    * prop_balance_and_status_invariant_under_random_ops (shadow model vs on-chain result per op, status-transition monotonicity, sum(released)==released_amount, sum(refunded)==refunded_amount, released+refunded <= funded <= total)
    * prop_release_then_refund_exclusivity
    * prop_refund_then_release_exclusivity
    * prop_total_balance_conservation
- Default 256 cases; override via PROPTEST_CASES at build time. PROPTEST_SEED reproduces a given run.
- proptest-regressions/proptest.txt committed so failing seeds persist.
- catch_unwind around each host call lets panicking ops (over-deposit, double-release, out-of-bounds, already-refunded) be asserted against the shadow model instead of aborting the test.

Verified: cargo test -p escrow (10/10) and
PROPTEST_CASES=1024 cargo test -p escrow (6/6 props, ~107s).