### PR TITLE
feat: immutable per-milestone evidence hash

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -62,6 +62,10 @@ pub enum EscrowError {
     AlreadyCancelled = 8,
     ContractNotFound = 9,
     MilestonesAlreadyReleased = 10,
+    /// Evidence hash has already been set for this milestone; it is immutable.
+    EvidenceHashAlreadySet = 11,
+    /// Milestone index is out of range for the contract.
+    EvidenceHashInvalidMilestoneIndex = 12,
 }
 
 #[contracttype]
@@ -100,6 +104,10 @@ enum DataKey {
     Contract(u32),
     MilestoneReleased(u32, u32),
     RefundableBalance(u32),
+    /// Immutable evidence hash for a milestone (e.g. IPFS CID).
+    /// Write-once: once set it cannot be overwritten.
+    /// Key: (contract_id, milestone_idx)
+    MilestoneEvidenceHash(u32, u32),
 }
 
 fn update_readiness_checklist<F>(env: &Env, f: F)
@@ -362,6 +370,82 @@ impl Escrow {
             }
         }
         released
+    }
+
+    // ─── Milestone evidence hash entry points ─────────────────────────────────
+
+    /// Returns the evidence hash for `milestone_idx`, or `None` if not yet set.
+    ///
+    /// The hash is a 32-byte value (e.g. an IPFS CID digest) that was committed
+    /// by an authorized party.  Returning `None` means no evidence has been
+    /// attached; the raw content is never stored on-chain.
+    pub fn get_milestone_evidence_hash(
+        env: Env,
+        contract_id: u32,
+        milestone_idx: u32,
+    ) -> Option<BytesN<32>> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MilestoneEvidenceHash(contract_id, milestone_idx))
+    }
+
+    /// Attach an immutable evidence hash to a milestone.
+    ///
+    /// Authorization: the caller must be the contract's **client** or
+    /// **freelancer**.  The arbiter may read but not write evidence.
+    ///
+    /// Immutability: once a hash is stored it cannot be overwritten.  Any
+    /// second call for the same `(contract_id, milestone_idx)` panics with
+    /// `EvidenceHashAlreadySet`.
+    ///
+    /// The `hash` is a 32-byte digest (e.g. SHA-256 of an IPFS CID) so that
+    /// the raw content is never exposed on-chain.
+    ///
+    /// Emits a `milestone_evidence` event on success.
+    pub fn set_milestone_evidence_hash(
+        env: Env,
+        contract_id: u32,
+        milestone_idx: u32,
+        hash: BytesN<32>,
+        caller: Address,
+    ) -> bool {
+        caller.require_auth();
+
+        let contract_key = DataKey::Contract(contract_id);
+        let contract = env
+            .storage()
+            .persistent()
+            .get::<_, ContractData>(&contract_key)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+
+        // Authorization: only client or freelancer may attach evidence.
+        if caller != contract.client && caller != contract.freelancer {
+            env.panic_with_error(EscrowError::UnauthorizedRole);
+        }
+
+        // Bounds check.
+        if milestone_idx >= contract.milestones.len() {
+            env.panic_with_error(EscrowError::EvidenceHashInvalidMilestoneIndex);
+        }
+
+        let key = DataKey::MilestoneEvidenceHash(contract_id, milestone_idx);
+
+        // Write-once: reject any attempt to overwrite an existing hash.
+        if env.storage().persistent().has(&key) {
+            env.panic_with_error(EscrowError::EvidenceHashAlreadySet);
+        }
+
+        env.storage().persistent().set(&key, &hash);
+
+        // Emit an indexer-friendly event so off-chain tooling can correlate
+        // the on-chain commitment with the off-chain content without storing
+        // the content itself.
+        env.events().publish(
+            (Symbol::new(&env, "milestone_evidence"), contract_id),
+            (milestone_idx, hash, caller),
+        );
+
+        true
     }
 }
 

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -27,6 +27,8 @@ fn total_milestone_amount() -> i128 {
 
 mod ttl_tests;
 
+mod milestone_evidence_hash;
+
 #[test]
 fn test_hello() {
     let env = new_env();

--- a/contracts/escrow/src/test/milestone_evidence_hash.rs
+++ b/contracts/escrow/src/test/milestone_evidence_hash.rs
@@ -1,0 +1,211 @@
+//! Tests for the milestone evidence hash feature.
+//!
+//! Covers authorization, write-once immutability, bounds checking, and the
+//! happy-path read/write flow.
+
+use super::{create_contract, register_client, total_milestone_amount};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+fn dummy_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0xab; 32])
+}
+
+fn other_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0xcd; 32])
+}
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
+/// `get_milestone_evidence_hash` returns `None` before any hash is set.
+#[test]
+fn get_returns_none_before_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    assert!(client.get_milestone_evidence_hash(&contract_id, &0).is_none());
+}
+
+/// Client can set a hash; it is retrievable afterwards.
+#[test]
+fn client_can_set_and_retrieve_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = create_contract(&env, &client);
+
+    let hash = dummy_hash(&env);
+    assert!(client.set_milestone_evidence_hash(&contract_id, &0, &hash, &client_addr));
+
+    let stored = client
+        .get_milestone_evidence_hash(&contract_id, &0)
+        .expect("hash should be stored");
+    assert_eq!(stored, hash);
+}
+
+/// Freelancer can also set a hash.
+#[test]
+fn freelancer_can_set_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, freelancer_addr, contract_id) = create_contract(&env, &client);
+
+    let hash = dummy_hash(&env);
+    assert!(client.set_milestone_evidence_hash(&contract_id, &0, &hash, &freelancer_addr));
+    assert_eq!(
+        client.get_milestone_evidence_hash(&contract_id, &0).unwrap(),
+        hash
+    );
+}
+
+/// Hashes for different milestones are stored independently.
+#[test]
+fn hashes_are_isolated_per_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = create_contract(&env, &client);
+
+    let h0 = dummy_hash(&env);
+    let h1 = other_hash(&env);
+
+    client.set_milestone_evidence_hash(&contract_id, &0, &h0, &client_addr);
+    client.set_milestone_evidence_hash(&contract_id, &1, &h1, &client_addr);
+
+    assert_eq!(client.get_milestone_evidence_hash(&contract_id, &0).unwrap(), h0);
+    assert_eq!(client.get_milestone_evidence_hash(&contract_id, &1).unwrap(), h1);
+    assert!(client.get_milestone_evidence_hash(&contract_id, &2).is_none());
+}
+
+/// A hash set on one contract does not appear on another.
+#[test]
+fn hashes_are_isolated_across_contracts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr_a, _, id_a) = create_contract(&env, &client);
+    let (client_addr_b, _, id_b) = create_contract(&env, &client);
+
+    client.set_milestone_evidence_hash(&id_a, &0, &dummy_hash(&env), &client_addr_a);
+
+    assert!(client.get_milestone_evidence_hash(&id_a, &0).is_some());
+    assert!(client.get_milestone_evidence_hash(&id_b, &0).is_none());
+    let _ = client_addr_b; // suppress unused warning
+}
+
+// ── immutability ──────────────────────────────────────────────────────────────
+
+/// A second `set_milestone_evidence_hash` call for the same milestone panics.
+#[test]
+#[should_panic]
+fn overwrite_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = create_contract(&env, &client);
+
+    client.set_milestone_evidence_hash(&contract_id, &0, &dummy_hash(&env), &client_addr);
+    // Second call — must panic with EvidenceHashAlreadySet.
+    client.set_milestone_evidence_hash(&contract_id, &0, &other_hash(&env), &client_addr);
+}
+
+/// Even the same hash value cannot be re-submitted (write-once, not idempotent).
+#[test]
+#[should_panic]
+fn resubmitting_same_hash_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = create_contract(&env, &client);
+
+    let hash = dummy_hash(&env);
+    client.set_milestone_evidence_hash(&contract_id, &0, &hash.clone(), &client_addr);
+    client.set_milestone_evidence_hash(&contract_id, &0, &hash, &client_addr);
+}
+
+// ── authorization ─────────────────────────────────────────────────────────────
+
+/// A third-party address (not client or freelancer) is rejected.
+#[test]
+#[should_panic]
+fn unauthorized_caller_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    let attacker = Address::generate(&env);
+    client.set_milestone_evidence_hash(&contract_id, &0, &dummy_hash(&env), &attacker);
+}
+
+/// The arbiter (if present) cannot set evidence — only client/freelancer can.
+#[test]
+#[should_panic]
+fn arbiter_cannot_set_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let milestones = soroban_sdk::vec![&env, 200_0000000_i128, 400_0000000_i128, 600_0000000_i128];
+
+    // create_contract with arbiter — call the contract directly with arbiter param
+    let contract_id = escrow.create_contract(&client_addr, &freelancer_addr, &Some(arbiter_addr.clone()), &milestones);
+
+    escrow.set_milestone_evidence_hash(&contract_id, &0, &dummy_hash(&env), &arbiter_addr);
+}
+
+// ── bounds ────────────────────────────────────────────────────────────────────
+
+/// An out-of-range milestone index is rejected.
+#[test]
+#[should_panic]
+fn out_of_range_index_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = create_contract(&env, &client);
+
+    client.set_milestone_evidence_hash(&contract_id, &99, &dummy_hash(&env), &client_addr);
+}
+
+/// Setting a hash on a non-existent contract panics.
+#[test]
+#[should_panic]
+fn missing_contract_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let caller = Address::generate(&env);
+
+    client.set_milestone_evidence_hash(&999, &0, &dummy_hash(&env), &caller);
+}
+
+// ── integration ───────────────────────────────────────────────────────────────
+
+/// Evidence hash survives a full release cycle — it remains readable after the
+/// milestone is released and the contract completes.
+#[test]
+fn hash_persists_after_milestone_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = create_contract(&env, &client);
+
+    let hash = dummy_hash(&env);
+    client.set_milestone_evidence_hash(&contract_id, &0, &hash.clone(), &client_addr);
+
+    // Fund and release milestone 0.
+    client.deposit_funds(&contract_id, &total_milestone_amount());
+    client.release_milestone(&contract_id, &0);
+
+    // Hash must still be readable.
+    assert_eq!(
+        client.get_milestone_evidence_hash(&contract_id, &0).unwrap(),
+        hash
+    );
+}


### PR DESCRIPTION
Closes #246

---

## Summary

Allows attaching a 32-byte immutable evidence hash (e.g. IPFS CID digest) to any milestone. The raw content is never stored on-chain — only the hash commitment — supporting dispute resolution without leaking content.

## Changes

**`contracts/escrow/src/lib.rs`**
- `DataKey::MilestoneEvidenceHash(u32, u32)` — separate persistent storage key, never touches existing milestone data
- `EscrowError::EvidenceHashAlreadySet = 11` — write-once guard
- `EscrowError::EvidenceHashInvalidMilestoneIndex = 12` — bounds guard
- `get_milestone_evidence_hash(contract_id, milestone_idx) -> Option<BytesN<32>>` — returns `None` if not yet set
- `set_milestone_evidence_hash(contract_id, milestone_idx, hash, caller)` — client or freelancer only; write-once; emits `milestone_evidence` event

**`contracts/escrow/src/test/milestone_evidence_hash.rs`** (new, 13 tests)

| Category | Tests |
|---|---|
| Happy path | get returns None before set, client can set, freelancer can set, isolation per milestone, isolation across contracts |
| Immutability | overwrite rejected, same hash resubmission rejected |
| Authorization | third-party rejected, arbiter rejected |
| Bounds | out-of-range index rejected, missing contract rejected |
| Integration | hash persists after milestone release |

## Security properties

- **Write-once**: `storage().has()` check before every write; no overwrite path exists
- **Authorization**: `caller.require_auth()` + explicit client/freelancer check; arbiter is read-only
- **No content on-chain**: only a `BytesN<32>` digest is stored; raw evidence stays off-chain
- **Additive storage**: new `DataKey` variant; zero impact on existing contract records