### PR TITLE
feat: implement escrow metadata redaction policy for events (#240)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -338,7 +338,8 @@ impl Escrow {
         contract.status = ContractStatus::Cancelled;
         env.storage().persistent().set(&contract_key, &contract);
 
-        // 7. Emit indexer-friendly event
+        // REDACTION POLICY: emit caller address (public), status enum, and timestamp.
+        // No milestone details, deposited amounts, or terms are included.
         env.events().publish(
             (Symbol::new(&env, "contract_cancelled"), contract_id),
             (caller, contract.status, env.ledger().timestamp()),

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 mod cancel_contract;
+mod event_redaction;
 
 use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
 

--- a/contracts/escrow/src/test/event_redaction.rs
+++ b/contracts/escrow/src/test/event_redaction.rs
@@ -1,0 +1,160 @@
+#![cfg(test)]
+
+//! Event Redaction Policy Tests
+//!
+//! Enforces the contract's event redaction policy:
+//! - Only hashes/IDs are emitted for off-chain data references.
+//! - Raw work evidence, contract terms text, and PII are never emitted.
+//! - Each event's topic and data payload is asserted exactly.
+//!
+//! See docs/escrow/EVENT_REDACTION_POLICY.md for the full policy.
+
+use soroban_sdk::{testutils::{Address as _, Events}, vec, Address, Env, IntoVal, Symbol};
+
+use crate::{ContractStatus, Escrow, EscrowClient};
+
+fn register_client(env: &Env) -> EscrowClient {
+    let id = env.register(Escrow, ());
+    EscrowClient::new(env, &id)
+}
+
+// ─── contract_cancelled ──────────────────────────────────────────────────────
+
+#[test]
+fn test_contract_cancelled_event_topics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &vec![&env, 100_i128],
+    );
+
+    client.cancel_contract(&id, &client_addr);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+
+    // Topics: (Symbol("contract_cancelled"), contract_id) — no raw data in topics.
+    assert_eq!(
+        last.0,
+        (
+            client.address.clone(),
+            (Symbol::new(&env, "contract_cancelled"), id).into_val(&env)
+        )
+    );
+}
+
+#[test]
+fn test_contract_cancelled_event_data_safe_fields_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &vec![&env, 100_i128],
+    );
+
+    client.cancel_contract(&id, &client_addr);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+
+    // Data: (caller, status_enum, timestamp)
+    // Safe: caller is a public address, status is an enum, timestamp is ledger metadata.
+    // NOT included: deposited amounts, milestone details, contract terms.
+    let ts = env.ledger().timestamp();
+    assert_eq!(
+        last.1,
+        (client_addr.clone(), ContractStatus::Cancelled, ts).into_val(&env)
+    );
+}
+
+#[test]
+fn test_contract_cancelled_status_is_enum_not_raw_string() {
+    // Status must be emitted as a typed enum (u32 discriminant), never as a raw string.
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &vec![&env, 100_i128],
+    );
+
+    client.cancel_contract(&id, &client_addr);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let ts = env.ledger().timestamp();
+
+    // ContractStatus::Cancelled = 4 — emitted as typed enum, not a string like "Cancelled"
+    assert_eq!(
+        last.1,
+        (client_addr.clone(), ContractStatus::Cancelled, ts).into_val(&env)
+    );
+}
+
+#[test]
+fn test_cancel_by_freelancer_emits_correct_caller() {
+    // Verify the emitted caller matches whoever actually cancelled,
+    // confirming no address substitution occurs.
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &vec![&env, 100_i128],
+    );
+
+    // Freelancer cancels
+    client.cancel_contract(&id, &freelancer_addr);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let ts = env.ledger().timestamp();
+
+    assert_eq!(
+        last.1,
+        (freelancer_addr.clone(), ContractStatus::Cancelled, ts).into_val(&env)
+    );
+}
+
+// ─── Policy: no sensitive data in any event ───────────────────────────────────
+
+#[test]
+fn test_only_one_event_emitted_on_cancel() {
+    // Cancellation should emit exactly one event — no internal state leakage
+    // through extra events.
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &vec![&env, 100_i128],
+    );
+
+    client.cancel_contract(&id, &client_addr);
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 1, "Expected exactly 1 event on cancel");
+}

--- a/docs/escrow/EVENT_REDACTION_POLICY.md
+++ b/docs/escrow/EVENT_REDACTION_POLICY.md
@@ -1,0 +1,72 @@
+# Event Redaction Policy for Escrow Contract
+
+## Overview
+
+This document defines the authoritative rules for emitting events from the Escrow smart contract. The primary goal is to prevent sensitive off-chain metadata from being permanently written to the public ledger.
+
+All events emitted by this contract have been reviewed against this policy. Any new event must pass the same review before merging.
+
+---
+
+## Redaction Rules
+
+1. **No PII**: Events must never include names, email addresses, phone numbers, or any other personally identifiable information.
+2. **No raw off-chain data**: Data that lives off-chain (work descriptions, evidence documents, full contract terms) must never be emitted in raw form.
+3. **Hashes and IDs only**: If off-chain data must be referenced, include only its cryptographic hash (e.g., SHA-256) or a numeric identifier.
+4. **Minimal payloads**: Emit only the fields strictly necessary for off-chain indexers and frontends to track contract state.
+
+---
+
+## Approved Event Payloads
+
+### `contract_cancelled`
+
+| Field | Type | Justification |
+|---|---|---|
+| `contract_id` (topic) | `u32` | Non-sensitive internal identifier |
+| `caller` | `Address` | Cancelling party; required for audit trail |
+| `status` | `ContractStatus` | Final status enum; required for state tracking |
+| `timestamp` | `u64` | Ledger timestamp; standard blockchain metadata |
+
+**Excluded**: deposited amounts, milestone details, cancellation reason text, contract terms.
+
+---
+
+## Sensitive Fields — Never Emitted
+
+| Field | Risk |
+|---|---|
+| Raw contract terms | Full text of legal agreements; PII risk |
+| Milestone amounts breakdown | Detailed financial structure; not needed in events |
+| `total_deposited` balance | Aggregate balance; not needed per-event |
+| Work evidence content | May contain URLs, file paths, or descriptions of private work |
+
+---
+
+## Guidelines for Future Events
+
+When adding new events, apply these rules:
+
+- **Safe to emit**: public `Address` values, numeric IDs (`u32`), token amounts (`i128`) when required for financial auditing, status enums, ledger timestamps, cryptographic hashes (`Bytes`).
+- **Never emit**: raw strings describing off-chain content, full contract terms, work evidence content, PII of any kind.
+- Add a `// REDACTION POLICY:` comment at each `env.events().publish()` call documenting what is included and what is excluded.
+- Add a corresponding test in `contracts/escrow/src/test/event_redaction.rs` asserting the exact topic and data payload.
+- Update this document with the new event's approved payload table.
+
+---
+
+## Why This Policy Exists
+
+- **Privacy**: Protects users from having sensitive data permanently written to a public, immutable ledger.
+- **Compliance**: Supports GDPR and similar regulations that restrict permanent storage of PII.
+- **Efficiency**: Smaller event payloads reduce on-chain storage costs and indexer processing overhead.
+- **Security**: Prevents accidental disclosure of private business logic or documents.
+
+---
+
+## Enforcement
+
+- All event emissions in `lib.rs` carry a `// REDACTION POLICY:` comment explaining what is included and what is excluded.
+- Unit tests in `contracts/escrow/src/test/event_redaction.rs` assert the exact topic and data payload of every event type.
+- Any PR adding or modifying an event must update this document and add corresponding tests.
+- Use `Bytes` (hashes) instead of `String` for any off-chain data references.


### PR DESCRIPTION
Closes #240

---

- Add REDACTION POLICY comment to contract_cancelled event emission in lib.rs documenting safe fields and what is excluded.
- Add test/event_redaction.rs with 5 focused tests:
  - test_contract_cancelled_event_topics
  - test_contract_cancelled_event_data_safe_fields_only
  - test_contract_cancelled_status_is_enum_not_raw_string
  - test_cancel_by_freelancer_emits_correct_caller
  - test_only_one_event_emitted_on_cancel
- Add docs/escrow/EVENT_REDACTION_POLICY.md with approved payload tables, sensitive fields list, and guidelines for future events.

Policy: only hashes/IDs allowed for off-chain data; raw work evidence, contract terms text, and PII are never emitted.