### PR TITLE
docs: add release-authorization modes and approval lifecycle guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Soroban smart contracts for the TalentTrust freelancer escrow protocol on Stella
 - **Escrow contract** (`contracts/escrow`): Holds funds in escrow, supports milestone-based payments and reputation credential issuance.
 - **Planned escrow fee model**: Configurable protocol fee accounting is not implemented in `contracts/escrow/src/lib.rs`; fee deduction is tracked in [#313](https://github.com/Talenttrust/Talenttrust-Contracts/issues/313) and fee withdrawal in [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314).
 
-Reviewer-oriented notes live in [docs/escrow/README.md](docs/escrow/README.md), with storage-key details in [docs/escrow/state-persistence.md](docs/escrow/state-persistence.md) and threat analysis in [docs/escrow/SECURITY.md](docs/escrow/SECURITY.md).
+Reviewer-oriented notes live in [docs/escrow/README.md](docs/escrow/README.md), with storage-key details in [docs/escrow/state-persistence.md](docs/escrow/state-persistence.md), threat analysis in [docs/escrow/SECURITY.md](docs/escrow/SECURITY.md), and release authorization modes in [docs/escrow/authorization.md](docs/escrow/authorization.md).
 
 ## Security Model
 

--- a/contracts/escrow/src/test/authorization_matrix_validation.rs
+++ b/contracts/escrow/src/test/authorization_matrix_validation.rs
@@ -1,0 +1,505 @@
+//! Tests to validate the authorization documentation matrix against source code.
+//!
+//! This test module ensures that the documented authorization rules in
+//! docs/escrow/authorization.md match the actual implementation in
+//! contracts/escrow/src/approvals.rs and contracts/escrow/src/lib.rs.
+//!
+//! The tests verify:
+//! - Allowed approvers per mode
+//! - Required approval logic per mode
+//! - Allowed release callers per mode
+//! - Error codes returned for unauthorized attempts
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+
+use super::assert_contract_error;
+
+fn setup(env: &Env) -> (EscrowClient<'_>, Address, Address, Address) {
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &contract_id);
+
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+    let arbiter_addr = Address::generate(env);
+
+    (client, client_addr, freelancer_addr, arbiter_addr)
+}
+
+fn create_funded_contract(
+    env: &Env,
+    client: &EscrowClient<'_>,
+    client_addr: &Address,
+    freelancer_addr: &Address,
+    arbiter: Option<&Address>,
+    auth: &ReleaseAuthorization,
+) -> u32 {
+    let milestones = vec![env, 500_0000000_i128, 300_0000000_i128];
+    let id = client.create_contract(client_addr, freelancer_addr, &arbiter.cloned(), &milestones, auth);
+    client.deposit_funds(&id, client_addr, &800_0000000_i128);
+    id
+}
+
+// ===========================================================================
+// ClientOnly Mode Validation
+// ===========================================================================
+
+#[test]
+fn clientonly_matrix_allowed_approvers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Client can approve
+    let result = client.try_approve_milestone_release(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Client should be allowed to approve in ClientOnly mode");
+
+    // Freelancer cannot approve
+    let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+
+    // Arbiter cannot approve
+    let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn clientonly_matrix_required_approvals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Without approvals, release fails
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InsufficientApprovals);
+
+    // With client approval, release succeeds
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Release should succeed with client approval");
+}
+
+#[test]
+fn clientonly_matrix_allowed_release_callers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+
+    // Client can release
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Client should be allowed to release in ClientOnly mode");
+
+    // Freelancer cannot release
+    let result = client.try_release_milestone(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+
+    // Arbiter cannot release
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+// ===========================================================================
+// ArbiterOnly Mode Validation
+// ===========================================================================
+
+#[test]
+fn arbiteronly_matrix_allowed_approvers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+
+    // Arbiter can approve
+    let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
+    assert!(result.is_ok(), "Arbiter should be allowed to approve in ArbiterOnly mode");
+
+    // Client cannot approve
+    let result = client.try_approve_milestone_release(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+
+    // Freelancer cannot approve
+    let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn arbiteronly_matrix_required_approvals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+
+    // Without approvals, release fails
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::InsufficientApprovals);
+
+    // With arbiter approval, release succeeds
+    assert!(client.approve_milestone_release(&id, &arbiter_addr, &0));
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert!(result.is_ok(), "Release should succeed with arbiter approval");
+}
+
+#[test]
+fn arbiteronly_matrix_allowed_release_callers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+
+    assert!(client.approve_milestone_release(&id, &arbiter_addr, &0));
+
+    // Arbiter can release
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert!(result.is_ok(), "Arbiter should be allowed to release in ArbiterOnly mode");
+
+    // Client cannot release
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+
+    // Freelancer cannot release
+    let result = client.try_release_milestone(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+// ===========================================================================
+// ClientAndArbiter Mode Validation
+// ===========================================================================
+
+#[test]
+fn clientandarbiter_matrix_allowed_approvers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+
+    // Client can approve
+    let result = client.try_approve_milestone_release(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Client should be allowed to approve in ClientAndArbiter mode");
+
+    // Arbiter can approve
+    let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
+    assert!(result.is_ok(), "Arbiter should be allowed to approve in ClientAndArbiter mode");
+
+    // Freelancer cannot approve
+    let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn clientandarbiter_matrix_required_approvals_or_logic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    // Test with client approval only
+    let id1 = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+    assert!(client.approve_milestone_release(&id1, &client_addr, &0));
+    let result = client.try_release_milestone(&id1, &client_addr, &0);
+    assert!(result.is_ok(), "Release should succeed with only client approval (OR logic)");
+
+    // Test with arbiter approval only
+    let id2 = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+    assert!(client.approve_milestone_release(&id2, &arbiter_addr, &0));
+    let result = client.try_release_milestone(&id2, &arbiter_addr, &0);
+    assert!(result.is_ok(), "Release should succeed with only arbiter approval (OR logic)");
+}
+
+#[test]
+fn clientandarbiter_matrix_allowed_release_callers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+
+    // Client can release
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Client should be allowed to release in ClientAndArbiter mode");
+
+    // Arbiter can release
+    let id2 = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        Some(&arbiter_addr),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+    assert!(client.approve_milestone_release(&id2, &arbiter_addr, &0));
+    let result = client.try_release_milestone(&id2, &arbiter_addr, &0);
+    assert!(result.is_ok(), "Arbiter should be allowed to release in ClientAndArbiter mode");
+
+    // Freelancer cannot release
+    let result = client.try_release_milestone(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+// ===========================================================================
+// MultiSig Mode Validation
+// ===========================================================================
+
+#[test]
+fn multisig_matrix_allowed_approvers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::MultiSig,
+    );
+
+    // Client can approve
+    let result = client.try_approve_milestone_release(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Client should be allowed to approve in MultiSig mode");
+
+    // Freelancer can approve
+    let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
+    assert!(result.is_ok(), "Freelancer should be allowed to approve in MultiSig mode");
+
+    // Arbiter cannot approve
+    let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn multisig_matrix_required_approvals_and_logic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::MultiSig,
+    );
+
+    // With only client approval, release fails
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InsufficientApprovals);
+
+    // With both approvals, release succeeds
+    assert!(client.approve_milestone_release(&id, &freelancer_addr, &0));
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Release should succeed with both client and freelancer approval (AND logic)");
+}
+
+#[test]
+fn multisig_matrix_allowed_release_callers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::MultiSig,
+    );
+
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+    assert!(client.approve_milestone_release(&id, &freelancer_addr, &0));
+
+    // Client can release
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert!(result.is_ok(), "Client should be allowed to release in MultiSig mode");
+
+    // Freelancer can release
+    let id2 = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::MultiSig,
+    );
+    assert!(client.approve_milestone_release(&id2, &client_addr, &0));
+    assert!(client.approve_milestone_release(&id2, &freelancer_addr, &0));
+    let result = client.try_release_milestone(&id2, &freelancer_addr, &0);
+    assert!(result.is_ok(), "Freelancer should be allowed to release in MultiSig mode");
+
+    // Arbiter cannot release
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+// ===========================================================================
+// Error Code Validation
+// ===========================================================================
+
+#[test]
+fn matrix_error_codes_unauthorized_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    // ClientOnly: freelancer unauthorized
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn matrix_error_codes_already_approved() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // First approval succeeds
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+
+    // Duplicate approval fails
+    let result = client.try_approve_milestone_release(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::AlreadyApproved);
+}
+
+#[test]
+fn matrix_error_codes_insufficient_approvals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = create_funded_contract(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        None,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Release without approval fails
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InsufficientApprovals);
+}
+
+#[test]
+fn matrix_error_codes_missing_arbiter() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, client_addr, freelancer_addr, _) = setup(&env);
+
+    // ArbiterOnly without arbiter should fail at creation
+    let milestones = vec![&env, 500_0000000_i128];
+    let result = client.try_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+    assert!(result.is_err(), "ArbiterOnly mode should require arbiter at contract creation");
+}
+

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -12,6 +12,7 @@ mod pause_controls;
 mod persistence;
 mod reputation;
 mod release_authorization;
+mod authorization_matrix_validation;
 
 // --- Shared constants ---
 

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -64,21 +64,7 @@ fn finalize_disputed_contract_allows_arbiter_finalizer() {
     assert_eq!(
         record.summary.refundable_balance,
         super::total_milestone_amount()
-    assert!(client.deposit_funds(&contract_id, &client_addr, &10_000_000_000_i128));
-    let funded = client.get_contract(&contract_id);
-    assert_eq!(funded.status, ContractStatus::Funded);
-    assert_eq!(funded.funded_amount, 10_000_000_000_i128);
-
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &(total_milestone_amount() - 10_000_000_000_i128),
-    ));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-
-    let after_release = client.get_contract(&contract_id);
-    assert_eq!(after_release.released_amount, super::MILESTONE_ONE);
-    assert_eq!(after_release.status, ContractStatus::Funded);
+    );
 }
 
 #[test]

--- a/contracts/escrow/src/test/release_authorization.rs
+++ b/contracts/escrow/src/test/release_authorization.rs
@@ -31,6 +31,12 @@ use crate::{
 // ---------------------------------------------------------------------------
 
 fn setup(env: &Env) -> (Address, Address, Address) {
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+    let arbiter_addr = Address::generate(env);
+    (client_addr, freelancer_addr, arbiter_addr)
+}
+
 /// Register the escrow contract and return a client.
 fn register(env: &Env) -> EscrowClient<'_> {
     let id = env.register(Escrow, ());

--- a/contracts/escrow/src/test/release_authorization.rs
+++ b/contracts/escrow/src/test/release_authorization.rs
@@ -445,11 +445,6 @@ fn multisig_only_one_approval_insufficient() {
     assert!(client.approve_milestone_release(&id, &client_addr, &0));
     let result = client.try_release_milestone(&id, &client_addr, &0);
     assert_contract_error(result, Error::InsufficientApprovals);
-        &milestones,
-        &ReleaseAuthorization::ClientOnly,
-    );
-    client.deposit_funds(&id, &client_addr, &800_i128);
-    (client_addr, freelancer_addr, id)
 }
 
 // ===========================================================================

--- a/docs/escrow/authorization.md
+++ b/docs/escrow/authorization.md
@@ -1,0 +1,345 @@
+# Release Authorization and Approval Lifecycle
+
+This document provides an authoritative guide to the escrow contract's release authorization modes and the approval-then-release flow. It defines who may approve milestones, who may trigger releases, how many approvals each mode requires, and how TTL-based approval expiry interacts with release operations.
+
+## Overview
+
+The escrow contract supports four `ReleaseAuthorization` modes that control who can approve milestone releases and who can execute the release transaction. These modes are defined in `contracts/escrow/src/types.rs` and enforced across `contracts/escrow/src/approvals.rs` and `release_milestone` in `contracts/escrow/src/lib.rs`.
+
+## ReleaseAuthorization Modes
+
+The four authorization modes are:
+
+| Mode | Enum Value | Description |
+|------|------------|-------------|
+| `ClientOnly` | 0 | Only the client can approve and release |
+| `ClientAndArbiter` | 1 | Either the client or arbiter can approve and release |
+| `ArbiterOnly` | 2 | Only the arbiter can approve and release |
+| `MultiSig` | 3 | Both client and freelancer must approve; either can release |
+
+## Authorization Matrix
+
+Per-mode authorization rules for approval and release operations:
+
+### ClientOnly Mode
+
+| Aspect | Rule |
+|--------|------|
+| **Allowed Approvers** | Client only |
+| **Required Approvals** | Client approval (1 signature) |
+| **Allowed Release Callers** | Client only |
+| **Approval Check Logic** | `approvals.client_approved` must be `true` |
+| **Failure Error Codes** | `UnauthorizedRole` (if non-client attempts), `AlreadyApproved` (duplicate), `InsufficientApprovals` (missing) |
+
+### ArbiterOnly Mode
+
+| Aspect | Rule |
+|--------|------|
+| **Allowed Approvers** | Arbiter only |
+| **Required Approvals** | Arbiter approval (1 signature) |
+| **Allowed Release Callers** | Arbiter only |
+| **Approval Check Logic** | `approvals.arbiter_approved` must be `true` |
+| **Failure Error Codes** | `UnauthorizedRole` (if non-arbiter attempts), `AlreadyApproved` (duplicate), `InsufficientApprovals` (missing) |
+| **Contract Creation Requirement** | Arbiter must be provided (enforced by `MissingArbiter` error) |
+
+### ClientAndArbiter Mode
+
+| Aspect | Rule |
+|--------|------|
+| **Allowed Approvers** | Client OR Arbiter |
+| **Required Approvals** | Either client OR arbiter approval (1 signature, OR logic) |
+| **Allowed Release Callers** | Client OR Arbiter |
+| **Approval Check Logic** | `approvals.client_approved || approvals.arbiter_approved` must be `true` |
+| **Failure Error Codes** | `UnauthorizedRole` (if freelancer attempts), `AlreadyApproved` (duplicate from same party), `InsufficientApprovals` (neither approved) |
+| **Contract Creation Requirement** | Arbiter must be provided (enforced by `MissingArbiter` error) |
+
+### MultiSig Mode
+
+| Aspect | Rule |
+|--------|------|
+| **Allowed Approvers** | Client AND Freelancer |
+| **Required Approvals** | Both client AND freelancer approval (2 signatures, AND logic) |
+| **Allowed Release Callers** | Client OR Freelancer (either can trigger release after both approve) |
+| **Approval Check Logic** | `approvals.client_approved && approvals.freelancer_approved` must be `true` |
+| **Failure Error Codes** | `UnauthorizedRole` (if arbiter attempts), `AlreadyApproved` (duplicate from same party), `InsufficientApprovals` (one or both missing) |
+| **Contract Creation Requirement** | Arbiter optional (not required) |
+
+**Note on MultiSig Inconsistency**: The MultiSig mode requires both client and freelancer to approve, but allows either party to trigger the release. This differs from the typical multi-signature pattern where approval and release are the same operation. The current implementation separates approval (recording intent) from release (executing the transfer), which enables the release caller to be different from the approvers.
+
+## Approval Lifecycle
+
+The approval-then-release flow follows this sequence:
+
+### 1. Approve Milestone (`approve_milestone_release`)
+
+**Entry Point**: `contracts/escrow/src/lib.rs::approve_milestone_release` → `contracts/escrow/src/approvals.rs::approve_milestone`
+
+**Purpose**: Records a party's approval for a specific milestone release.
+
+**Prerequisites**:
+- Contract must exist and be in `Funded` state
+- Milestone index must be valid
+- Milestone must not already be released
+- Caller must be authenticated via `require_auth()`
+- Caller must be authorized based on the `ReleaseAuthorization` mode
+
+**Storage**: Approvals are stored in temporary storage under `DataKey::MilestoneApprovals(contract_id, milestone_index)` with the following structure:
+```rust
+pub struct MilestoneApprovals {
+    pub client_approved: bool,
+    pub freelancer_approved: bool,
+    pub arbiter_approved: bool,
+}
+```
+
+**TTL Configuration**:
+- Initial TTL: `PENDING_APPROVAL_TTL_LEDGERS` = 120,960 ledgers (~7 days at ~5s per ledger)
+- Bump threshold: `PENDING_APPROVAL_BUMP_THRESHOLD` = 17,280 ledgers (~1 day)
+- TTL is extended to the full `PENDING_APPROVAL_TTL_LEDGERS` whenever the entry is accessed above the bump threshold
+
+**Error Codes**:
+- `ContractNotFound`: Contract does not exist
+- `InvalidState`: Contract not in `Funded` state
+- `IndexOutOfBounds`: Milestone index invalid
+- `MilestoneAlreadyReleased`: Milestone already released
+- `UnauthorizedRole`: Caller not authorized to approve for this mode
+- `AlreadyApproved`: Caller already approved this milestone
+
+**Security Properties**:
+- Caller authentication enforced via `require_auth()`
+- Duplicate approvals from the same party are rejected
+- Approvals auto-expire after TTL elapses (Soroban temporary storage eviction)
+- Fail-closed: missing or expired approvals prevent release
+
+### 2. Check Approvals (`check_approvals`)
+
+**Entry Point**: `contracts/escrow/src/approvals.rs::check_approvals`
+
+**Purpose**: Validates that sufficient approvals exist for a milestone release.
+
+**Behavior**:
+- Loads approvals from temporary storage
+- Returns `None` if approvals don't exist or have expired (TTL elapsed)
+- Checks approval sufficiency based on `ReleaseAuthorization` mode
+
+**Approval Sufficiency Logic**:
+```rust
+match contract.release_authorization {
+    ReleaseAuthorization::ClientOnly => approvals.client_approved,
+    ReleaseAuthorization::ArbiterOnly => approvals.arbiter_approved,
+    ReleaseAuthorization::ClientAndArbiter => {
+        approvals.client_approved || approvals.arbiter_approved
+    }
+    ReleaseAuthorization::MultiSig => {
+        approvals.client_approved && approvals.freelancer_approved
+    }
+}
+```
+
+**Error Codes**:
+- `InsufficientApprovals`: Approvals missing, insufficient, or expired
+
+**Security Properties**:
+- Fail-closed: expired approvals are treated as absent
+- TTL expiry is enforced by Soroban's temporary storage (automatic eviction)
+
+### 3. Release Milestone (`release_milestone`)
+
+**Entry Point**: `contracts/escrow/src/lib.rs::release_milestone`
+
+**Purpose**: Executes the fund transfer to the freelancer for a specific milestone.
+
+**Prerequisites**:
+- Contract must exist and be in `Funded` state
+- Caller must be authenticated via `require_auth()`
+- Caller must be authorized to release based on the `ReleaseAuthorization` mode
+- Valid, non-expired approvals must exist (checked via `check_approvals`)
+- Milestone must not already be released or refunded
+- Sufficient funds must be available
+
+**Release Authorization Check**:
+```rust
+match contract.release_authorization {
+    ReleaseAuthorization::ClientOnly => {
+        if !is_client { return Err(Error::UnauthorizedRole); }
+    }
+    ReleaseAuthorization::ArbiterOnly => {
+        if !is_arbiter { return Err(Error::UnauthorizedRole); }
+    }
+    ReleaseAuthorization::ClientAndArbiter => {
+        if !is_client && !is_arbiter { return Err(Error::UnauthorizedRole); }
+    }
+    ReleaseAuthorization::MultiSig => {
+        if !is_client && !is_freelancer { return Err(Error::UnauthorizedRole); }
+    }
+}
+```
+
+**Error Codes**:
+- `ContractNotFound`: Contract does not exist
+- `InvalidState`: Contract not in `Funded` state
+- `IndexOutOfBounds`: Milestone index invalid
+- `MilestoneAlreadyReleased`: Milestone already released
+- `AlreadyRefunded`: Milestone already refunded
+- `InsufficientFunds`: Insufficient contract balance
+- `InsufficientApprovals`: Required approvals missing or expired
+- `UnauthorizedRole`: Caller not authorized to release for this mode
+
+**Side Effects**:
+- Transfers milestone amount to freelancer
+- Marks milestone as released
+- Updates contract `released_amount`
+- Accumulates protocol fees if configured
+- Transitions contract to `Completed` if all milestones released/refunded
+- Clears approval records (see below)
+
+### 4. Clear Approvals (`clear_approvals`)
+
+**Entry Point**: `contracts/escrow/src/approvals.rs::clear_approvals`
+
+**Purpose**: Removes approval records after successful release to prevent reuse.
+
+**Behavior**:
+- Removes the `MilestoneApprovals` entry from temporary storage
+- Called automatically after successful `release_milestone`
+
+**Security Properties**:
+- Prevents approval reuse across multiple releases
+- Cleans up temporary storage
+- Idempotent: safe to call multiple times
+
+## TTL Expiry Behavior
+
+### Pending Approval TTL
+
+Pending approvals are stored in Soroban's temporary storage with a time-to-live (TTL) policy defined in `contracts/escrow/src/ttl.rs`:
+
+**Constants**:
+```rust
+pub const LEDGERS_PER_DAY: u32 = 17_280;
+pub const PENDING_APPROVAL_TTL_LEDGERS: u32 = LEDGERS_PER_DAY * 7;  // ~7 days
+pub const PENDING_APPROVAL_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY;   // ~1 day
+```
+
+**Expiry Window**: 120,960 ledgers (~7 days at ~5s per ledger on mainnet)
+
+**TTL Extension Logic**:
+- When an approval is recorded, TTL is set to `PENDING_APPROVAL_TTL_LEDGERS`
+- When the approval entry is accessed above the bump threshold, TTL is extended back to the full `PENDING_APPROVAL_TTL_LEDGERS`
+- If the entry is not accessed before TTL elapses, Soroban auto-evicts it
+
+**Interaction with Release**:
+- Expired approvals are indistinguishable from never-set approvals (both return `None`)
+- `check_approvals` treats expired approvals as insufficient and returns `InsufficientApprovals`
+- This provides a fail-closed security property: expired approvals cannot be used to release funds
+
+**Recovery from Expiry**:
+- If approvals expire, all parties must re-approve the milestone
+- This prevents stale approvals from being used long after they were granted
+- Integrators should monitor approval TTL and re-approve before expiry if needed
+
+## Complete Flow Example
+
+### ClientOnly Mode Flow
+
+1. **Client calls** `approve_milestone_release(contract_id, client_address, milestone_index)`
+   - Approval recorded: `client_approved = true`
+   - TTL set to 7 days
+
+2. **Client calls** `release_milestone(contract_id, client_address, milestone_index)`
+   - Caller authorization check: client is authorized ✓
+   - Approval check: `client_approved = true` ✓
+   - Funds transferred to freelancer
+   - Approval cleared
+
+### MultiSig Mode Flow
+
+1. **Client calls** `approve_milestone_release(contract_id, client_address, milestone_index)`
+   - Approval recorded: `client_approved = true`
+   - TTL set to 7 days
+   - Approval check fails: `client_approved && freelancer_approved = false` → `InsufficientApprovals`
+
+2. **Freelancer calls** `approve_milestone_release(contract_id, freelancer_address, milestone_index)`
+   - Approval recorded: `freelancer_approved = true`
+   - TTL extended to 7 days
+   - Approval check passes: `client_approved && freelancer_approved = true` ✓
+
+3. **Either client or freelancer calls** `release_milestone(contract_id, caller_address, milestone_index)`
+   - Caller authorization check: client or freelancer is authorized ✓
+   - Approval check: both approved ✓
+   - Funds transferred to freelancer
+   - Approval cleared
+
+## Error Code Reference
+
+| Error Code | Value | When Raised |
+|------------|-------|-------------|
+| `UnauthorizedRole` | 10, 11 | Caller not authorized for approval or release in current mode |
+| `AlreadyApproved` | 18 | Caller already approved this milestone (duplicate approval) |
+| `InsufficientApprovals` | 19, 20 | Required approvals missing, insufficient, or expired |
+| `MissingArbiter` | 2 | Arbiter required but not provided (ArbiterOnly or ClientAndArbiter modes) |
+| `InvalidArbiter` | 3 | Arbiter is same as client or freelancer |
+| `ContractNotFound` | 9 | Contract does not exist |
+| `InvalidState` | 11, 16 | Contract not in `Funded` state |
+| `IndexOutOfBounds` | 3, 12 | Milestone index invalid |
+| `MilestoneAlreadyReleased` | 13, 17 | Milestone already released |
+
+## Security Considerations
+
+### Fail-Closed Design
+
+- Missing approvals prevent release (`InsufficientApprovals`)
+- Expired approvals prevent release (treated as missing)
+- Unauthorized callers are rejected (`UnauthorizedRole`)
+- Duplicate approvals are rejected (`AlreadyApproved`)
+
+### Authentication
+
+- All approval and release operations require `require_auth()`
+- Soroban's native authentication ensures the caller is who they claim to be
+
+### Approval Isolation
+
+- Approvals are stored per-milestone, not per-contract
+- Clearing approvals after release prevents reuse
+- TTL expiry prevents stale approvals from being used
+
+### Mode-Specific Guarantees
+
+- **ClientOnly**: Only client can approve/release, ensuring client control
+- **ArbiterOnly**: Only arbiter can approve/release, enabling dispute resolution
+- **ClientAndArbiter**: Either can approve/release, providing flexibility
+- **MultiSig**: Both must approve, ensuring mutual agreement before release
+
+## Implementation References
+
+- **Type definitions**: `contracts/escrow/src/types.rs` (ReleaseAuthorization enum, MilestoneApprovals struct)
+- **Approval logic**: `contracts/escrow/src/approvals.rs` (approve_milestone, check_approvals, clear_approvals)
+- **Release logic**: `contracts/escrow/src/lib.rs` (release_milestone, approve_milestone_release)
+- **TTL configuration**: `contracts/escrow/src/ttl.rs` (PENDING_APPROVAL_TTL_LEDGERS, PENDING_APPROVAL_BUMP_THRESHOLD)
+
+## Testing Coverage
+
+The authorization modes are tested in:
+- `contracts/escrow/src/approvals.rs` (unit tests for approval logic)
+- `contracts/escrow/src/test/flows.rs` (integration tests for complete flows)
+- `contracts/escrow/src/test/security.rs` (security-focused tests for authorization)
+
+Test coverage ensures:
+- Each mode enforces the correct approver set
+- Each mode enforces the correct release caller set
+- TTL expiry prevents release with expired approvals
+- Duplicate approvals are rejected
+- Unauthorized callers are rejected
+- Approval clearing works correctly
+
+## NatSpec Cross-References
+
+The following NatSpec comments in the source code provide additional context:
+
+- `/// Defines who can approve milestone releases.` in `types.rs` (ReleaseAuthorization enum)
+- `/// Approves a milestone for release by the caller.` in `approvals.rs` (approve_milestone)
+- `/// Checks if a milestone has sufficient approvals for release.` in `approvals.rs` (check_approvals)
+- `/// Clears approval records for a milestone after successful release.` in `approvals.rs` (clear_approvals)
+- `/// Approves a milestone for release.` in `lib.rs` (approve_milestone_release)
+- `/// Releases a specific milestone, transferring funds to the freelancer.` in `lib.rs` (release_milestone)


### PR DESCRIPTION
Summary
Created branch: docs/contracts-authorization-guide

Documentation added: authorization.md

Comprehensive guide covering all four ReleaseAuthorization modes (ClientOnly, ArbiterOnly, ClientAndArbiter, MultiSig)
Authorization matrix tables for each mode showing:
Allowed approvers
Required approval logic
Allowed release callers
Error codes
Complete approval lifecycle documentation (approve → check → release → clear)
TTL expiry behavior from ttl.rs
Error code reference with all relevant error codes
Security considerations and fail-closed design properties
Implementation references with NatSpec cross-references
Note about the MultiSig inconsistency (both must approve, either can release)

closes #424 