### PR TITLE
refactor: collapse AmountValidationError into canonical EscrowError

### DIFF
--- a/contracts/escrow/src/amount_validation.rs
+++ b/contracts/escrow/src/amount_validation.rs
@@ -17,21 +17,7 @@ pub const MAX_SINGLE_AMOUNT_STROOPS: i128 = 1_000_000_0000000; // 1M tokens
 #[allow(dead_code)] // available for callers; not used internally
 pub const MIN_POSITIVE_AMOUNT: i128 = 1;
 
-#[contracterror]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u32)]
-pub enum AmountValidationError {
-    /// Amount must be positive (greater than 0)
-    NonPositiveAmount = 1000,
-    /// Amount exceeds maximum allowed per operation
-    AmountExceedsMaximum = 1001,
-    /// Amount would cause overflow in calculations
-    PotentialOverflow = 1002,
-    /// Invalid stroop precision (amount must be multiple of 1 stroop)
-    InvalidStroopPrecision = 1003,
-    /// Total amount exceeds contract maximum
-    ExceedsContractMaximum = 1004,
-}
+// Removed the redundant AmountValidationError enum. Errors are now represented by the canonical `Error` enum from `crate::Error`.
 
 /// Validates a single amount for positivity and bounds
 ///
@@ -41,15 +27,16 @@ pub enum AmountValidationError {
 /// # Returns
 /// `Ok(())` if valid, `Err(AmountValidationError)` if invalid
 #[allow(dead_code)] // available for callers; not used by the contract directly
-pub fn validate_single_amount(amount: i128) -> Result<(), AmountValidationError> {
+pub fn validate_single_amount(amount: i128) -> Result<(), crate::EscrowError> {
     // Check positivity
     if amount <= MIN_POSITIVE_AMOUNT - 1 {
-        return Err(AmountValidationError::NonPositiveAmount);
+        return Err(crate::EscrowError::AmountMustBePositive);
     }
 
     // Check maximum bounds
     if amount > MAX_SINGLE_AMOUNT_STROOPS {
-        return Err(AmountValidationError::AmountExceedsMaximum);
+        // No direct canonical error; map to InvalidMilestoneAmount for generic excess amount
+        return Err(crate::EscrowError::InvalidMilestoneAmount);
     }
 
     // Check stroop precision (must be integer, which i128 already guarantees)
@@ -67,7 +54,7 @@ pub fn validate_single_amount(amount: i128) -> Result<(), AmountValidationError>
 /// # Returns
 /// `Ok(total)` with sum of all amounts if valid, `Err(AmountValidationError)` if invalid
 #[allow(dead_code)] // available for callers; not used by the contract directly
-pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, AmountValidationError> {
+pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, crate::EscrowError> {
     let mut total: i128 = 0;
 
     for &amount in amounts.iter() {
@@ -78,7 +65,7 @@ pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, AmountValidationE
         if let Some(new_total) = total.checked_add(amount) {
             total = new_total;
         } else {
-            return Err(AmountValidationError::PotentialOverflow);
+            return Err(crate::EscrowError::PotentialOverflow);
         }
     }
 
@@ -97,9 +84,10 @@ pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, AmountValidationE
 pub fn validate_contract_total(
     total_amount: i128,
     max_contract_total: i128,
-) -> Result<(), AmountValidationError> {
+) -> Result<(), crate::EscrowError> {
     if total_amount > max_contract_total {
-        return Err(AmountValidationError::ExceedsContractMaximum);
+        // Map to InvalidMilestoneAmount for contract total overflow
+        return Err(crate::EscrowError::InvalidMilestoneAmount);
     }
     Ok(())
 }
@@ -116,7 +104,7 @@ pub fn validate_contract_total(
 pub fn validate_milestone_amounts(
     milestone_amounts: &[i128],
     max_contract_total: i128,
-) -> Result<i128, AmountValidationError> {
+) -> Result<i128, crate::EscrowError> {
     // Validate each milestone amount and calculate total
     let total = validate_amount_array(milestone_amounts)?;
 
@@ -140,17 +128,17 @@ pub fn validate_deposit_amount(
     deposit_amount: i128,
     current_deposited: i128,
     max_contract_total: i128,
-) -> Result<(), AmountValidationError> {
+) -> Result<(), crate::EscrowError> {
     // Validate deposit amount itself
     validate_single_amount(deposit_amount)?;
 
     // Check if deposit would exceed contract maximum
     if let Some(new_total) = current_deposited.checked_add(deposit_amount) {
         if new_total > max_contract_total {
-            return Err(AmountValidationError::ExceedsContractMaximum);
+            return Err(crate::EscrowError::InvalidMilestoneAmount);
         }
     } else {
-        return Err(AmountValidationError::PotentialOverflow);
+        return Err(crate::EscrowError::PotentialOverflow);
     }
 
     Ok(())

--- a/contracts/escrow/src/simple_amount_test.rs
+++ b/contracts/escrow/src/simple_amount_test.rs
@@ -7,7 +7,7 @@
 mod tests {
     use crate::amount_validation::{
         safe_add_amounts, safe_subtract_amounts, validate_contract_total, validate_deposit_amount,
-        validate_milestone_amounts, validate_single_amount, AmountValidationError,
+        validate_milestone_amounts, validate_single_amount, EscrowError,
         MAX_SINGLE_AMOUNT_STROOPS, MIN_POSITIVE_AMOUNT,
     };
     use crate::MAX_TOTAL_ESCROW_STROOPS;
@@ -22,15 +22,15 @@ mod tests {
         // Test invalid amounts
         assert_eq!(
             validate_single_amount(0),
-            Err(AmountValidationError::NonPositiveAmount)
+            Err(EscrowError::AmountMustBePositive)
         );
         assert_eq!(
             validate_single_amount(-1),
-            Err(AmountValidationError::NonPositiveAmount)
+            Err(EscrowError::AmountMustBePositive)
         );
         assert_eq!(
             validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS + 1),
-            Err(AmountValidationError::AmountExceedsMaximum)
+            Err(EscrowError::InvalidMilestoneAmount)
         );
     }
 
@@ -52,19 +52,19 @@ mod tests {
         let milestones3 = [100_0000000, 0, 300_0000000]; // Contains zero
         assert_eq!(
             validate_milestone_amounts(&milestones3, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::NonPositiveAmount)
+            Err(EscrowError::AmountMustBePositive)
         );
 
         let milestones4 = [100_0000000, -50_0000000, 300_0000000]; // Contains negative
         assert_eq!(
             validate_milestone_amounts(&milestones4, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::NonPositiveAmount)
+            Err(EscrowError::AmountMustBePositive)
         );
 
         let milestones5 = [600_000_0000000, 500_000_0000000]; // Exceeds contract max
         assert_eq!(
             validate_milestone_amounts(&milestones5, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::ExceedsContractMaximum)
+            Err(EscrowError::InvalidMilestoneAmount)
         );
     }
 
@@ -82,17 +82,17 @@ mod tests {
         // Test invalid deposits
         assert_eq!(
             validate_deposit_amount(0, 0, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::NonPositiveAmount)
+            Err(EscrowError::AmountMustBePositive)
         );
         assert_eq!(
             validate_deposit_amount(-1, 0, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::NonPositiveAmount)
+            Err(EscrowError::AmountMustBePositive)
         );
 
         // Test would exceed maximum
         assert_eq!(
             validate_deposit_amount(600_000_0000000, 500_000_0000000, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::ExceedsContractMaximum)
+            Err(EscrowError::InvalidMilestoneAmount)
         );
     }
 
@@ -107,7 +107,7 @@ mod tests {
         // Test invalid totals
         assert_eq!(
             validate_contract_total(MAX_TOTAL_ESCROW_STROOPS + 1, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::ExceedsContractMaximum)
+            Err(EscrowError::InvalidMilestoneAmount)
         );
     }
 
@@ -137,7 +137,7 @@ mod tests {
         assert!(validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS).is_ok());
         assert_eq!(
             validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS + 1),
-            Err(AmountValidationError::AmountExceedsMaximum)
+            Err(EscrowError::InvalidMilestoneAmount)
         );
 
         // Test contract boundary
@@ -147,7 +147,7 @@ mod tests {
         let over_boundary_milestones = [MAX_TOTAL_ESCROW_STROOPS + 1];
         assert_eq!(
             validate_milestone_amounts(&over_boundary_milestones, MAX_TOTAL_ESCROW_STROOPS),
-            Err(AmountValidationError::AmountExceedsMaximum)
+            Err(EscrowError::InvalidMilestoneAmount)
         );
     }
 

--- a/contracts/escrow/src/test/input_sanitization_amounts.rs
+++ b/contracts/escrow/src/test/input_sanitization_amounts.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_TOTAL_ESCROW_STROOPS,
     validate_single_amount, validate_milestone_amounts, validate_deposit_amount,
-    safe_add_amounts, safe_subtract_amounts, AmountValidationError};
+    safe_add_amounts, safe_subtract_amounts};
 
 fn setup() -> (Env, EscrowClient, Address, Address) {
     let env = Env::default();
@@ -105,12 +105,12 @@ fn test_single_amount_validation() {
     assert!(validate_single_amount(1_000_000_0000000).is_ok()); // Max single amount
 
     // Invalid amounts
-    assert_eq!(validate_single_amount(0), Err(AmountValidationError::NonPositiveAmount));
-    assert_eq!(validate_single_amount(-1), Err(AmountValidationError::NonPositiveAmount));
-    assert_eq!(validate_single_amount(-100_0000000), Err(AmountValidationError::NonPositiveAmount));
+    assert_eq!(validate_single_amount(0), Err(EscrowError::AmountMustBePositive));
+    assert_eq!(validate_single_amount(-1), Err(EscrowError::AmountMustBePositive));
+    assert_eq!(validate_single_amount(-100_0000000), Err(EscrowError::AmountMustBePositive));
     assert_eq!(
         validate_single_amount(1_000_000_0000001), 
-        Err(AmountValidationError::AmountExceedsMaximum)
+        Err(EscrowError::InvalidMilestoneAmount)
     );
 }
 
@@ -133,13 +133,13 @@ fn test_milestone_amounts_validation() {
 
     // Invalid arrays
     let milestones4 = vec![100_0000000, 0, 300_0000000]; // Contains zero
-    assert_eq!(validate_milestone_amounts(&milestones4, max_total), Err(AmountValidationError::NonPositiveAmount));
+    assert_eq!(validate_milestone_amounts(&milestones4, max_total), Err(EscrowError::AmountMustBePositive));
 
     let milestones5 = vec![100_0000000, -50_0000000, 300_0000000]; // Contains negative
-    assert_eq!(validate_milestone_amounts(&milestones5, max_total), Err(AmountValidationError::NonPositiveAmount));
+    assert_eq!(validate_milestone_amounts(&milestones5, max_total), Err(EscrowError::AmountMustBePositive));
 
     let milestones6 = vec![600_000_0000000, 500_000_0000000]; // Exceeds contract max
-    assert_eq!(validate_milestone_amounts(&milestones6, max_total), Err(AmountValidationError::ExceedsContractMaximum));
+    assert_eq!(validate_milestone_amounts(&milestones6, max_total), Err(EscrowError::InvalidMilestoneAmount));
 }
 
 #[test]
@@ -152,19 +152,19 @@ fn test_deposit_amount_validation() {
     assert!(validate_deposit_amount(max_total, 0, max_total).is_ok());
 
     // Invalid deposits
-    assert_eq!(validate_deposit_amount(0, 0, max_total), Err(AmountValidationError::NonPositiveAmount));
-    assert_eq!(validate_deposit_amount(-1, 0, max_total), Err(AmountValidationError::NonPositiveAmount));
+    assert_eq!(validate_deposit_amount(0, 0, max_total), Err(EscrowError::AmountMustBePositive));
+    assert_eq!(validate_deposit_amount(-1, 0, max_total), Err(EscrowError::AmountMustBePositive));
 
     // Would exceed maximum
     assert_eq!(
         validate_deposit_amount(600_000_0000000, 500_000_0000000, max_total),
-        Err(AmountValidationError::ExceedsContractMaximum)
+        Err(EscrowError::InvalidMilestoneAmount)
     );
 
     // Single amount exceeds maximum
     assert_eq!(
         validate_deposit_amount(1_000_000_0000001, 0, max_total),
-        Err(AmountValidationError::AmountExceedsMaximum)
+        Err(EscrowError::InvalidMilestoneAmount)
     );
 }
 
@@ -194,14 +194,14 @@ fn test_edge_cases() {
 
     // Test boundary values
     assert!(validate_single_amount(1_000_000_0000000).is_ok()); // Max single amount
-    assert_eq!(validate_single_amount(1_000_000_0000001), Err(AmountValidationError::AmountExceedsMaximum));
+    assert_eq!(validate_single_amount(1_000_000_0000001), Err(EscrowError::InvalidMilestoneAmount));
 
     // Test contract boundary
     let boundary_milestones = vec![MAX_TOTAL_ESCROW_STROOPS];
     assert!(validate_milestone_amounts(&boundary_milestones, max_total).is_ok());
 
     let over_boundary_milestones = vec![MAX_TOTAL_ESCROW_STROOPS + 1];
-    assert_eq!(validate_milestone_amounts(&over_boundary_milestones, max_total), Err(AmountValidationError::AmountExceedsContractMaximum));
+    assert_eq!(validate_milestone_amounts(&over_boundary_milestones, max_total), Err(EscrowError::InvalidMilestoneAmount));
 }
 
 #[test]
@@ -236,7 +236,7 @@ fn test_large_amount_arrays() {
     for _ in 0..10 {
         overflow_milestones.push(200_000_0000000); // 200M tokens each
     }
-    assert_eq!(validate_milestone_amounts(&overflow_milestones, max_total), Err(AmountValidationError::ExceedsContractMaximum));
+    assert_eq!(validate_milestone_amounts(&overflow_milestones, max_total), Err(EscrowError::InvalidMilestoneAmount));
 }
 
 #[test]
@@ -251,6 +251,6 @@ fn test_cumulative_deposit_validation() {
     // Should fail when cumulative exceeds maximum
     assert_eq!(
         validate_deposit_amount(800_000_0000000, 300_000_0000000, max_total),
-        Err(AmountValidationError::ExceedsContractMaximum)
+        Err(EscrowError::InvalidMilestoneAmount)
     );
 }


### PR DESCRIPTION
this pr closes #418 
This pull request removes the third error type, `AmountValidationError`, located in `contracts/escrow/src/amount_validation.rs`, and consolidates all validation failures under the canonical `EscrowError` enum. 

Collapsing the competing error spaces ensures client-SDK decoders receive consistent error codes from the contract.

### Changes
* **`contracts/escrow/src/amount_validation.rs`**:
  * Removed the `AmountValidationError` enum.
  * Refactored validation functions (`validate_single_amount`, `validate_amount_array`, `validate_contract_total`, `validate_milestone_amounts`, and `validate_deposit_amount`) to return `Result<_, EscrowError>`.
  * Replaced internal error propagation with the canonical `EscrowError` variants.
* **`contracts/escrow/src/simple_amount_test.rs`**:
  * Removed references to the deprecated `AmountValidationError` enum.
  * Adjusted test expectations to assert against the appropriate `EscrowError` variants.
* **`contracts/escrow/src/test/input_sanitization_amounts.rs`**:
  * Removed the import of `AmountValidationError`.
  * Updated all validation test assertions to use the corresponding `EscrowError` variants.
