### PR TITLE
test: prevent snapshot artifact regeneration in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,12 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Check no snapshot or artifact files were generated
+        run: |
+          DIRTY=$(git status --porcelain)
+          if [ -n "$DIRTY" ]; then
+            echo "::error::Tests generated untracked/modified files. Add them to .gitignore or fix the test."
+            echo "$DIRTY"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,15 @@
 **/*.rs.bk
 # Soroban CLI / local test output (do not commit)
 contracts/**/test_snapshots/
+contracts/**/.soroban/
+**/.soroban/
+**/snapshots/
 .cargo/
 
 # Coverage output
 coverage_summary.txt
 lcov.info
+
+# Soroban CLI wasm / identity artifacts
+*.wasm
+*.xdr


### PR DESCRIPTION
 ## Summary
  - Added a CI step that runs `git status --porcelain` after `cargo test` and fails if any untracked or modified files exist                                     - Expanded `.gitignore` to cover additional Soroban CLI output paths (`.soroban/`, `snapshots/`, `*.wasm`, `*.xdr`) beyond the existing `test_snapshots/`
  pattern

  ## Why
  Previously, `cargo test` could silently regenerate snapshot artifacts into tracked paths with no CI enforcement. This ensures any future test that writes
  files outside ignored directories will be caught immediately.

  Closes #241