### PR TITLE
Add deterministic contract id allocation and prevent id reuse across migrations

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -96,10 +96,15 @@ pub struct PendingMigration {
 
 #[contracttype]
 #[derive(Clone)]
-enum DataKey {
+pub enum DataKey {
     Contract(u32),
     MilestoneReleased(u32, u32),
     RefundableBalance(u32),
+    /// Monotonically increasing counter. Holds the *next* ID to be issued.
+    /// Written before contract data is stored so the ID is permanently
+    /// consumed even if a subsequent write panics (write-ahead reservation).
+    /// Never decremented; IDs are never reused.
+    NextContractId,
 }
 
 fn update_readiness_checklist<F>(env: &Env, f: F)
@@ -178,8 +183,15 @@ impl Escrow {
         let id: u32 = env
             .storage()
             .persistent()
-            .get(&DataKey::ContractCount)
-            .unwrap_or(0u32);
+            .get(&DataKey::NextContractId)
+            .unwrap_or(1u32);
+
+        // Write-ahead: reserve the ID by persisting the incremented counter
+        // BEFORE writing contract data. If any subsequent write panics, the
+        // counter has already advanced, so this ID is never reused.
+        env.storage()
+            .persistent()
+            .set(&DataKey::NextContractId, &(id + 1));
 
         let data = EscrowContractData {
             client,
@@ -195,7 +207,6 @@ impl Escrow {
         env.storage()
             .persistent()
             .set(&DataKey::Milestones(id), &milestones);
-        env.storage().persistent().set(&DataKey::ContractCount, &(id + 1));
 
         id
     }

--- a/contracts/escrow/src/test/contract_id_allocation.rs
+++ b/contracts/escrow/src/test/contract_id_allocation.rs
@@ -1,0 +1,146 @@
+//! # Contract ID Allocation Tests
+//!
+//! Verifies the monotonic, never-reused ID allocation scheme:
+//!
+//! - IDs start at 1 and increment by 1 on every successful creation.
+//! - The `NextContractId` counter is written *before* contract data
+//!   (write-ahead reservation), so a panic after the counter write does not
+//!   allow the same ID to be reused on the next call.
+//! - Sequential calls in the same environment never produce the same ID.
+
+use super::{default_milestones, generated_participants, register_client};
+use crate::{DataKey, EscrowError};
+use soroban_sdk::{vec, Env};
+
+// ─── Monotonicity ─────────────────────────────────────────────────────────────
+
+#[test]
+fn first_contract_id_is_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (ca, fa) = generated_participants(&env);
+
+    let id = client.create_contract(&ca, &fa, &default_milestones(&env));
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn ids_increment_monotonically() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let mut prev = 0u32;
+    for _ in 0..5 {
+        let (ca, fa) = generated_participants(&env);
+        let id = client.create_contract(&ca, &fa, &default_milestones(&env));
+        assert!(id > prev, "id {id} must be greater than previous {prev}");
+        prev = id;
+    }
+}
+
+#[test]
+fn ids_are_strictly_sequential() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (ca1, fa1) = generated_participants(&env);
+    let (ca2, fa2) = generated_participants(&env);
+    let (ca3, fa3) = generated_participants(&env);
+
+    let id1 = client.create_contract(&ca1, &fa1, &default_milestones(&env));
+    let id2 = client.create_contract(&ca2, &fa2, &default_milestones(&env));
+    let id3 = client.create_contract(&ca3, &fa3, &default_milestones(&env));
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(id3, 3);
+}
+
+// ─── No reuse ─────────────────────────────────────────────────────────────────
+
+/// Simulates the write-ahead guarantee: after the counter is advanced, a
+/// subsequent failed creation must not reuse the reserved ID.
+///
+/// We verify this by inspecting the persisted `NextContractId` directly after
+/// a successful creation and confirming it is already beyond the issued ID,
+/// so any future call — even one that panics mid-write — cannot reclaim it.
+#[test]
+fn counter_is_advanced_before_contract_data_is_written() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_id = env.register(crate::Escrow, ());
+    let client = crate::EscrowClient::new(&env, &escrow_id);
+
+    let (ca, fa) = generated_participants(&env);
+    let issued_id = client.create_contract(&ca, &fa, &default_milestones(&env));
+
+    // The counter must already point past the issued ID.
+    env.as_contract(&escrow_id, || {
+        let next: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextContractId)
+            .expect("NextContractId must be set after first creation");
+        assert!(
+            next > issued_id,
+            "NextContractId ({next}) must exceed the issued id ({issued_id})"
+        );
+    });
+}
+
+#[test]
+fn failed_creation_does_not_reuse_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    // Successful creation — ID 1 is issued and counter advances to 2.
+    let (ca, fa) = generated_participants(&env);
+    let id1 = client.create_contract(&ca, &fa, &default_milestones(&env));
+    assert_eq!(id1, 1);
+
+    // Attempt a creation that will fail validation (empty milestones).
+    // The counter must NOT have been touched (failure happens before counter write).
+    let (ca2, fa2) = generated_participants(&env);
+    let bad_milestones = vec![&env]; // empty — triggers EmptyMilestones error
+    let result = client.try_create_contract(&ca2, &fa2, &bad_milestones);
+    assert_eq!(result, Err(Ok(EscrowError::EmptyMilestones)));
+
+    // Next successful creation must get ID 2, not ID 1.
+    let (ca3, fa3) = generated_participants(&env);
+    let id2 = client.create_contract(&ca3, &fa3, &default_milestones(&env));
+    assert_eq!(id2, 2, "ID after failed attempt must still be 2, not 1");
+}
+
+// ─── Re-entrance / isolation ──────────────────────────────────────────────────
+
+/// Two independent contract instances must each maintain their own counter;
+/// IDs from one must not collide with IDs from the other.
+#[test]
+fn separate_contract_instances_have_independent_counters() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id_a = env.register(crate::Escrow, ());
+    let id_b = env.register(crate::Escrow, ());
+    let client_a = crate::EscrowClient::new(&env, &id_a);
+    let client_b = crate::EscrowClient::new(&env, &id_b);
+
+    let (ca, fa) = generated_participants(&env);
+    let a1 = client_a.create_contract(&ca, &fa, &default_milestones(&env));
+    let b1 = client_b.create_contract(&ca, &fa, &default_milestones(&env));
+
+    // Both start at 1 — they are independent storage namespaces.
+    assert_eq!(a1, 1);
+    assert_eq!(b1, 1);
+
+    let (ca2, fa2) = generated_participants(&env);
+    let a2 = client_a.create_contract(&ca2, &fa2, &default_milestones(&env));
+    let b2 = client_b.create_contract(&ca2, &fa2, &default_milestones(&env));
+
+    assert_eq!(a2, 2);
+    assert_eq!(b2, 2);
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -1,0 +1,113 @@
+#![cfg(test)]
+
+use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, Symbol, Vec};
+
+use crate::{ContractStatus, Escrow, EscrowClient};
+
+// ─── Sub-modules ──────────────────────────────────────────────────────────────
+
+pub mod access_control;
+pub mod cancel_contract;
+pub mod client_migration;
+pub mod contract_id_allocation;
+pub mod emergency_controls;
+pub mod flows;
+pub mod governance;
+pub mod hello;
+pub mod input_sanitization_amounts;
+pub mod input_sanitization_identities;
+pub mod lifecycle;
+pub mod mainnet_readiness;
+pub mod milestone_schedule;
+pub mod pause_controls;
+pub mod performance;
+pub mod persistence;
+pub mod security;
+pub mod storage;
+pub mod timeout_tests;
+pub mod ttl_tests;
+
+// ─── Shared constants ─────────────────────────────────────────────────────────
+
+pub const MILESTONE_ONE: i128 = 200_0000000;
+pub const MILESTONE_TWO: i128 = 400_0000000;
+pub const MILESTONE_THREE: i128 = 600_0000000;
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+pub fn setup_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+pub fn register_client(env: &Env) -> EscrowClient {
+    let id = env.register(Escrow, ());
+    EscrowClient::new(env, &id)
+}
+
+/// Alias used by hello.rs and client_migration.rs.
+pub fn register_escrow(env: &Env) -> EscrowClient {
+    register_client(env)
+}
+
+pub fn generated_participants(env: &Env) -> (Address, Address) {
+    (Address::generate(env), Address::generate(env))
+}
+
+pub fn default_milestones(env: &Env) -> Vec<i128> {
+    vec![env, MILESTONE_ONE, MILESTONE_TWO, MILESTONE_THREE]
+}
+
+pub fn total_milestone_amount() -> i128 {
+    MILESTONE_ONE + MILESTONE_TWO + MILESTONE_THREE
+}
+
+/// Alias used by access_control.rs.
+pub fn total_milestones() -> i128 {
+    total_milestone_amount()
+}
+
+pub fn world_symbol() -> Symbol {
+    symbol_short!("World")
+}
+
+/// Creates a contract and returns (client_addr, freelancer_addr, contract_id).
+pub fn create_contract(env: &Env, client: &EscrowClient) -> (Address, Address, u32) {
+    let (client_addr, freelancer_addr) = generated_participants(env);
+    let milestones = default_milestones(env);
+    let contract_id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    (client_addr, freelancer_addr, contract_id)
+}
+
+/// Alias used by client_migration.rs.
+pub fn create_sample_contract(env: &Env, client: &EscrowClient) -> (Address, Address, u32) {
+    create_contract(env, client)
+}
+
+pub fn full_funding_amount() -> i128 {
+    total_milestone_amount()
+}
+
+/// Creates a contract, fully funds it, and releases all milestones.
+pub fn complete_contract(env: &Env, client: &EscrowClient) -> (Address, Address, u32) {
+    let (client_addr, freelancer_addr, contract_id) = create_contract(env, client);
+    client.deposit_funds(&contract_id, &total_milestone_amount());
+    client.release_milestone(&contract_id, &0);
+    client.release_milestone(&contract_id, &1);
+    client.release_milestone(&contract_id, &2);
+    (client_addr, freelancer_addr, contract_id)
+}
+
+/// Asserts that a `try_*` result carries the expected `EscrowError`.
+pub fn assert_contract_error<T>(
+    result: Result<T, Result<crate::EscrowError, soroban_sdk::InvokeError>>,
+    expected: crate::EscrowError,
+) {
+    assert_eq!(result, Err(Ok(expected)));
+}
+
+/// Asserts that a closure panics (used by client_migration.rs).
+pub fn assert_panics<F: FnOnce() + std::panic::UnwindSafe>(f: F) {
+    assert!(std::panic::catch_unwind(f).is_err());
+}

--- a/docs/escrow/state-persistence.md
+++ b/docs/escrow/state-persistence.md
@@ -74,3 +74,37 @@ Reputation invariants:
 3. Confirm milestone double release is rejected.
 4. Confirm completed contracts can issue reputation once.
 5. Confirm pause and emergency flags block every mutating payment path.
+
+## Contract ID Allocation
+
+Contract IDs are issued by a monotonically increasing counter stored under the
+`NextContractId` key in persistent storage.
+
+### Allocation algorithm
+
+1. Read `NextContractId` from persistent storage; default to `1` if absent.
+2. **Write-ahead**: persist `NextContractId + 1` before writing any contract data.
+3. Write the `Contract(id)` record.
+4. Return `id` to the caller.
+
+### Safety properties
+
+**Monotonic** — the counter is never decremented. Every successful call to
+`create_contract` produces an ID strictly greater than all previously issued IDs.
+
+**Never reused** — the counter is advanced in step 2, before the contract data
+write in step 3. If the contract write panics or the transaction is rolled back
+after step 2, the counter has already moved forward. The skipped ID is
+permanently retired; it will never be assigned to a different contract.
+
+**Failure safe** — validation errors (empty milestones, invalid participants,
+etc.) are checked before step 2. A rejected call leaves the counter unchanged,
+so no IDs are wasted on invalid inputs.
+
+**Storage-migration safe** — `NextContractId` is a dedicated, named key with no
+dependency on the shape of `EscrowContractData`. Migrating or upgrading the
+contract record schema does not affect the counter.
+
+**Per-instance isolation** — each deployed contract instance has its own
+persistent storage namespace. Counters from different instances are independent
+and do not interfere.


### PR DESCRIPTION
Closes #229 

Description
Ensure contract ids are monotonic, never reused, and safe across storage migrations and upgrades.

Requirements and context
Must be secure, tested, and documented
Must maintain id allocation under failure and re-entrance assumptions