### PR TITLE
ci: add clippy gate for escrow contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,16 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Build
         run: cargo build

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ When paused, mutating escrow operations are blocked.
 ## Contributing
 
 1. Fork the repo and create a branch from `main`.
-2. Make changes; keep tests and formatting passing:
+2. Make changes; keep tests, lints, and formatting passing:
    - `cargo fmt --all`
+   - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo test`
    - `cargo build`
-3. Open a pull request. CI runs `cargo fmt --all -- --check`, `cargo build`, and `cargo test` on push/PR to `main`.
+3. Open a pull request. CI runs `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build`, and `cargo test` on push/PR to `main`.
 
 ## Contract status transition guardrails
 
@@ -74,6 +75,7 @@ Common commands:
 On every push and pull request to `main`, GitHub Actions:
 
 - Checks formatting (`cargo fmt --all -- --check`)
+- Lints with warnings denied (`cargo clippy --workspace --all-targets -- -D warnings`)
 - Builds the workspace (`cargo build`)
 - Runs tests (`cargo test`)
 

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
 
 use crate::{Escrow, EscrowClient};
@@ -34,7 +32,7 @@ fn test_deposit_funds() {
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
 
-    let result = client.deposit_funds(&1, &1_000_0000000);
+    let result = client.deposit_funds(&1, &10_000_000_000);
     assert!(result);
 }
 


### PR DESCRIPTION
Adds cargo clippy --workspace --all-targets -- -D warnings step to GitHub Actions so common Rust pitfalls fail the build. Installs the clippy component alongside rustfmt and runs it after fmt and before build to share the compile cache warmed by clippy.

Fixes two clippy findings surfaced by the new gate:
- remove redundant #![cfg(test)] from contracts/escrow/src/test.rs (module already gated via #[cfg(test)] in lib.rs)
- regroup 1_000_0000000 to 10_000_000_000 to satisfy clippy::inconsistent_digit_grouping

Updates README contributing and CI/CD sections to document the new gate.

Closes #237