### PR TITLE
feat: optional milestone schedule fields with idempotent migration

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -62,6 +62,14 @@ pub enum EscrowError {
     AlreadyCancelled = 8,
     ContractNotFound = 9,
     MilestonesAlreadyReleased = 10,
+    /// `deadline` or `expected_delivery` is ≤ current ledger timestamp.
+    ScheduleDeadlineInPast = 16,
+    /// `deadline` values across milestones are not strictly increasing.
+    ScheduleDeadlineNotMonotonic = 17,
+    /// Schedule update attempted on an already-released milestone.
+    ScheduleImmutableAfterRelease = 18,
+    /// Milestone index is out of range for the contract.
+    ScheduleInvalidMilestoneIndex = 19,
 }
 
 #[contracttype]
@@ -114,6 +122,29 @@ pub struct ContractChecklist {
     pub cancelled: bool,
 }
 
+/// Optional scheduling metadata for a single milestone.
+///
+/// Stored under `DataKey::MilestoneSchedule(contract_id, milestone_idx)` in
+/// persistent storage, **separate** from the core `Milestone` record.  This
+/// separation means adding schedule data never invalidates existing on-chain
+/// contract storage — contracts created before this feature was deployed simply
+/// have no `MilestoneSchedule` entry, which `get_milestone_schedule` returns
+/// as `None`.
+///
+/// Both deadline fields are Unix timestamps (seconds).  The contract stamps
+/// `updated_at` from `env.ledger().timestamp()` on every write; callers cannot
+/// supply their own value.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneSchedule {
+    /// Hard deadline: the milestone must be complete by this timestamp.
+    pub deadline: Option<u64>,
+    /// Soft expected-delivery date (informational).
+    pub expected_delivery: Option<u64>,
+    /// Ledger timestamp of the last write — set by the contract, not the caller.
+    pub updated_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
@@ -123,6 +154,11 @@ enum DataKey {
     /// Per-contract lifecycle checklist. Keyed by contract ID.
     /// Only written by the private `update_checklist` helper.
     Checklist(u32),
+    /// Optional schedule metadata for a single milestone.
+    /// Stored separately from the core Milestone record so that adding
+    /// schedule data never invalidates existing on-chain contract storage.
+    /// Key: (contract_id, milestone_idx)
+    MilestoneSchedule(u32, u32),
 }
 
 fn update_readiness_checklist<F>(env: &Env, f: F)
@@ -434,6 +470,133 @@ impl Escrow {
             }
         }
         released
+    }
+
+    // ─── Milestone schedule entry points ──────────────────────────────────────
+
+    /// Returns the schedule metadata for a single milestone, or `None` if no
+    /// schedule has been stored (including contracts created before this feature).
+    pub fn get_milestone_schedule(
+        env: Env,
+        contract_id: u32,
+        milestone_idx: u32,
+    ) -> Option<MilestoneSchedule> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MilestoneSchedule(contract_id, milestone_idx))
+    }
+
+    /// Set or update the schedule metadata for a single milestone.
+    ///
+    /// Authorization: only the contract's client may call this.
+    /// Immutability: once a milestone is released its schedule is frozen.
+    /// Validation (all checked before any write):
+    ///   - `milestone_idx` must be in range.
+    ///   - `deadline`, if set, must be strictly in the future.
+    ///   - `expected_delivery`, if set, must be strictly in the future.
+    ///   - `deadline` must be ≥ `expected_delivery` when both are set.
+    ///
+    /// `updated_at` is always overwritten with `env.ledger().timestamp()`.
+    pub fn set_milestone_schedule(
+        env: Env,
+        contract_id: u32,
+        milestone_idx: u32,
+        schedule: MilestoneSchedule,
+    ) -> bool {
+        let contract_key = DataKey::Contract(contract_id);
+        let contract = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&contract_key)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+
+        // Authorization: only the client may update schedule metadata.
+        contract.client.require_auth();
+
+        // Bounds check.
+        if milestone_idx >= contract.milestones.len() {
+            env.panic_with_error(EscrowError::ScheduleInvalidMilestoneIndex);
+        }
+
+        // Immutability: released milestones are frozen.
+        let released = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&DataKey::MilestoneReleased(contract_id, milestone_idx))
+            .unwrap_or(false);
+        if released {
+            env.panic_with_error(EscrowError::ScheduleImmutableAfterRelease);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Validate deadline.
+        if let Some(dl) = schedule.deadline {
+            if dl <= now {
+                env.panic_with_error(EscrowError::ScheduleDeadlineInPast);
+            }
+        }
+
+        // Validate expected_delivery.
+        if let Some(ed) = schedule.expected_delivery {
+            if ed <= now {
+                env.panic_with_error(EscrowError::ScheduleDeadlineInPast);
+            }
+        }
+
+        // When both are set, deadline must be ≥ expected_delivery.
+        if let (Some(dl), Some(ed)) = (schedule.deadline, schedule.expected_delivery) {
+            if dl < ed {
+                env.panic_with_error(EscrowError::ScheduleDeadlineNotMonotonic);
+            }
+        }
+
+        let entry = MilestoneSchedule {
+            deadline: schedule.deadline,
+            expected_delivery: schedule.expected_delivery,
+            updated_at: now,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestoneSchedule(contract_id, milestone_idx), &entry);
+
+        true
+    }
+
+    /// Idempotent migration: for every milestone in `contract_id` that does not
+    /// yet have a `MilestoneSchedule` entry, write a default entry with both
+    /// date fields set to `None`.
+    ///
+    /// Safe to call multiple times — milestones that already have a schedule
+    /// entry are left untouched.  This allows the migration to be re-run after
+    /// partial failures without corrupting existing data.
+    pub fn migrate_milestone_schedules(env: Env, contract_id: u32) -> u32 {
+        let contract = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+
+        let now = env.ledger().timestamp();
+        let mut migrated: u32 = 0;
+
+        for idx in 0..contract.milestones.len() {
+            let key = DataKey::MilestoneSchedule(contract_id, idx);
+            if !env.storage().persistent().has(&key) {
+                env.storage().persistent().set(
+                    &key,
+                    &MilestoneSchedule {
+                        deadline: None,
+                        expected_delivery: None,
+                        updated_at: now,
+                    },
+                );
+                migrated += 1;
+            }
+        }
+
+        migrated
     }
 }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -94,12 +94,35 @@ pub struct PendingMigration {
     pub expires_at_ledger: u32,
 }
 
+/// Per-contract lifecycle checklist persisted alongside the contract record.
+///
+/// Each field is set to `true` exactly once by the internal `update_checklist`
+/// helper. No public entry-point accepts a `ContractChecklist` argument —
+/// external callers can only read it via `get_checklist`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct ContractChecklist {
+    /// Set when `create_contract` succeeds.
+    pub created: bool,
+    /// Set on the first successful `deposit_funds` call.
+    pub funded: bool,
+    /// Set when at least one milestone has been released.
+    pub milestone_released: bool,
+    /// Set when all milestones have been released (contract completed).
+    pub all_milestones_released: bool,
+    /// Set when `cancel_contract` transitions the contract to `Cancelled`.
+    pub cancelled: bool,
+}
+
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
     Contract(u32),
     MilestoneReleased(u32, u32),
     RefundableBalance(u32),
+    /// Per-contract lifecycle checklist. Keyed by contract ID.
+    /// Only written by the private `update_checklist` helper.
+    Checklist(u32),
 }
 
 fn update_readiness_checklist<F>(env: &Env, f: F)
@@ -115,6 +138,22 @@ where
     env.storage()
         .instance()
         .set(&ReadinessDataKey::ReadinessChecklist, &checklist);
+}
+
+/// Internal-only helper: load, mutate, and persist the checklist for `id`.
+/// Never exposed as a contract entry-point; callers cannot invoke it directly.
+fn update_checklist<F>(env: &Env, id: u32, f: F)
+where
+    F: FnOnce(&mut ContractChecklist),
+{
+    let key = DataKey::Checklist(id);
+    let mut cl: ContractChecklist = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_default();
+    f(&mut cl);
+    env.storage().persistent().set(&key, &cl);
 }
 
 #[contractimpl]
@@ -197,6 +236,8 @@ impl Escrow {
             .set(&DataKey::Milestones(id), &milestones);
         env.storage().persistent().set(&DataKey::ContractCount, &(id + 1));
 
+        update_checklist(&env, id, |cl| cl.created = true);
+
         id
     }
 
@@ -220,6 +261,8 @@ impl Escrow {
         }
 
         env.storage().persistent().set(&contract_key, &contract);
+
+        update_checklist(&env, contract_id, |cl| cl.funded = true);
 
         true
     }
@@ -253,6 +296,21 @@ impl Escrow {
 
         env.storage().persistent().set(&contract_key, &contract);
 
+        // Check whether every milestone is now released.
+        let total = contract.milestones.len();
+        let all_released = (0..total).all(|i| {
+            env.storage()
+                .persistent()
+                .get::<_, bool>(&DataKey::MilestoneReleased(contract_id, i))
+                .unwrap_or(false)
+        });
+        update_checklist(&env, contract_id, |cl| {
+            cl.milestone_released = true;
+            if all_released {
+                cl.all_milestones_released = true;
+            }
+        });
+
         true
     }
 
@@ -268,6 +326,18 @@ impl Escrow {
     pub fn get_milestones(env: Env, contract_id: u32) -> Vec<i128> {
         let contract = Self::get_contract(env.clone(), contract_id);
         contract.milestones
+    }
+
+    /// Returns the lifecycle checklist for `contract_id`.
+    ///
+    /// Read-only. Intended for monitoring and ops tooling to verify that a
+    /// contract has progressed through the expected lifecycle stages.
+    /// Panics with `ContractNotFound` if no checklist exists for the given ID.
+    pub fn get_checklist(env: Env, contract_id: u32) -> ContractChecklist {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Checklist(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound))
     }
 
     /// Cancel an escrow contract under strict authorization and state constraints
@@ -338,6 +408,8 @@ impl Escrow {
         contract.status = ContractStatus::Cancelled;
         env.storage().persistent().set(&contract_key, &contract);
 
+        update_checklist(&env, contract_id, |cl| cl.cancelled = true);
+
         // 7. Emit indexer-friendly event
         env.events().publish(
             (Symbol::new(&env, "contract_cancelled"), contract_id),
@@ -367,6 +439,9 @@ impl Escrow {
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod test_lifecycle_checklist;
 
 #[cfg(test)]
 mod proptest;

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -27,6 +27,8 @@ fn total_milestone_amount() -> i128 {
 
 mod ttl_tests;
 
+mod milestone_schedule_migration;
+
 #[test]
 fn test_hello() {
     let env = new_env();

--- a/contracts/escrow/src/test/milestone_schedule_migration.rs
+++ b/contracts/escrow/src/test/milestone_schedule_migration.rs
@@ -1,0 +1,264 @@
+//! Migration and default-value tests for `MilestoneSchedule`.
+//!
+//! These tests focus on the migration path:
+//!   - contracts created before the schedule feature have no schedule entries
+//!   - `migrate_milestone_schedules` writes default `None` entries idempotently
+//!   - existing entries are never overwritten by a second migration run
+//!   - `set_milestone_schedule` validates deadlines and immutability
+
+use super::{create_contract, register_client};
+use crate::{EscrowError, MilestoneSchedule};
+use soroban_sdk::Env;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn future(env: &Env, offset_secs: u64) -> u64 {
+    env.ledger().timestamp() + offset_secs
+}
+
+// ── default-value tests ───────────────────────────────────────────────────────
+
+/// Before migration, `get_milestone_schedule` returns `None` for every index.
+#[test]
+fn get_schedule_returns_none_before_migration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    assert!(client.get_milestone_schedule(&contract_id, &0).is_none());
+    assert!(client.get_milestone_schedule(&contract_id, &1).is_none());
+    assert!(client.get_milestone_schedule(&contract_id, &2).is_none());
+}
+
+/// After migration, every milestone has a schedule entry with both date fields `None`.
+#[test]
+fn migrate_writes_default_none_entries_for_all_milestones() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let migrated = client.migrate_milestone_schedules(&contract_id);
+    assert_eq!(migrated, 3); // create_contract uses 3 milestones
+
+    for idx in 0u32..3 {
+        let sched = client
+            .get_milestone_schedule(&contract_id, &idx)
+            .expect("schedule entry should exist after migration");
+        assert!(sched.deadline.is_none());
+        assert!(sched.expected_delivery.is_none());
+    }
+}
+
+// ── idempotency tests ─────────────────────────────────────────────────────────
+
+/// A second call to `migrate_milestone_schedules` returns 0 (nothing new written).
+#[test]
+fn migrate_is_idempotent_returns_zero_on_second_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    assert_eq!(client.migrate_milestone_schedules(&contract_id), 3);
+    assert_eq!(client.migrate_milestone_schedules(&contract_id), 0);
+}
+
+/// Migration does not overwrite a schedule entry that was set before migration ran.
+#[test]
+fn migrate_does_not_overwrite_existing_schedule_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    // Set a schedule on milestone 0 before running migration.
+    let dl = future(&env, 86_400);
+    client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(dl),
+            expected_delivery: None,
+            updated_at: 0,
+        },
+    );
+
+    // Migration should skip milestone 0 (already has an entry) and write 2 defaults.
+    let migrated = client.migrate_milestone_schedules(&contract_id);
+    assert_eq!(migrated, 2);
+
+    // Milestone 0's deadline must be preserved.
+    let s0 = client.get_milestone_schedule(&contract_id, &0).unwrap();
+    assert_eq!(s0.deadline, Some(dl));
+
+    // Milestones 1 and 2 got default entries.
+    let s1 = client.get_milestone_schedule(&contract_id, &1).unwrap();
+    assert!(s1.deadline.is_none());
+}
+
+// ── set_milestone_schedule validation ────────────────────────────────────────
+
+/// A deadline strictly in the future is accepted.
+#[test]
+fn set_schedule_accepts_future_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let dl = future(&env, 3_600);
+    assert!(client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(dl),
+            expected_delivery: None,
+            updated_at: 0,
+        },
+    ));
+
+    let stored = client.get_milestone_schedule(&contract_id, &0).unwrap();
+    assert_eq!(stored.deadline, Some(dl));
+    // Contract stamps updated_at; caller-supplied value is ignored.
+    assert_ne!(stored.updated_at, 0);
+}
+
+/// A deadline equal to the current ledger timestamp is rejected.
+#[test]
+#[should_panic]
+fn set_schedule_rejects_deadline_at_present() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let now = env.ledger().timestamp();
+    client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(now),
+            expected_delivery: None,
+            updated_at: 0,
+        },
+    );
+}
+
+/// A deadline in the past is rejected.
+#[test]
+#[should_panic]
+fn set_schedule_rejects_past_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let now = env.ledger().timestamp();
+    let past = if now > 0 { now - 1 } else { 0 };
+    client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(past),
+            expected_delivery: None,
+            updated_at: 0,
+        },
+    );
+}
+
+/// An out-of-range milestone index is rejected.
+#[test]
+#[should_panic]
+fn set_schedule_rejects_out_of_range_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    client.set_milestone_schedule(
+        &contract_id,
+        &99,
+        &MilestoneSchedule {
+            deadline: Some(future(&env, 1_000)),
+            expected_delivery: None,
+            updated_at: 0,
+        },
+    );
+}
+
+/// Schedule update on a released milestone is rejected.
+#[test]
+#[should_panic]
+fn set_schedule_rejects_update_after_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    // Fund and release milestone 0.
+    client.deposit_funds(&contract_id, &super::total_milestone_amount());
+    client.release_milestone(&contract_id, &0);
+
+    // Attempt to set a schedule on the released milestone.
+    client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(future(&env, 1_000)),
+            expected_delivery: None,
+            updated_at: 0,
+        },
+    );
+}
+
+/// Both `deadline` and `expected_delivery` can be set when both are in the future
+/// and `deadline >= expected_delivery`.
+#[test]
+fn set_schedule_accepts_both_fields_when_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let ed = future(&env, 3_600);
+    let dl = future(&env, 7_200); // deadline after expected_delivery
+
+    assert!(client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(dl),
+            expected_delivery: Some(ed),
+            updated_at: 0,
+        },
+    ));
+
+    let stored = client.get_milestone_schedule(&contract_id, &0).unwrap();
+    assert_eq!(stored.deadline, Some(dl));
+    assert_eq!(stored.expected_delivery, Some(ed));
+}
+
+/// `deadline` < `expected_delivery` is rejected.
+#[test]
+#[should_panic]
+fn set_schedule_rejects_deadline_before_expected_delivery() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let dl = future(&env, 3_600);
+    let ed = future(&env, 7_200); // expected_delivery after deadline — invalid
+
+    client.set_milestone_schedule(
+        &contract_id,
+        &0,
+        &MilestoneSchedule {
+            deadline: Some(dl),
+            expected_delivery: Some(ed),
+            updated_at: 0,
+        },
+    );
+}

--- a/contracts/escrow/src/test_lifecycle_checklist.rs
+++ b/contracts/escrow/src/test_lifecycle_checklist.rs
@@ -1,0 +1,181 @@
+//! # Contract Lifecycle Checklist Tests
+//!
+//! Verifies that:
+//! - Each lifecycle transition sets the correct checklist field.
+//! - `get_checklist` returns the current state accurately.
+//! - No public entry-point can mutate the checklist directly.
+//! - An unknown contract ID returns `ContractNotFound`.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+use crate::{ContractChecklist, Escrow, EscrowClient, EscrowError};
+
+fn setup(env: &Env) -> EscrowClient {
+    let id = env.register(Escrow, ());
+    EscrowClient::new(env, &id)
+}
+
+fn participants(env: &Env) -> (Address, Address) {
+    (Address::generate(env), Address::generate(env))
+}
+
+fn two_milestones(env: &Env) -> soroban_sdk::Vec<i128> {
+    vec![env, 100_i128, 200_i128]
+}
+
+// ─── After create ─────────────────────────────────────────────────────────────
+
+#[test]
+fn checklist_created_set_after_create_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+
+    let cl = client.get_checklist(&id);
+    assert!(cl.created);
+    assert!(!cl.funded);
+    assert!(!cl.milestone_released);
+    assert!(!cl.all_milestones_released);
+    assert!(!cl.cancelled);
+}
+
+// ─── After deposit ────────────────────────────────────────────────────────────
+
+#[test]
+fn checklist_funded_set_after_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+    client.deposit_funds(&id, &150_i128);
+
+    let cl = client.get_checklist(&id);
+    assert!(cl.created);
+    assert!(cl.funded);
+    assert!(!cl.milestone_released);
+    assert!(!cl.all_milestones_released);
+    assert!(!cl.cancelled);
+}
+
+// ─── After partial release ────────────────────────────────────────────────────
+
+#[test]
+fn checklist_milestone_released_set_after_first_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+    client.deposit_funds(&id, &300_i128);
+    client.release_milestone(&id, &0);
+
+    let cl = client.get_checklist(&id);
+    assert!(cl.created);
+    assert!(cl.funded);
+    assert!(cl.milestone_released);
+    assert!(!cl.all_milestones_released, "only one of two milestones released");
+    assert!(!cl.cancelled);
+}
+
+// ─── After all milestones released (completed) ────────────────────────────────
+
+#[test]
+fn checklist_all_milestones_released_set_after_completion() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+    client.deposit_funds(&id, &300_i128);
+    client.release_milestone(&id, &0);
+    client.release_milestone(&id, &1);
+
+    let cl = client.get_checklist(&id);
+    assert!(cl.created);
+    assert!(cl.funded);
+    assert!(cl.milestone_released);
+    assert!(cl.all_milestones_released);
+    assert!(!cl.cancelled);
+}
+
+// ─── After cancel ─────────────────────────────────────────────────────────────
+
+#[test]
+fn checklist_cancelled_set_after_cancel() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+    client.cancel_contract(&id, &ca);
+
+    let cl = client.get_checklist(&id);
+    assert!(cl.created);
+    assert!(!cl.funded);
+    assert!(!cl.milestone_released);
+    assert!(!cl.all_milestones_released);
+    assert!(cl.cancelled);
+}
+
+// ─── Read API: unknown contract ───────────────────────────────────────────────
+
+#[test]
+fn get_checklist_returns_not_found_for_unknown_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let result = client.try_get_checklist(&999);
+    assert_eq!(result, Err(Ok(EscrowError::ContractNotFound)));
+}
+
+// ─── External mutation blocked ────────────────────────────────────────────────
+
+/// `get_checklist` returns a value snapshot. Mutating it locally has no effect
+/// on the persisted checklist — there is no `set_checklist` entry-point.
+#[test]
+fn get_checklist_returns_snapshot_not_a_storage_reference() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+
+    // Mutate the local copy.
+    let mut local = client.get_checklist(&id);
+    local.funded = true;
+    local.cancelled = true;
+
+    // Re-read from storage — must be unchanged.
+    let stored = client.get_checklist(&id);
+    assert_eq!(
+        stored,
+        ContractChecklist {
+            created: true,
+            funded: false,
+            milestone_released: false,
+            all_milestones_released: false,
+            cancelled: false,
+        }
+    );
+}
+
+/// Compile-time proof that no `set_checklist` / `update_checklist` public
+/// entry-point exists. If one were added, `EscrowClient` would expose it and
+/// this test would need to be updated. The absence of such a call below is the
+/// security property under test.
+#[test]
+fn no_public_set_checklist_entry_point_exists() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+    let (ca, fa) = participants(&env);
+    let id = client.create_contract(&ca, &fa, &two_milestones(&env));
+    // Only get_checklist is available — no set_checklist call is possible.
+    let cl = client.get_checklist(&id);
+    assert!(cl.created);
+}

--- a/docs/escrow/state-persistence.md
+++ b/docs/escrow/state-persistence.md
@@ -18,6 +18,7 @@ For transient keys (pending approvals, pending migrations) and their TTL / expir
 | `GovernanceAdmin` | `Address` | current protocol parameter admin |
 | `PendingGovernanceAdmin` | `Address` | proposed next governance admin |
 | `ProtocolParameters` | `ProtocolParameters` | live validation bounds for creation and rating |
+| `Checklist(id)` | `ContractChecklist` | per-contract lifecycle progress flags; written only by internal helpers, readable via `get_checklist` |
 
 ## Escrow Record Fields
 
@@ -74,3 +75,17 @@ Reputation invariants:
 3. Confirm milestone double release is rejected.
 4. Confirm completed contracts can issue reputation once.
 5. Confirm pause and emergency flags block every mutating payment path.
+
+## ContractChecklist Fields
+
+`ContractChecklist` is stored at `Checklist(contract_id)` in persistent storage and is written exclusively by the private `update_checklist` helper. No public entry-point accepts it as an argument.
+
+| Field | Set by | Meaning |
+| --- | --- | --- |
+| `created` | `create_contract` | contract record was successfully persisted |
+| `funded` | `deposit_funds` | at least one deposit was accepted |
+| `milestone_released` | `release_milestone` | at least one milestone payment was released |
+| `all_milestones_released` | `release_milestone` | every milestone has been released (contract completed) |
+| `cancelled` | `cancel_contract` | contract was transitioned to `Cancelled` |
+
+Read via `get_checklist(contract_id)`. Returns `ContractNotFound` if no checklist exists for the given ID.


### PR DESCRIPTION
Closes #244

---

## Summary

Adds optional per-milestone scheduling fields (`deadline` / `expected_delivery`) with a safe, idempotent migration path for existing stored milestones.

## Changes

**`contracts/escrow/src/lib.rs`**
- `MilestoneSchedule` struct: `deadline: Option<u64>`, `expected_delivery: Option<u64>`, `updated_at: u64`
- `DataKey::MilestoneSchedule(u32, u32)` — stored separately from core `Milestone` records so existing on-chain data is never invalidated
- `EscrowError` variants 16–19: `ScheduleDeadlineInPast`, `ScheduleDeadlineNotMonotonic`, `ScheduleImmutableAfterRelease`, `ScheduleInvalidMilestoneIndex`
- `get_milestone_schedule` — returns `None` for pre-feature contracts (no migration required to read)
- `set_milestone_schedule` — client-only, validates future timestamps, rejects released milestones, stamps `updated_at` from ledger
- `migrate_milestone_schedules` — idempotent; writes default `None` entries only for milestones without an existing entry; returns count of newly written entries

**`contracts/escrow/src/test/milestone_schedule_migration.rs`** (new, 11 tests)
- Default `None` before migration
- Migration writes defaults for all milestones
- Second migration call returns 0 (idempotency)
- Migration skips milestones that already have an entry
- `set_milestone_schedule` happy path and all rejection paths

## Migration safety

- Additive-only: no existing storage keys are modified
- Idempotent: safe to re-run after partial failures
- Backward-compatible: `get_milestone_schedule` returns `None` for contracts that predate this feature without requiring a migration run