### PR TITLE
add get_average_rating accessor

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -711,6 +711,27 @@ impl Escrow {
             .get(&DataKey::Reputation(freelancer))
     }
 
+    /// Returns the freelancer's average reputation rating, scaled by 100.
+    ///
+    /// The return value uses two-decimal fixed-point precision, so `450`
+    /// represents `4.50`. Returns `None` when `completed_contracts == 0`.
+    pub fn get_average_rating(env: Env, freelancer: Address) -> Option<i128> {
+        let record: ReputationRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Reputation(freelancer.clone()))
+            .unwrap_or_default();
+        if record.completed_contracts == 0 {
+            return None;
+        }
+        let numerator = record
+            .total_rating
+            .checked_mul(100)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+        let denominator = i128::from(record.completed_contracts);
+        Some(numerator / denominator)
+    }
+
     pub fn get_pending_reputation_credits(env: Env, freelancer: Address) -> u32 {
         env.storage()
             .persistent()

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -8,6 +8,7 @@ use crate::{Escrow, EscrowClient, EscrowError};
 
 mod emergency_controls;
 mod pause_controls;
+mod reputation;
 
 // ─── Shared constants ─────────────────────────────────────────────────────────
 

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -1,0 +1,76 @@
+use super::{create_contract, default_milestones, generated_participants, register_client};
+use crate::types::DepositMode;
+use soroban_sdk::Env;
+
+#[test]
+fn average_rating_returns_none_when_no_completed_contracts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (_client_addr, freelancer_addr) = generated_participants(&env);
+    assert_eq!(client.get_average_rating(&freelancer_addr), None);
+}
+
+#[test]
+fn average_rating_returns_scaled_value_for_completed_contracts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (client_addr, freelancer_addr) = generated_participants(&env);
+    let milestones = default_milestones(&env);
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &milestones,
+        &DepositMode::ExactTotal,
+    );
+    assert!(client.deposit_funds(&contract_id, &super::total_milestone_amount()));
+    assert!(client.release_milestone(&contract_id, &0));
+    assert!(client.release_milestone(&contract_id, &1));
+    assert!(client.release_milestone(&contract_id, &2));
+    assert!(client.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5));
+
+    let average = client.get_average_rating(&freelancer_addr);
+    assert_eq!(average, Some(500));
+}
+
+#[test]
+fn average_rating_aggregates_across_multiple_completed_contracts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (client_addr, freelancer_addr) = generated_participants(&env);
+    let milestones = default_milestones(&env);
+
+    let first_contract = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &milestones,
+        &DepositMode::ExactTotal,
+    );
+    assert!(client.deposit_funds(&first_contract, &super::total_milestone_amount()));
+    assert!(client.release_milestone(&first_contract, &0));
+    assert!(client.release_milestone(&first_contract, &1));
+    assert!(client.release_milestone(&first_contract, &2));
+    assert!(client.issue_reputation(&first_contract, &client_addr, &freelancer_addr, &5));
+
+    let second_contract = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &milestones,
+        &DepositMode::ExactTotal,
+    );
+    assert!(client.deposit_funds(&second_contract, &super::total_milestone_amount()));
+    assert!(client.release_milestone(&second_contract, &0));
+    assert!(client.release_milestone(&second_contract, &1));
+    assert!(client.release_milestone(&second_contract, &2));
+    assert!(client.issue_reputation(&second_contract, &client_addr, &freelancer_addr, &4));
+
+    let reputation = client.get_reputation(&freelancer_addr).unwrap();
+    assert_eq!(reputation.completed_contracts, 2);
+    assert_eq!(reputation.total_rating, 9);
+    assert_eq!(client.get_average_rating(&freelancer_addr), Some(450));
+}

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -233,6 +233,7 @@ Core escrow endpoints:
 - `issue_reputation(contract_id, rating) -> bool`
 - `get_contract(contract_id) -> EscrowContractData`
 - `get_reputation(freelancer) -> Option<ReputationRecord>`
+- `get_average_rating(freelancer) -> Option<i128>`
 - `get_pending_reputation_credits(freelancer) -> u32`
 
 Operational controls:

--- a/docs/escrow/REPUTATION.md
+++ b/docs/escrow/REPUTATION.md
@@ -26,6 +26,14 @@ Every successful reputation update emits a `rated` event containing:
 
 Ratings are persisted as `ReputationEntry` structs in the contract's persistent storage, mapping `DataKey::Reputation(contract_id, freelancer_address)` to the entry. This ensures an immutable audit trail of individual ratings alongside aggregate scores in `ReputationRecord`.
 
+## Average Rating Accessor
+
+The contract exposes `get_average_rating(freelancer) -> Option<i128>` as a read-only helper for consumer convenience. The returned integer is scaled by 100, so `450` represents an average rating of `4.50`.
+
+- Returns `None` when the freelancer has no completed contracts.
+- Returns `Some(value)` when `completed_contracts > 0`.
+- The result is computed as `(total_rating * 100) / completed_contracts`.
+
 ## Security Assumptions
 
 - **Access Control:** `issue_reputation` requires the client's authentication.


### PR DESCRIPTION
Close #339 

## Pull Request Summary

### Title
`feat(escrow): add get_average_rating accessor`

### Description
This PR adds a read-only average reputation accessor to the TalentTrust Escrow contract and documents its behavior for consumers.

### What Changed
- lib.rs
  - Added `get_average_rating(env: Env, freelancer: Address) -> Option<i128>`
  - Computes average rating as `(total_rating * 100) / completed_contracts`
  - Returns `None` when `completed_contracts == 0`
  - Uses two-decimal fixed-point scaling so `450` represents `4.50`
  - Includes overflow protection with `EscrowError::PotentialOverflow`

- mod.rs
  - Registered new `reputation` test module

- reputation.rs
  - Added tests covering:
    - no completed contracts → `None`
    - single completed contract → `Some(500)`
    - multiple completed contracts → aggregated `Some(450)`

- README.md
  - Documented new public helper: `get_average_rating(freelancer) -> Option<i128)`

- REPUTATION.md
  - Documented average rating semantics, scaling factor, and `None` behavior

### Verification
- `cargo test -p escrow` ✅
- `cargo fmt --all -- --check` ✅
