### PR TITLE
feat(escrow): emit structured deposit and fee events

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -173,6 +173,61 @@ impl Escrow {
         );
     }
 
+    /// Emit a structured deposit event for indexer reconstruction.
+    fn emit_deposit_event(
+        env: &Env,
+        contract_id: u32,
+        amount: i128,
+        total_deposited: i128,
+        status: ContractStatus,
+    ) {
+        env.events().publish(
+            (symbol_short!("deposit"), contract_id),
+            (amount, total_deposited, status as u32, env.ledger().timestamp()),
+        );
+    }
+
+    fn protocol_fee_bps(env: &Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::ProtocolFeeBps)
+            .unwrap_or(0)
+    }
+
+    fn emit_protocol_fee_event(
+        env: &Env,
+        contract_id: u32,
+        milestone_index: u32,
+        fee: i128,
+        net: i128,
+    ) {
+        env.events().publish(
+            (symbol_short!("protocol_fee"), contract_id, milestone_index),
+            (fee, net, env.ledger().timestamp()),
+        );
+    }
+
+    fn maybe_emit_protocol_fee_event(
+        env: &Env,
+        contract_id: u32,
+        milestone_index: u32,
+        milestone_amount: i128,
+    ) {
+        let fee_bps = Self::protocol_fee_bps(env);
+        if fee_bps == 0 {
+            return;
+        }
+        let fee = milestone_amount
+            .checked_mul(fee_bps as i128)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow))
+            .checked_add(9999)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow))
+            / 10_000;
+        let net = safe_subtract_amounts(milestone_amount, fee)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+        Self::emit_protocol_fee_event(env, contract_id, milestone_index, fee, net);
+    }
+
     // ─── Accounting invariants ───────────────────────────────────────────
 
     /// Validate the core accounting invariant:
@@ -500,6 +555,14 @@ impl Escrow {
             );
         }
 
+        Self::emit_deposit_event(
+            &env,
+            contract_id,
+            amount,
+            contract.total_deposited,
+            contract.status,
+        );
+
         true
     }
 
@@ -575,6 +638,13 @@ impl Escrow {
         env.events().publish(
             (symbol_short!("released"), contract_id, milestone_index),
             (milestone_amount, env.ledger().timestamp()),
+        );
+
+        Self::maybe_emit_protocol_fee_event(
+            &env,
+            contract_id,
+            milestone_index,
+            milestone_amount,
         );
         true
     }

--- a/contracts/escrow/src/test/flows.rs
+++ b/contracts/escrow/src/test/flows.rs
@@ -1,6 +1,6 @@
 use super::{complete_contract, default_milestones, register_client, total_milestone_amount};
-use crate::EscrowError;
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use crate::{EscrowError, types::DataKey};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
 
 #[test]
 fn multiple_contracts_for_same_freelancer() {
@@ -55,4 +55,35 @@ fn scenario_reputation_invalid_rating_six_fails() {
 
     let result = client.try_issue_reputation(&contract_id, &6, &None);
     super::assert_contract_error(result, EscrowError::InvalidRating);
+}
+
+#[test]
+fn deposit_funds_emits_structured_deposit_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &total_milestone_amount()));
+
+    let events = env.events().all();
+    assert!(events.iter().any(|event| event.0 == symbol_short!("deposit")));
+}
+
+#[test]
+fn release_milestone_emits_protocol_fee_event_when_fees_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_, _, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &total_milestone_amount()));
+    env.storage()
+        .persistent()
+        .set(&DataKey::ProtocolFeeBps, &100u32);
+
+    assert!(client.release_milestone(&contract_id, &0));
+
+    let events = env.events().all();
+    assert!(events.iter().any(|event| event.0 == symbol_short!("protocol_fee")));
 }

--- a/docs/escrow/contract.md
+++ b/docs/escrow/contract.md
@@ -94,6 +94,7 @@ ReadinessChecklist {
 - Deposits funds into escrow.
 - Only the client can call this.
 - Updates contract status to Funded after success.
+- Emits a structured deposit event for every successful deposit.
 - Returns true if successful.
 
 ### release_milestone(env, contract_id, token, freelancer, amount) -> bool
@@ -197,8 +198,9 @@ Lifecycle operations covered:
 
 - `create_contract` -> operation `create`
 - `deposit_funds` -> operation `deposit`
+- `release_milestone` -> operation `released`
+- `protocol_fee` -> emitted on milestone release when protocol fees are active
 - `approve_milestone` -> operation `approve`
-- `release_milestone` -> operation `release`
 - `cancel_contract` -> operation `cancel`
 
 Breaking change note:


### PR DESCRIPTION
Closes #336 

Summary

This change adds structured event emission for escrow balance changes in the TalentTrust escrow contract.

### Key updates

- `contracts/escrow/src/lib.rs`
  - Added a dedicated `deposit` event for every successful `deposit_funds` call.
  - Added a `protocol_fee` event emitted on `release_milestone` when protocol fees are active.
  - Ensured every balance-changing operation now emits a reconstructable structured event.

- `contracts/escrow/src/test/flows.rs`
  - Added regression coverage for structured deposit event emission.
  - Added protocol fee event coverage when active fees are configured.

- `docs/escrow/contract.md`
  - Documented the new `deposit` event and updated the deterministic event schema to include the protocol fee event.

## Motivation

Indexers could not reconstruct funding history because `deposit_funds` only emitted an audit event on status changes. This fix aligns deposit event behavior with `create_contract` and release milestone events, and adds a fee-specific event for protocol fee accounting.

## Behavior

- `deposit_funds` emits topic `(symbol_short!("deposit"), contract_id)` with data `(amount, new_total_deposited, new_status, timestamp)`.
- `release_milestone` emits topic `(symbol_short!("protocol_fee"), contract_id, milestone_index)` with data `(fee, net, timestamp)` when `ProtocolFeeBps` is active.
- No additional event is emitted when protocol fees are disabled.

## Testing

Run the following commands locally:

```bash
cargo test -p escrow deposit_funds_emits_structured_deposit_event release_milestone_emits_protocol_fee_event_when_fees_active
cargo test -p escrow
cargo fmt --all -- --check
```

## Notes

- The new event helpers were added while preserving existing audit event behavior.
- Fee calculation uses safe overflow checks and the existing protocol fee rounding approach.
- Documentation was updated to reflect the new structured event schema.
