### PR TITLE
feat: add contract summary view for indexers

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -12,9 +12,12 @@ pub use ttl::{
     PENDING_MIGRATION_BUMP_THRESHOLD, PENDING_MIGRATION_TTL_LEDGERS,
 };
 
-use types::ContractStatus;
-
 mod types;
+
+use types::ContractStatus;
+pub use crate::types::{
+    CONTRACT_SUMMARY_SCHEMA_VERSION, ContractSummary, MilestoneSummary,
+};
 
 // ─── Bounds constants ─────────────────────────────────────────────────────────
 //
@@ -41,7 +44,6 @@ pub const MAX_TOTAL_ESCROW_STROOPS: i128 = 1_000_000_0000000; // 1 M tokens × 1
 pub const MAINNET_PROTOCOL_VERSION: u32 = 1u32;
 pub const MAINNET_MAX_TOTAL_ESCROW_PER_CONTRACT_STROOPS: i128 = 1_000_000_000_000_000i128;
 
-mod types;
 pub use crate::types::{MainnetReadinessInfo, ReadinessChecklist};
 use crate::types::DataKey as ReadinessDataKey;
 
@@ -362,6 +364,81 @@ impl Escrow {
             }
         }
         released
+    }
+
+    /// Returns a stable, single-read summary of an escrow contract for off-chain indexers.
+    ///
+    /// Combines contract roles, lifecycle status, financial totals, and
+    /// per-milestone state into one atomic call so that indexing pipelines
+    /// do not need multiple separate storage reads.
+    ///
+    /// # Fields
+    ///
+    /// | Field | Description |
+    /// |---|---|
+    /// | `schema_version` | Always `CONTRACT_SUMMARY_SCHEMA_VERSION` (`1`); incremented on breaking changes |
+    /// | `client` | Address that funds the contract |
+    /// | `freelancer` | Address that receives milestone payments |
+    /// | `arbiter` | Optional dispute-resolution address (`None` if not set) |
+    /// | `status` | Current lifecycle status (`Created`, `Funded`, `Completed`, `Cancelled`, `Refunded`, `Disputed`) |
+    /// | `reputation_issued` | Whether a reputation score has already been recorded |
+    /// | `total_amount` | Sum of all milestone amounts in stroops |
+    /// | `funded_amount` | Total deposited by the client in stroops |
+    /// | `released_amount` | Total released to the freelancer in stroops |
+    /// | `refundable_balance` | Balance not yet released or refunded, in stroops |
+    /// | `released_milestone_count` | Number of milestones released so far |
+    /// | `milestones` | Per-milestone index, amount, `released`, and `refunded` flags |
+    ///
+    /// # Errors
+    ///
+    /// Panics with `EscrowError::ContractNotFound` if `contract_id` does not exist.
+    ///
+    /// # Backwards compatibility
+    ///
+    /// This method is additive and backwards-compatible with all existing
+    /// contract storage.  If the return layout ever changes in a breaking way
+    /// `CONTRACT_SUMMARY_SCHEMA_VERSION` will be incremented so consumers can
+    /// detect and handle the new format.
+    pub fn get_contract_summary(env: Env, contract_id: u32) -> ContractSummary {
+        // Load the main contract record (panics with ContractNotFound if absent).
+        let record = Self::get_contract(env.clone(), contract_id);
+
+        // Load the ordered milestone list.
+        let raw_milestones = Self::get_milestones(env.clone(), contract_id);
+
+        // Load the current refundable balance (0 if never set).
+        let refundable_balance = Self::get_refundable_balance(env.clone(), contract_id);
+
+        // Build the per-milestone summaries and count released milestones.
+        let mut milestone_summaries: Vec<MilestoneSummary> = Vec::new(&env);
+        let mut released_milestone_count: u32 = 0u32;
+
+        for (idx, m) in raw_milestones.iter().enumerate() {
+            if m.released {
+                released_milestone_count += 1;
+            }
+            milestone_summaries.push_back(MilestoneSummary {
+                index: idx as u32,
+                amount: m.amount,
+                released: m.released,
+                refunded: m.refunded,
+            });
+        }
+
+        ContractSummary {
+            schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,
+            client: record.client,
+            freelancer: record.freelancer,
+            arbiter: record.arbiter,
+            status: record.status,
+            reputation_issued: record.reputation_issued,
+            total_amount: record.total_amount,
+            funded_amount: record.funded_amount,
+            released_amount: record.released_amount,
+            refundable_balance,
+            released_milestone_count,
+            milestones: milestone_summaries,
+        }
     }
 }
 

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 mod cancel_contract;
+mod summary;
 
 use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
 

--- a/contracts/escrow/src/test/summary.rs
+++ b/contracts/escrow/src/test/summary.rs
@@ -1,0 +1,432 @@
+//! # Contract Summary Tests
+//!
+//! Verifies `get_contract_summary` across the full escrow lifecycle:
+//! - Created, Funded, partial release, full release (Completed), Cancelled
+//! - Field correctness: roles, status, financial totals, milestone flags
+//! - Schema version stability
+//! - Error on unknown contract
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+use crate::{ContractStatus, Escrow, EscrowClient, EscrowError, CONTRACT_SUMMARY_SCHEMA_VERSION};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn register_client(env: &Env) -> EscrowClient {
+    let id = env.register(Escrow, ());
+    EscrowClient::new(env, &id)
+}
+
+fn generate_participants(env: &Env) -> (Address, Address) {
+    (Address::generate(env), Address::generate(env))
+}
+
+fn default_milestones(env: &Env) -> soroban_sdk::Vec<i128> {
+    vec![env, 200_0000000_i128, 400_0000000_i128, 600_0000000_i128]
+}
+
+fn total_amount() -> i128 {
+    200_0000000 + 400_0000000 + 600_0000000
+}
+
+// ---------------------------------------------------------------------------
+// Schema / versioning
+// ---------------------------------------------------------------------------
+
+/// The schema_version field must always equal CONTRACT_SUMMARY_SCHEMA_VERSION.
+#[test]
+fn summary_schema_version_is_stable() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.schema_version, CONTRACT_SUMMARY_SCHEMA_VERSION);
+    assert_eq!(summary.schema_version, 1u32);
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+/// Roles are surfaced correctly without an arbiter.
+#[test]
+fn summary_roles_without_arbiter() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.client, client_addr);
+    assert_eq!(summary.freelancer, freelancer_addr);
+    assert!(summary.arbiter.is_none());
+}
+
+/// Roles are surfaced correctly when an arbiter is present.
+#[test]
+fn summary_roles_with_arbiter() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+    let arbiter_addr = Address::generate(&env);
+
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &default_milestones(&env),
+    );
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.client, client_addr);
+    assert_eq!(summary.freelancer, freelancer_addr);
+    assert_eq!(summary.arbiter, Some(arbiter_addr));
+}
+
+// ---------------------------------------------------------------------------
+// Created state
+// ---------------------------------------------------------------------------
+
+/// Summary immediately after creation reflects Created status and zero balances.
+#[test]
+fn summary_at_created_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.status, ContractStatus::Created);
+    assert_eq!(summary.total_amount, total_amount());
+    assert_eq!(summary.funded_amount, 0);
+    assert_eq!(summary.released_amount, 0);
+    assert_eq!(summary.refundable_balance, 0);
+    assert_eq!(summary.released_milestone_count, 0);
+    assert!(!summary.reputation_issued);
+}
+
+/// All milestone flags are false immediately after creation.
+#[test]
+fn summary_milestones_all_pending_at_creation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.milestones.len(), 3);
+    for m in summary.milestones.iter() {
+        assert!(!m.released, "milestone {} should not be released", m.index);
+        assert!(!m.refunded, "milestone {} should not be refunded", m.index);
+    }
+}
+
+/// Milestone indices are zero-based and sequential.
+#[test]
+fn summary_milestone_indices_are_sequential() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    let summary = client.get_contract_summary(&contract_id);
+    for (pos, m) in summary.milestones.iter().enumerate() {
+        assert_eq!(m.index, pos as u32);
+    }
+}
+
+/// Milestone amounts in the summary match the amounts passed to create_contract.
+#[test]
+fn summary_milestone_amounts_match_creation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    let summary = client.get_contract_summary(&contract_id);
+    let amounts: soroban_sdk::Vec<i128> = summary.milestones.iter().map(|m| m.amount).collect();
+    assert_eq!(amounts.get(0).unwrap(), 200_0000000_i128);
+    assert_eq!(amounts.get(1).unwrap(), 400_0000000_i128);
+    assert_eq!(amounts.get(2).unwrap(), 600_0000000_i128);
+}
+
+// ---------------------------------------------------------------------------
+// Funded state
+// ---------------------------------------------------------------------------
+
+/// After a full deposit the summary reflects Funded status and the deposited amount.
+#[test]
+fn summary_at_funded_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+    client.deposit_funds(&contract_id, &total_amount());
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.status, ContractStatus::Funded);
+    assert_eq!(summary.funded_amount, total_amount());
+    assert_eq!(summary.released_amount, 0);
+    assert_eq!(summary.released_milestone_count, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Partial release
+// ---------------------------------------------------------------------------
+
+/// After releasing one milestone the summary correctly marks it released.
+#[test]
+fn summary_after_first_milestone_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+    client.deposit_funds(&contract_id, &total_amount());
+    client.release_milestone(&contract_id, &0);
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.released_milestone_count, 1);
+    assert_eq!(summary.released_amount, 200_0000000_i128);
+    assert!(summary.milestones.get(0).unwrap().released);
+    assert!(!summary.milestones.get(1).unwrap().released);
+    assert!(!summary.milestones.get(2).unwrap().released);
+}
+
+/// released_milestone_count increments correctly with each successive release.
+#[test]
+fn summary_released_milestone_count_increments() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+    client.deposit_funds(&contract_id, &total_amount());
+
+    client.release_milestone(&contract_id, &0);
+    assert_eq!(
+        client.get_contract_summary(&contract_id).released_milestone_count,
+        1
+    );
+
+    client.release_milestone(&contract_id, &1);
+    assert_eq!(
+        client.get_contract_summary(&contract_id).released_milestone_count,
+        2
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Completed state
+// ---------------------------------------------------------------------------
+
+/// After all milestones are released the summary reflects Completed status.
+#[test]
+fn summary_at_completed_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+    client.deposit_funds(&contract_id, &total_amount());
+    client.release_milestone(&contract_id, &0);
+    client.release_milestone(&contract_id, &1);
+    client.release_milestone(&contract_id, &2);
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.status, ContractStatus::Completed);
+    assert_eq!(summary.released_amount, total_amount());
+    assert_eq!(summary.released_milestone_count, 3);
+
+    for m in summary.milestones.iter() {
+        assert!(m.released, "milestone {} should be released", m.index);
+    }
+}
+
+/// reputation_issued flips to true after issue_reputation is called.
+#[test]
+fn summary_reputation_issued_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+    client.deposit_funds(&contract_id, &total_amount());
+    client.release_milestone(&contract_id, &0);
+    client.release_milestone(&contract_id, &1);
+    client.release_milestone(&contract_id, &2);
+
+    let before = client.get_contract_summary(&contract_id);
+    assert!(!before.reputation_issued);
+
+    client.issue_reputation(&contract_id, &5);
+
+    let after = client.get_contract_summary(&contract_id);
+    assert!(after.reputation_issued);
+}
+
+// ---------------------------------------------------------------------------
+// Cancelled state
+// ---------------------------------------------------------------------------
+
+/// After cancellation the summary reflects Cancelled status.
+#[test]
+fn summary_at_cancelled_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+    client.cancel_contract(&contract_id, &client_addr);
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.status, ContractStatus::Cancelled);
+    assert_eq!(summary.released_milestone_count, 0);
+    assert_eq!(summary.released_amount, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+/// Calling get_contract_summary for a non-existent contract must fail.
+#[test]
+fn summary_fails_for_unknown_contract_id() {
+    let env = Env::default();
+    let client = register_client(&env);
+
+    let result = client.try_get_contract_summary(&999);
+    assert!(
+        result.is_err(),
+        "expected an error for a non-existent contract"
+    );
+    assert_eq!(result, Err(Ok(EscrowError::ContractNotFound)));
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle consistency
+// ---------------------------------------------------------------------------
+
+/// Summary totals must be internally consistent throughout the lifecycle:
+/// released_amount <= funded_amount <= total_amount.
+#[test]
+fn summary_totals_are_consistent_across_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr) = generate_participants(&env);
+
+    let contract_id =
+        client.create_contract(&client_addr, &freelancer_addr, &None, &default_milestones(&env));
+
+    // Created
+    let s = client.get_contract_summary(&contract_id);
+    assert!(s.released_amount <= s.funded_amount);
+    assert!(s.funded_amount <= s.total_amount);
+
+    // Funded
+    client.deposit_funds(&contract_id, &total_amount());
+    let s = client.get_contract_summary(&contract_id);
+    assert!(s.released_amount <= s.funded_amount);
+    assert!(s.funded_amount <= s.total_amount);
+
+    // First milestone released
+    client.release_milestone(&contract_id, &0);
+    let s = client.get_contract_summary(&contract_id);
+    assert!(s.released_amount <= s.funded_amount);
+    assert!(s.funded_amount <= s.total_amount);
+
+    // Fully released
+    client.release_milestone(&contract_id, &1);
+    client.release_milestone(&contract_id, &2);
+    let s = client.get_contract_summary(&contract_id);
+    assert_eq!(s.released_amount, s.funded_amount);
+    assert_eq!(s.funded_amount, s.total_amount);
+}
+
+/// Multiple independent contracts each have their own isolated summary.
+#[test]
+fn summary_is_isolated_per_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = register_client(&env);
+    let (client_addr1, freelancer_addr1) = generate_participants(&env);
+    let (client_addr2, freelancer_addr2) = generate_participants(&env);
+
+    let id1 = client.create_contract(
+        &client_addr1,
+        &freelancer_addr1,
+        &None,
+        &default_milestones(&env),
+    );
+    let id2 = client.create_contract(
+        &client_addr2,
+        &freelancer_addr2,
+        &None,
+        &vec![&env, 100_i128, 200_i128],
+    );
+
+    client.deposit_funds(&id1, &total_amount());
+    client.release_milestone(&id1, &0);
+
+    let s1 = client.get_contract_summary(&id1);
+    let s2 = client.get_contract_summary(&id2);
+
+    assert_eq!(s1.status, ContractStatus::Funded);
+    assert_eq!(s1.released_milestone_count, 1);
+    assert_eq!(s2.status, ContractStatus::Created);
+    assert_eq!(s2.released_milestone_count, 0);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Bytes, String};
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, String, Vec};
 
 #[contracttype]
 pub enum DataKey {
@@ -49,3 +49,75 @@ pub struct MilestoneFunding {
     pub funded_amount: i128,
 }
 
+// ─── Indexer summary types ────────────────────────────────────────────────────
+
+/// Schema version stamped on every [`ContractSummary`].
+///
+/// Increment this constant whenever [`ContractSummary`] changes in a
+/// backwards-incompatible way so that consumers can gate on the version field.
+pub const CONTRACT_SUMMARY_SCHEMA_VERSION: u32 = 1;
+
+/// Compact, per-milestone state included in a [`ContractSummary`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneSummary {
+    /// Zero-based position of this milestone in the contract.
+    pub index: u32,
+    /// Agreed value of this milestone in stroops.
+    pub amount: i128,
+    /// `true` once the client has released this milestone to the freelancer.
+    pub released: bool,
+    /// `true` once this milestone has been refunded back to the client.
+    pub refunded: bool,
+}
+
+/// A self-contained, single-read snapshot of an escrow contract for indexers.
+///
+/// Returned by `Escrow::get_contract_summary`. Combines contract roles,
+/// lifecycle status, financial totals, and per-milestone state into one
+/// atomic call so that indexing pipelines do not need multiple round-trips.
+///
+/// # Stability / versioning
+///
+/// `schema_version` is set to [`CONTRACT_SUMMARY_SCHEMA_VERSION`] (`1`) in
+/// this release. If the struct layout changes in a breaking way the constant
+/// is incremented. Consumers should reject or re-fetch summaries whose
+/// `schema_version` they do not recognise.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractSummary {
+    // ── Versioning ────────────────────────────────────────────────────────────
+    /// Monotonically increasing layout version.
+    /// See [`CONTRACT_SUMMARY_SCHEMA_VERSION`].
+    pub schema_version: u32,
+
+    // ── Roles ─────────────────────────────────────────────────────────────────
+    /// Address of the client who funds the contract.
+    pub client: Address,
+    /// Address of the freelancer who performs the work.
+    pub freelancer: Address,
+    /// Optional third-party arbiter for dispute resolution.
+    pub arbiter: Option<Address>,
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+    /// Current contract lifecycle status.
+    pub status: ContractStatus,
+    /// Whether a reputation score has already been issued for this contract.
+    pub reputation_issued: bool,
+
+    // ── Financial totals ──────────────────────────────────────────────────────
+    /// Sum of all milestone amounts (agreed contract value), in stroops.
+    pub total_amount: i128,
+    /// Cumulative amount deposited by the client so far, in stroops.
+    pub funded_amount: i128,
+    /// Cumulative amount released to the freelancer so far, in stroops.
+    pub released_amount: i128,
+    /// Balance not yet released or refunded, in stroops.
+    pub refundable_balance: i128,
+
+    // ── Milestones ────────────────────────────────────────────────────────────
+    /// Number of milestones that have been released to the freelancer.
+    pub released_milestone_count: u32,
+    /// Per-milestone breakdown (index, amount, `released`, `refunded`).
+    pub milestones: Vec<MilestoneSummary>,
+}


### PR DESCRIPTION
Implements #233 — provides a stable single-read snapshot of an escrow contract for off-chain indexers via a new get_contract_summary view method on the Escrow contract.

Changes:
- contracts/escrow/src/types.rs
  * Add CONTRACT_SUMMARY_SCHEMA_VERSION constant (= 1)
  * Add MilestoneSummary contracttype (index, amount, released, refunded)
  * Add ContractSummary contracttype (roles, status, totals, milestones)

- contracts/escrow/src/lib.rs
  * Re-export ContractSummary, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION
  * Add get_contract_summary(env, contract_id) -> ContractSummary view method
    - Reads EscrowRecord, milestones, and refundable balance in one call
    - Populates released_milestone_count from per-milestone flags
    - Fully documented with field table and backwards-compat notes

- contracts/escrow/src/test/summary.rs  [NEW]
  * 17 tests covering all lifecycle steps: Created, Funded, partial release, Completed, Cancelled, and multi-contract isolation
  * Tests for schema_version stability, role population (with/without arbiter), sequential milestone indices, amount correctness, flag accuracy, reputation_issued toggling, and ContractNotFound error path

- contracts/escrow/src/test.rs
  * Register mod summary; to include the new test module
  
  Closes #174 