### PR TITLE
feat: standardize escrow lifecycle event schema

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,178 +1,53 @@
-# Pull Request: Implement Dispute Resolution Mechanism
+# Pull Request: Deterministic Escrow Lifecycle Events
 
 ## Summary
 
-This PR implements a comprehensive dispute resolution mechanism for the TalentTrust escrow contract, adding admin/arbitrator oversight with deterministic payout outcomes. The implementation addresses issue #57 and provides a secure, tested, and well-documented dispute resolution system.
+This PR standardizes escrow lifecycle event topics and payloads to provide deterministic indexing for create/deposit/approve/release/cancel flows.
 
-## Features Implemented
+## What changed
 
-### 🔐 **Admin/Arbitrator Roles**
-- Secure initialization with admin and arbitrator addresses
-- Role-based access control for all sensitive operations
-- Admin can update arbitrator, arbitrator can resolve disputes
+- `contracts/escrow/src/lib.rs`
+  - Added shared `emit_lifecycle_event(...)` helper.
+  - Standardized event topic format to:
+    - `("escrow", "v1", operation, contract_id)`
+  - Standardized event payload format to:
+    - `(status, amount, milestone_index, actor, timestamp)`
+  - Wired helper into:
+    - `create_contract` (`create`)
+    - `deposit_funds` (`deposit`)
+    - `approve_milestone` (`approve`)
+    - `release_milestone` (`release`)
+    - `cancel_contract` (`cancel`)
 
-### ⚖️ **Dispute Resolution Types**
-- **FullRefund**: 100% refund to client (for undelivered work)
-- **PartialRefund**: 70% to client, 30% to freelancer (for quality issues)
-- **FullPayout**: 100% to freelancer (for completed work)
-- **Split**: Custom split with mathematical validation (for complex cases)
+- `contracts/escrow/src/test/cancel_contract.rs`
+  - Updated cancellation event test to assert that an event is emitted.
 
-### 🛡️ **Security Features**
-- **Access Control**: Comprehensive role-based permissions
-- **Financial Safety**: Mathematical validation prevents fund loss
-- **State Machine**: Strict contract state management
-- **Deterministic Outcomes**: Predictable, auditable payout calculations
+- `docs/escrow/README.md`
+  - Added explicit deterministic lifecycle event schema and operation mappings.
+  - Added migration note for legacy cancellation topic consumers.
 
-### 📋 **Workflow**
-1. Client or freelancer creates dispute for funded contracts
-2. Arbitrator reviews evidence and determines resolution
-3. Contract status updates to `Resolved` with final payouts
-4. All decisions tracked with timestamps and decision-maker
+- `docs/escrow/contract.md`
+  - Updated cancel event documentation to the v1 deterministic schema.
+  - Added lifecycle event schema section and breaking-change note.
 
-## Changes Made
+## Backward compatibility
 
-### Core Implementation
-- **`contracts/escrow/src/lib.rs`**: Complete dispute resolution implementation
-  - Added storage structures for contracts and disputes
-  - Implemented admin/arbitrator access control
-  - Added dispute creation and resolution functions
-  - Comprehensive state validation and error handling
+- Breaking behavior for event consumers:
+  - Legacy cancellation topic `("contract_cancelled", contract_id)` is replaced by the v1 lifecycle topic format.
+  - Indexers and monitoring rules must migrate to `("escrow", "v1", "cancel", contract_id)`.
 
-### Testing
-- **`contracts/escrow/src/test.rs`**: 15+ comprehensive tests
-  - Normal workflow operations
-  - All dispute resolution scenarios
-  - Access control validation
-  - Edge cases and error conditions
-  - Security assumption testing
+## Test plan
 
-### Documentation
-- **`README.md`**: Updated with dispute resolution features
-- **`docs/escrow/README.md`**: Complete contract documentation
-- **`docs/escrow/dispute-resolution.md`**: API reference and usage examples
-- **`docs/escrow/security-analysis.md`**: Security analysis and threat model
+- [ ] `cargo build`
+- [ ] `cargo test -p escrow`
 
-## Security Analysis
+> Note: Rust toolchain (`cargo`) is not available in the current execution environment, so build/test commands could not be run here.
 
-### Threats Mitigated
-- ✅ **Unauthorized Access**: Role-based authentication
-- ✅ **Financial Loss**: Deterministic payout calculations
-- ✅ **State Manipulation**: Strict state machine validation
-- ✅ **Double Spending**: Status flags prevent duplicate operations
+## Security notes
 
-### Guarantees
-- **Total Preservation**: `client_payout + freelancer_payout = contract.total_amount`
-- **No Loss**: Zero possibility of funds being lost to contract
-- **Deterministic Outcomes**: Mathematical formulas prevent arbitrary allocations
-- **Audit Trail**: All decisions tracked with timestamps and decision-maker
-
-## Testing Coverage
-
-### Functional Tests
-- Contract creation and funding
-- Milestone release workflow
-- Dispute creation (client/freelancer)
-- All 4 resolution types
-- Admin/arbitrator role management
-
-### Security Tests
-- Unauthorized access attempts
-- Invalid split amounts
-- State transition violations
-- Double operation prevention
-
-### Edge Cases
-- Boundary conditions
-- Error scenarios
-- Invalid inputs
-
-## API Examples
-
-### Create Dispute
-```rust
-let dispute_id = escrow.create_dispute(
-    contract_id,
-    symbol_short!("quality_issues"),
-    vec![symbol_short!("evidence1")]
-);
-```
-
-### Resolve Dispute
-```rust
-// Partial refund (70/30 split)
-escrow.resolve_dispute(
-    dispute_id,
-    DisputeResolution::PartialRefund,
-    0,  // Not used for PartialRefund
-    0   // Not used for PartialRefund
-);
-
-// Custom split (60/40)
-escrow.resolve_dispute(
-    dispute_id,
-    DisputeResolution::Split,
-    600_0000000,  // 60% to client
-    400_0000000   // 40% to freelancer
-);
-```
-
-## Validation
-
-- ✅ **Code Review**: Implementation follows Soroban best practices
-- ✅ **Security Review**: Comprehensive threat analysis completed
-- ✅ **Testing**: All functions covered with unit tests
-- ✅ **Documentation**: Complete API and security documentation
-- ✅ **Standards Compliance**: Follows existing project patterns
-
-## Breaking Changes
-
-None. This is additive functionality that maintains backward compatibility with existing escrow operations.
-
-## Dependencies
-
-- Uses existing `soroban-sdk v22.0` dependency
-- No additional dependencies required
-
-## Performance Considerations
-
-- Efficient storage usage with Map-based data structures
-- Minimal gas overhead for dispute operations
-- Deterministic resolution calculations
-
-## Future Enhancements
-
-- Multi-signature dispute resolution
-- Time-based escrow releases
-- Reputation system integration
-- Cross-chain dispute resolution
-
-## Checklist
-
-- [x] Code follows project style guidelines
-- [x] Self-review of the code completed
-- [x] Documentation updated
-- [x] Tests added and passing
-- [x] Security analysis completed
-- [x] Breaking changes documented (none)
-- [x] Commit messages follow conventions
-
-## Testing Instructions
-
-```bash
-# Run tests (requires proper Rust environment)
-cargo test
-
-# Check formatting
-cargo fmt --all -- --check
-
-# Build verification
-cargo build
-```
-
-## Security Notes
-
-This implementation provides strong security guarantees through deterministic mathematical outcomes and strict access control. The remaining risks are primarily governance-related (arbitrator selection) rather than technical vulnerabilities.
+- Event emission is now centralized to reduce schema drift between lifecycle endpoints.
+- Topics and payload fields are fixed-shape and deterministic for safer downstream parsing.
 
 ---
 
-**Closes #57**
+Closes #259

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -102,6 +102,29 @@ enum DataKey {
     RefundableBalance(u32),
 }
 
+fn emit_lifecycle_event(
+    env: &Env,
+    operation: Symbol,
+    contract_id: u32,
+    status: ContractStatus,
+    amount: i128,
+    milestone_index: u32,
+    actor: Option<Address>,
+) {
+    // Stable topic and payload shape for indexers:
+    // topic: ("escrow", "v1", operation, contract_id)
+    // data: (status, amount, milestone_index, actor, timestamp)
+    env.events().publish(
+        (
+            symbol_short!("escrow"),
+            symbol_short!("v1"),
+            operation,
+            contract_id,
+        ),
+        (status, amount, milestone_index, actor, env.ledger().timestamp()),
+    );
+}
+
 fn update_readiness_checklist<F>(env: &Env, f: F)
 where
     F: FnOnce(&mut ReadinessChecklist),
@@ -197,6 +220,16 @@ impl Escrow {
             .set(&DataKey::Milestones(id), &milestones);
         env.storage().persistent().set(&DataKey::ContractCount, &(id + 1));
 
+        emit_lifecycle_event(
+            &env,
+            symbol_short!("create"),
+            id,
+            ContractStatus::Created,
+            total_amount,
+            0,
+            Some(client),
+        );
+
         id
     }
 
@@ -220,6 +253,15 @@ impl Escrow {
         }
 
         env.storage().persistent().set(&contract_key, &contract);
+        emit_lifecycle_event(
+            &env,
+            symbol_short!("deposit"),
+            contract_id,
+            contract.status,
+            amount,
+            0,
+            None,
+        );
 
         true
     }
@@ -230,6 +272,15 @@ impl Escrow {
         env.storage().persistent().set(
             &DataKey::MilestoneApprovalTime(contract_id, milestone_index),
             &approval_time,
+        );
+        emit_lifecycle_event(
+            &env,
+            symbol_short!("approve"),
+            contract_id,
+            ContractStatus::Funded,
+            0,
+            milestone_index,
+            None,
         );
         true
     }
@@ -247,11 +298,22 @@ impl Escrow {
         env.storage().persistent().set(&milestone_key, &true);
 
         // Update released amount
+        let mut released_amount = 0i128;
         if let Some(amount) = contract.milestones.get(milestone_index) {
+            released_amount = amount;
             contract.released_amount += amount;
         }
 
         env.storage().persistent().set(&contract_key, &contract);
+        emit_lifecycle_event(
+            &env,
+            symbol_short!("release"),
+            contract_id,
+            contract.status,
+            released_amount,
+            milestone_index,
+            None,
+        );
 
         true
     }
@@ -338,10 +400,15 @@ impl Escrow {
         contract.status = ContractStatus::Cancelled;
         env.storage().persistent().set(&contract_key, &contract);
 
-        // 7. Emit indexer-friendly event
-        env.events().publish(
-            (Symbol::new(&env, "contract_cancelled"), contract_id),
-            (caller, contract.status, env.ledger().timestamp()),
+        // 7. Emit deterministic lifecycle event for indexers.
+        emit_lifecycle_event(
+            &env,
+            symbol_short!("cancel"),
+            contract_id,
+            contract.status,
+            0,
+            0,
+            Some(caller),
         );
 
         true

--- a/contracts/escrow/src/test/cancel_contract.rs
+++ b/contracts/escrow/src/test/cancel_contract.rs
@@ -338,11 +338,8 @@ fn cancellation_emits_correct_event() {
     // Cancel
     assert!(client.cancel_contract(&contract_id, &client_addr));
 
-    // Event was emitted successfully (verified by successful cancellation)
-    // The event structure is:
-    // Topics: ("contract_cancelled", contract_id)
-    // Data: (caller, status, timestamp)
-    // This can be verified in test snapshots
+    let events = env.events().all();
+    assert!(!events.is_empty(), "cancel_contract must emit an event");
 }
 
 /// Cancellation is idempotent (consistent error on multiple attempts).

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -134,3 +134,31 @@ The escrow regression suite is split by concern:
 - `governance.rs`: admin and parameter persistence
 - `pause_controls.rs` and `emergency_controls.rs`: operational safety controls
 - `performance.rs`: resource regression ceilings
+
+## Deterministic Lifecycle Events (v1)
+
+Lifecycle operations now emit a standardized event shape to simplify indexing and alerting.
+
+- Topic tuple: `("escrow", "v1", operation, contract_id)`
+- Data tuple: `(status, amount, milestone_index, actor, timestamp)`
+
+Operation values:
+
+- `create`
+- `deposit`
+- `approve`
+- `release`
+- `cancel`
+
+Schema notes:
+
+- `status`: post-operation `ContractStatus`
+- `amount`: operation amount (or `0` when not applicable)
+- `milestone_index`: milestone index (or `0` when not applicable)
+- `actor`: `Some(Address)` when a caller identity is relevant, otherwise `None`
+- `timestamp`: ledger timestamp at emission
+
+Backwards compatibility:
+
+- Previous ad-hoc topics such as `("contract_cancelled", contract_id)` are replaced by the v1 lifecycle schema.
+- Indexers should migrate to the new topic/data tuples for deterministic parsing.

--- a/docs/escrow/contract.md
+++ b/docs/escrow/contract.md
@@ -59,7 +59,7 @@ released_amount: i128 – total amount released to freelancer
 
 ### cancel_contract(env, contract_id, caller) -> bool
 - Cancels an escrow contract under strict authorization and state constraints.
-- Emits `contract_cancelled` event for indexer consumption.
+- Emits deterministic lifecycle event payload for indexer consumption.
 
 **Authorization Rules:**
 - Created state: Client or Freelancer can cancel
@@ -77,9 +77,9 @@ released_amount: i128 – total amount released to freelancer
 - Cancelled → Cancelled ✗ (idempotent error)
 
 **Event Emission:**
-Emits `contract_cancelled` event with:
-- Topics: `("contract_cancelled", contract_id)`
-- Data: `(caller: Address, status: ContractStatus, timestamp: u64)`
+Emits lifecycle event with:
+- Topics: `("escrow", "v1", "cancel", contract_id)`
+- Data: `(status: ContractStatus, amount: i128, milestone_index: u32, actor: Option<Address>, timestamp: u64)`
 
 **Security Guarantees:**
 - Cryptographic authorization required (caller.require_auth())
@@ -138,3 +138,22 @@ Tests include:
 - Milestone release
 - Invalid deposit handling
 - Hello-world function check
+
+## Deterministic Event Schema
+
+The escrow lifecycle uses a shared event schema for deterministic indexing:
+
+- Topic tuple: `("escrow", "v1", operation, contract_id)`
+- Data tuple: `(status, amount, milestone_index, actor, timestamp)`
+
+Lifecycle operations covered:
+
+- `create_contract` -> operation `create`
+- `deposit_funds` -> operation `deposit`
+- `approve_milestone` -> operation `approve`
+- `release_milestone` -> operation `release`
+- `cancel_contract` -> operation `cancel`
+
+Breaking change note:
+
+- Consumers listening to legacy cancellation topic `contract_cancelled` must migrate to the v1 lifecycle event topic.


### PR DESCRIPTION
## Summary
- add a shared deterministic v1 lifecycle event helper in the escrow contract
- standardize event emission across create/deposit/approve/release/cancel operations
- document explicit event topic and payload schema in escrow docs, including legacy migration note

## Test plan
- [ ] cargo build
- [ ] cargo test -p escrow

> Note: Rust toolchain was unavailable in the execution environment, so build/tests could not be run there.

## Backward compatibility
- Existing cancellation event consumers using `contract_cancelled` must migrate to the new `("escrow", "v1", "cancel", contract_id)` topic tuple.

Closes #259