### PR TITLE
docs: document ContractSummary indexer schema and versioning

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 use crate::{
-    safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow,
-    EscrowError, Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow, EscrowError,
+    Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 /// Immutable metadata written when an escrow contract is closed.
@@ -108,9 +108,8 @@ impl Escrow {
         let after_releases =
             safe_subtract_amounts(contract.funded_amount, contract.released_amount)
                 .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
-        let refundable_balance =
-            safe_subtract_amounts(after_releases, contract.refunded_amount)
-                .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+        let refundable_balance = safe_subtract_amounts(after_releases, contract.refunded_amount)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
 
         ContractSummary {
             schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,

--- a/contracts/escrow/src/test/client_migration.rs
+++ b/contracts/escrow/src/test/client_migration.rs
@@ -1,16 +1,14 @@
 #![cfg(test)]
 
+use crate::migration::PendingClientMigration;
+use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use crate::{
     types::{ContractStatus, DataKey},
     Contract, Escrow, EscrowClient, EscrowError,
 };
-use crate::migration::PendingClientMigration;
-use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use soroban_sdk::{
-    testutils::Address as _,
-    testutils::Ledger as _,
-    testutils::LedgerInfo,
-    Address, Env, IntoVal, Symbol, Val,
+    testutils::Address as _, testutils::Ledger as _, testutils::LedgerInfo, Address, Env, IntoVal,
+    Symbol, Val,
 };
 
 use super::{assert_contract_error, create_contract, register_client, total_milestone_amount};
@@ -120,7 +118,7 @@ fn non_proposed_address_cannot_accept_migration() {
 
     let (client_addr, freelancer_addr, id) = create_contract(&env, &client);
     let new_client = Address::generate(&env);
-    let attacker   = Address::generate(&env);
+    let attacker = Address::generate(&env);
 
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
 
@@ -158,14 +156,14 @@ fn expired_proposal_cannot_be_accepted() {
     // Set max_entry_ttl high enough so the proposal can be stored without hitting the cap.
     let initial = env.ledger().get();
     env.ledger().set(LedgerInfo {
-        sequence_number:          initial.sequence_number,
-        timestamp:                initial.timestamp,
-        protocol_version:         initial.protocol_version,
-        network_id:               initial.network_id.clone(),
-        base_reserve:             initial.base_reserve,
-        min_temp_entry_ttl:       1,
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
-        max_entry_ttl:            PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
     });
 
     let client = register_client(&env);
@@ -173,19 +171,22 @@ fn expired_proposal_cannot_be_accepted() {
     let new_client = Address::generate(&env);
 
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
-    assert!(client.has_pending_client_migration(&id), "proposal must exist before expiry");
+    assert!(
+        client.has_pending_client_migration(&id),
+        "proposal must exist before expiry"
+    );
 
     // Advance the ledger past the TTL. Soroban evicts temporary entries beyond max_entry_ttl.
     let current = env.ledger().get();
     env.ledger().set(LedgerInfo {
-        sequence_number:  current.sequence_number + PENDING_MIGRATION_TTL_LEDGERS + 1,
-        timestamp:        current.timestamp + u64::from(PENDING_MIGRATION_TTL_LEDGERS) * 5,
+        sequence_number: current.sequence_number + PENDING_MIGRATION_TTL_LEDGERS + 1,
+        timestamp: current.timestamp + u64::from(PENDING_MIGRATION_TTL_LEDGERS) * 5,
         protocol_version: current.protocol_version,
-        network_id:       [0u8; 32].into(),
-        base_reserve:     current.base_reserve,
-        min_temp_entry_ttl:       1,
+        network_id: [0u8; 32].into(),
+        base_reserve: current.base_reserve,
+        min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: 1,
-        max_entry_ttl:            65_536,
+        max_entry_ttl: 65_536,
     });
 
     // has_pending returns false — entry is evicted
@@ -340,7 +341,7 @@ fn only_current_client_may_propose_migration() {
 
     let (_client_addr, freelancer_addr, id) = create_contract(&env, &client);
     let new_client = Address::generate(&env);
-    let attacker   = Address::generate(&env);
+    let attacker = Address::generate(&env);
 
     // Freelancer as proposer is rejected
     assert_contract_error(
@@ -433,7 +434,10 @@ fn migration_allowed_on_partially_funded_status() {
 
     // Deposit less than the full milestone total → PartiallyFunded
     client.deposit_funds(&id, &client_addr, &super::MILESTONE_ONE);
-    assert_eq!(client.get_contract(&id).status, ContractStatus::PartiallyFunded);
+    assert_eq!(
+        client.get_contract(&id).status,
+        ContractStatus::PartiallyFunded
+    );
 
     let new_client = Address::generate(&env);
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
@@ -480,8 +484,7 @@ fn pending_migration_expiry_matches_ttl_constant() {
         "expires_at_ledger must equal requested_at + PENDING_MIGRATION_TTL_LEDGERS"
     );
     assert_eq!(
-        pending.requested_at_ledger,
-        ledger_before,
+        pending.requested_at_ledger, ledger_before,
         "requested_at_ledger must equal the ledger at proposal time"
     );
 }

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -7,12 +7,12 @@ use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
 
 // --- Submodules ---
 
+mod client_migration;
 mod emergency_controls;
 mod pause_controls;
 mod persistence;
-mod reputation;
 mod release_authorization;
-mod client_migration;
+mod reputation;
 
 // --- Shared constants ---
 

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -1,5 +1,8 @@
-use super::{create_contract, register_client, total_milestone_amount};
-use crate::{ContractStatus, EscrowError, ReleaseAuthorization};
+use super::{
+    create_contract, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_THREE,
+    MILESTONE_TWO,
+};
+use crate::{ContractStatus, EscrowError, ReleaseAuthorization, CONTRACT_SUMMARY_SCHEMA_VERSION};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 /// Finalization succeeds from Completed status; record snapshot matches contract state.
@@ -41,11 +44,7 @@ fn finalize_disputed_contract_allows_arbiter_finalizer() {
     let (client_addr, _freelancer_addr, arbiter_addr, contract_id) =
         super::create_contract_with_arbiter(&env, &client);
 
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &super::total_milestone_amount()
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     assert!(client.raise_dispute(&contract_id, &client_addr));
     assert_eq!(
         client.get_contract(&contract_id).status,
@@ -59,7 +58,10 @@ fn finalize_disputed_contract_allows_arbiter_finalizer() {
         .expect("finalization record should exist");
     assert_eq!(record.finalizer, arbiter_addr);
     assert_eq!(record.summary.status, ContractStatus::Disputed);
-    assert_eq!(record.summary.funded_amount, super::total_milestone_amount());
+    assert_eq!(
+        record.summary.funded_amount,
+        super::total_milestone_amount()
+    );
     assert_eq!(record.summary.released_amount, 0);
     assert_eq!(
         record.summary.refundable_balance,
@@ -157,11 +159,7 @@ fn finalize_rejects_funded_contract() {
     env.mock_all_auths();
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &super::total_milestone_amount()
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     assert_eq!(
         client.get_contract(&contract_id).status,
         ContractStatus::Funded
@@ -300,11 +298,7 @@ fn finalize_completed_with_mixed_releases_and_refunds() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &super::total_milestone_amount()
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
@@ -322,7 +316,127 @@ fn finalize_completed_with_mixed_releases_and_refunds() {
         .get_finalization_record(&contract_id)
         .expect("finalization record should exist");
     assert_eq!(record.summary.status, ContractStatus::Completed);
-    assert_eq!(record.summary.released_amount, super::MILESTONE_ONE + super::MILESTONE_TWO);
+    assert_eq!(
+        record.summary.released_amount,
+        MILESTONE_ONE + MILESTONE_TWO
+    );
     assert_eq!(record.summary.refundable_balance, 0);
     assert_eq!(record.summary.released_milestone_count, 2);
+}
+
+/// Verify that every finalized record carries the current
+/// `CONTRACT_SUMMARY_SCHEMA_VERSION`.
+#[test]
+fn finalization_schema_version_matches_constant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
+    assert!(client.release_milestone(&contract_id, &client_addr, &0));
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
+    assert!(client.release_milestone(&contract_id, &client_addr, &1));
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
+    assert!(client.release_milestone(&contract_id, &client_addr, &2));
+
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    let record = client
+        .get_finalization_record(&contract_id)
+        .expect("finalization record should exist");
+
+    assert_eq!(
+        record.summary.schema_version, CONTRACT_SUMMARY_SCHEMA_VERSION,
+        "schema_version must match CONTRACT_SUMMARY_SCHEMA_VERSION"
+    );
+}
+
+/// Verify that `refundable_balance` exactly matches the documented formula
+/// `(funded_amount - released_amount) - refunded_amount` using the source
+/// [`Contract`] accounting fields that existed before finalisation.
+///
+/// The summary does NOT carry a `refunded_amount` field, so we read it from
+/// the on-chain [`Contract`] record.
+#[test]
+fn refundable_balance_matches_documented_derivation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    // Release milestones 0 and 1; refund milestone 2.
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
+    assert!(client.release_milestone(&contract_id, &client_addr, &0));
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
+    assert!(client.release_milestone(&contract_id, &client_addr, &1));
+    assert!(client.refund_unreleased_milestones(&contract_id, &vec![&env, 2u32]));
+
+    // Snapshot Contract accounting fields before finalization.
+    let contract_before = client.get_contract(&contract_id);
+    let funded = contract_before.funded_amount;
+    let released = contract_before.released_amount;
+    let refunded = contract_before.refunded_amount;
+    let expected_balance = (funded - released) - refunded;
+
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    let record = client
+        .get_finalization_record(&contract_id)
+        .expect("finalization record should exist");
+
+    assert_eq!(
+        record.summary.refundable_balance, expected_balance,
+        "refundable_balance must equal (funded_amount - released_amount) - refunded_amount \
+         from the source Contract record"
+    );
+    assert_eq!(
+        record.summary.refundable_balance, 0,
+        "with all milestones released or refunded, refundable_balance must be 0"
+    );
+}
+
+/// Verify that `released_milestone_count` matches the documented derivation:
+/// the number of milestones where `released == true`.
+#[test]
+fn released_milestone_count_matches_documented_derivation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    // Release only milestone 1; leave 0 and 2 unreleased.
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
+    assert!(client.release_milestone(&contract_id, &client_addr, &1));
+
+    // Refund the remaining unreleased milestones to reach Completed.
+    assert!(client.refund_unreleased_milestones(&contract_id, &vec![&env, 0u32, 2u32]));
+    assert_eq!(
+        client.get_contract(&contract_id).status,
+        ContractStatus::Completed
+    );
+
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    let record = client
+        .get_finalization_record(&contract_id)
+        .expect("finalization record should exist");
+
+    let summary = &record.summary;
+
+    // released_milestone_count must equal the number of milestone summaries
+    // with released == true.
+    let actual_released_count = summary.milestones.iter().filter(|ms| ms.released).count() as u32;
+
+    assert_eq!(
+        summary.released_milestone_count, actual_released_count,
+        "released_milestone_count must match actual count of released milestones"
+    );
+    assert_eq!(summary.released_milestone_count, 1);
+    assert_eq!(summary.released_amount, MILESTONE_TWO);
 }

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -176,32 +176,105 @@ pub struct GovernedParameters {
 
 // ─── Indexer summary types ────────────────────────────────────────────────────
 
+/// Current schema version for [`ContractSummary`].
+///
+/// Bumped when a breaking change is made to the summarised shape.
+/// Downstream indexers MUST branch on this field to decode the
+/// rest of the struct correctly.
+///
+/// # Current value
+/// `1`
+///
+/// # Versioning policy
+/// See `docs/escrow/indexer-schema.md`.
 #[allow(dead_code)]
 pub const CONTRACT_SUMMARY_SCHEMA_VERSION: u32 = 1;
 
+/// Per-milestone summary embedded in [`ContractSummary`].
+///
+/// A lightweight projection of the on-chain [`Milestone`] that omits
+/// internal accounting fields (`funded_amount`, `refunded_amount`,
+/// `work_evidence`) that are not relevant to off-chain indexers.
+///
+/// # Fields
+/// * `index` – 0-based position in the milestones vector.
+/// * `amount` – Original amount specified at contract creation (stroops).
+/// * `released` – `true` after [`release_milestone`] succeeds.
+/// * `refunded` – `true` after [`refund_unreleased_milestones`] includes this
+///   index.
+///
+/// [`release_milestone`]: crate::Escrow::release_milestone
+/// [`refund_unreleased_milestones`]: crate::Escrow::refund_unreleased_milestones
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MilestoneSummary {
+    /// 0-based milestone index.
     pub index: u32,
+    /// Original milestone amount in stroops (set at creation).
     pub amount: i128,
+    /// Whether this milestone has been released.
     pub released: bool,
+    /// Whether this milestone has been refunded.
     pub refunded: bool,
 }
 
+/// Denormalised, versioned snapshot of an escrow contract for off-chain
+/// indexers.
+///
+/// Produced during [`finalize_contract`] and stored as part of the
+/// finalization record.
+///
+/// # Field provenance
+///
+/// | Classification | Fields |
+/// |---|---|
+/// | Copied verbatim from [`Contract`] | `client`, `freelancer`, `arbiter`, `status`, `funded_amount`, `released_amount` |
+/// | Per-milestone projection from stored [`Milestone`] records | `milestones` |
+/// | Derived at finalisation | `total_amount`, `refundable_balance`, `released_milestone_count` |
+/// | Set to [`CONTRACT_SUMMARY_SCHEMA_VERSION`] | `schema_version` |
+/// | Hardcoded (see caveat) | `reputation_issued` |
+///
+/// # Versioning
+/// See `docs/escrow/indexer-schema.md`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractSummary {
+    /// Schema version used to produce this snapshot.
+    /// Indexers MUST check this before decoding.
     pub schema_version: u32,
+    /// Client address (copied from [`Contract::client`]).
     pub client: Address,
+    /// Freelancer address (copied from [`Contract::freelancer`]).
     pub freelancer: Address,
+    /// Optional arbiter address (copied from [`Contract::arbiter`]).
     pub arbiter: Option<Address>,
+    /// Contract status at finalisation time (copied from [`Contract::status`]).
     pub status: ContractStatus,
+    /// **Hardcoded to `false`** – not yet wired to the on-chain
+    /// `DataKey::ReputationIssued` flag.
+    ///
+    /// # Caveat
+    /// This field does NOT reflect the actual reputation issuance state.
+    /// See `docs/escrow/indexer-schema.md` for details.
     pub reputation_issued: bool,
+    /// Sum of every milestone's `amount` field (derived at finalisation).
     pub total_amount: i128,
+    /// Total amount deposited by the client (copied from
+    /// [`Contract::funded_amount`]).
     pub funded_amount: i128,
+    /// Total amount released to the freelancer (copied from
+    /// [`Contract::released_amount`]).
     pub released_amount: i128,
+    /// Remaining escrow balance that can be refunded (derived).
+    ///
+    /// Computed as:
+    /// ```text
+    /// refundable_balance = (funded_amount - released_amount) - refunded_amount
+    /// ```
     pub refundable_balance: i128,
+    /// Number of milestones with `released == true` (derived).
     pub released_milestone_count: u32,
+    /// Per-milestone summary entries.
     pub milestones: Vec<MilestoneSummary>,
 }
 

--- a/docs/escrow/indexer-schema.md
+++ b/docs/escrow/indexer-schema.md
@@ -1,0 +1,423 @@
+# ContractSummary Indexer Schema
+
+## Overview
+
+`ContractSummary` is a denormalised, versioned snapshot of an escrow contract
+produced when a contract is finalised via [`finalize_contract`]. It is stored
+as part of an immutable [`FinalizationRecord`] and can be retrieved with
+[`get_finalization_record`].
+
+**Purpose:**
+
+- Provide off-chain indexers with a single, self-describing record that can be
+  decoded without replaying every state mutation.
+- Versioned via [`CONTRACT_SUMMARY_SCHEMA_VERSION`] so indexers can branch on
+  schema changes without breaking.
+- Freeze the summarised state at the moment of finalisation so that subsequent
+  on-chain activity cannot alter the historical record.
+
+[`finalize_contract`]: ../contracts/escrow/src/finalize.rs
+[`get_finalization_record`]: ../contracts/escrow/src/lib.rs
+[`FinalizationRecord`]: ../contracts/escrow/src/finalize.rs
+[`CONTRACT_SUMMARY_SCHEMA_VERSION`]: ../contracts/escrow/src/types.rs
+
+### MilestoneSummary
+
+`MilestoneSummary` is a lightweight projection of an on-chain [`Milestone`]. It
+omits internal accounting fields (`funded_amount`, `refunded_amount`,
+`work_evidence`) that are not useful to indexers.
+
+[`Milestone`]: ../contracts/escrow/src/types.rs
+
+### How indexers consume the snapshot
+
+1. Call [`get_finalization_record(contract_id)`] on-chain.
+2. Inspect `record.summary.schema_version`.
+3. Decode `record.summary` according to the schema matching that version.
+4. Index the flattened fields and the `milestones` vector into an off-chain
+   store.
+
+There is currently **no** standalone `get_contract_summary` entrypoint; the
+summary is only available as part of a `FinalizationRecord`. See
+[ghit-issues.md](../../ghit-issues.md#L520) for the planned addition.
+
+[`get_finalization_record(contract_id)`]: ../contracts/escrow/src/lib.rs
+
+---
+
+## ContractSummary Schema
+
+Source: `contracts/escrow/src/types.rs:193`, produced by `finalize.rs:76`.
+
+| # | Field | Type | Stored/Derived | Source / Computation |
+|---|-------|------|----------------|----------------------|
+| 1 | `schema_version` | `u32` | Constant | `CONTRACT_SUMMARY_SCHEMA_VERSION` (value `1`) |
+| 2 | `client` | `Address` | Stored | Copied from `Contract.client` |
+| 3 | `freelancer` | `Address` | Stored | Copied from `Contract.freelancer` |
+| 4 | `arbiter` | `Option<Address>` | Stored | Copied from `Contract.arbiter` |
+| 5 | `status` | `ContractStatus` | Stored | Copied from `Contract.status` |
+| 6 | `reputation_issued` | `bool` | **Hardcoded** | Always `false` – see [Known Caveats](#reputation_issued) |
+| 7 | `total_amount` | `i128` | Derived | Sum of all `Milestone.amount` values via `checked_add` |
+| 8 | `funded_amount` | `i128` | Stored | Copied from `Contract.funded_amount` |
+| 9 | `released_amount` | `i128` | Stored | Copied from `Contract.released_amount` |
+| 10 | `refundable_balance` | `i128` | Derived | See [Derived Field Explanations](#derived-field-explanations) |
+| 11 | `released_milestone_count` | `u32` | Derived | See [Derived Field Explanations](#derived-field-explanations) |
+| 12 | `milestones` | `Vec<MilestoneSummary>` | Derived | Built per-milestone from stored `Vec<Milestone>` |
+
+### Field details
+
+#### `schema_version: u32`
+- **Value:** `CONTRACT_SUMMARY_SCHEMA_VERSION` = `1`.
+- **Usage:** Indexers MUST check this before interpreting the struct. Future
+  versions may add, remove, or reorder fields.
+
+#### `client: Address`
+- Copied directly from the stored `Contract.client`.
+- Immutable after creation.
+
+#### `freelancer: Address`
+- Copied directly from the stored `Contract.freelancer`.
+- Immutable after creation.
+
+#### `arbiter: Option<Address>`
+- Copied directly from the stored `Contract.arbiter`.
+- May be `None` if no arbiter was assigned.
+
+#### `status: ContractStatus`
+- Copied directly from the stored `Contract.status`.
+- Only `Completed` or `Disputed` are finalisable (see `finalize.rs:155-158`).
+
+#### `reputation_issued: bool`
+- **Hardcoded to `false`.** See [Known Caveats](#reputation_issued).
+
+#### `total_amount: i128`
+- Sum of every `Milestone.amount` in the contract, accumulated with
+  `checked_add`.
+- Panics with `PotentialOverflow` on arithmetic overflow.
+
+#### `funded_amount: i128`
+- Copied from `Contract.funded_amount` (total client deposits).
+
+#### `released_amount: i128`
+- Copied from `Contract.released_amount` (sum of released milestone amounts).
+
+#### `refundable_balance: i128`
+- Derived. See [Derived Field Explanations](#refundable_balance).
+
+#### `released_milestone_count: u32`
+- Derived. See [Derived Field Explanations](#released_milestone_count).
+
+#### `milestones: Vec<MilestoneSummary>`
+- Built by iterating the stored `Vec<Milestone>` and projecting each entry.
+
+---
+
+## MilestoneSummary Schema
+
+Source: `contracts/escrow/src/types.rs:184`, produced by `finalize.rs:100`.
+
+| # | Field | Type | Description | Source |
+|---|-------|------|-------------|--------|
+| 1 | `index` | `u32` | 0-based milestone position | Copied from enumeration index |
+| 2 | `amount` | `i128` | Original milestone amount in stroops | Copied from `Milestone.amount` |
+| 3 | `released` | `bool` | Whether this milestone has been released | Copied from `Milestone.released` |
+| 4 | `refunded` | `bool` | Whether this milestone has been refunded | Copied from `Milestone.refunded` |
+
+### Construction
+
+For each `(index, ms)` in the stored milestone vector, the summariser emits:
+
+```rust
+MilestoneSummary {
+    index: index as u32,
+    amount: ms.amount,
+    released: ms.released,
+    refunded: ms.refunded,
+}
+```
+
+---
+
+## Derived Field Explanations
+
+### `refundable_balance`
+
+Computed in `finalize.rs:108-113`:
+
+```rust
+let after_releases =
+    safe_subtract_amounts(contract.funded_amount, contract.released_amount)
+        .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+let refundable_balance =
+    safe_subtract_amounts(after_releases, contract.refunded_amount)
+        .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+```
+
+**Derivation (expanded):**
+
+```
+refundable_balance = (funded_amount - released_amount) - refunded_amount
+```
+
+`safe_subtract_amounts` delegates to `i128::checked_sub` (`amount_validation.rs:167-169`).
+If any intermediate subtraction underflows (i.e. `funded_amount < released_amount` or
+`(funded_amount - released_amount) < refunded_amount`), the contract panics with
+`AccountingInvariantViolated`. This should never happen for a well-formed contract,
+because the mutation entrypoints enforce the invariant:
+
+```
+released_amount + refunded_amount <= funded_amount
+```
+
+**Simplified formula** (equivalent, but the code uses two steps for clarity):
+
+```
+refundable_balance = funded_amount - released_amount - refunded_amount
+```
+
+The same invariant is visible in `lib.rs:536` (`get_refundable_balance`) and
+`dispute.rs:34-37` (`resolution_payouts`).
+
+### `released_milestone_count`
+
+Computed in `finalize.rs:85-98`:
+
+```rust
+let mut released_milestone_count: u32 = 0;
+for (index, ms) in milestones.iter().enumerate() {
+    if ms.released {
+        released_milestone_count = released_milestone_count
+            .checked_add(1)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+    }
+    // ...
+}
+```
+
+**Derivation:**
+
+```
+released_milestone_count = count of milestones where ms.released == true
+```
+
+Each released milestone increments the counter by 1 using `checked_add`. Overflow
+(> u32::MAX milestones, i.e. > 4B) panics with `PotentialOverflow`.
+
+### `total_amount`
+
+Computed in `finalize.rs:84-92`:
+
+```rust
+let mut total_amount: i128 = 0;
+for (index, ms) in milestones.iter().enumerate() {
+    total_amount = total_amount
+        .checked_add(ms.amount)
+        .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+    // ...
+}
+```
+
+**Derivation:**
+
+```
+total_amount = sum of all milestone.amount values
+```
+
+This sum is **not** stored on-chain; it is recomputed at finalisation time.
+
+### `schema_version`
+
+Set to the constant `CONTRACT_SUMMARY_SCHEMA_VERSION` (`finalize.rs:116`):
+
+```rust
+schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,
+```
+
+No negotiation or per-contract override – all finalised contracts carry the
+version that was current when the contract code was deployed.
+
+---
+
+## Schema Versioning Policy
+
+### Current version
+
+`CONTRACT_SUMMARY_SCHEMA_VERSION = 1` (defined in `types.rs:180`).
+
+### When the version MUST be bumped
+
+Bump `CONTRACT_SUMMARY_SCHEMA_VERSION` when any of the following changes are
+made to `ContractSummary` or `MilestoneSummary`:
+
+| Change | Examples | Bump required? |
+|--------|----------|----------------|
+| Add a new field | Adding `resolved_at: u64` | **Yes** (breaking unless at end with default) |
+| Remove a field | Removing `reputation_issued` | **Yes** (breaking) |
+| Rename a field | `total_amount` → `milestone_total` | **Yes** (breaking for named-field decoding) |
+| Change field type | `released_milestone_count` from `u32` to `i128` | **Yes** (breaking) |
+| Change derivation logic | Different `refundable_balance` formula | **Yes** (semantic breaking change) |
+| Reorder fields | Moving `status` after `milestones` | **Yes** (positional decoders break) |
+| Add new variant | New `ContractStatus` variant | **Yes** (exhaustive-match decoders break) |
+| Fix `reputation_issued` to read real state | Wire to `DataKey::ReputationIssued` | **No** (bugfix, schema-compatible) |
+| Add optional field at end | Adding `resolved_at: Option<u64>` after `milestones` | **No** (backward compatible) |
+
+### Breaking vs non-breaking changes
+
+**Breaking:** Any change that would cause a downstream indexer to mis-decode or
+panic if it uses the old schema version to read the new struct.
+
+**Non-breaking:** Bugfixes that correct the value of an existing field without
+changing its type or position (e.g. wiring `reputation_issued` to real storage).
+
+### Backward compatibility expectations
+
+- Old indexers MUST continue to decode schema version `1` records correctly
+  even after a new version is introduced.
+- The contract code MUST NOT produce records with a schema version older than
+  the current constant.
+- Schema version is **not** downgraded when contract code is rolled back.
+
+### How downstream indexers should branch on `schema_version`
+
+```python
+record = client.get_finalization_record(contract_id)
+summary = record.summary
+
+if summary.schema_version == 1:
+    index_v1(summary)
+elif summary.schema_version == 2:
+    index_v2(summary)
+else:
+    raise RuntimeError(f"Unknown schema version {summary.schema_version}")
+```
+
+Indexers SHOULD treat unknown schema versions as hard errors rather than
+attempting best-effort decoding.
+
+### Migration guidance
+
+When bumping the schema version:
+
+1. Increment `CONTRACT_SUMMARY_SCHEMA_VERSION` in `types.rs`.
+2. Update the `ContractSummary` struct (add/remove/change fields).
+3. Update `MilestoneSummary` if needed.
+4. Update `summarize_contract` in `finalize.rs` to populate new fields.
+5. Update this document (`docs/escrow/indexer-schema.md`).
+6. Update downstream indexer code to handle the new version.
+7. Run `cargo test` to verify all existing tests still pass (they use the
+   current version constant).
+
+---
+
+## Known Caveats
+
+### `reputation_issued`
+
+**Current behaviour:** `reputation_issued` is **hardcoded to `false`** in
+`summarize_contract` (`finalize.rs:121`).
+
+```rust
+reputation_issued: false,
+```
+
+The actual on-chain reputation issuance state is stored under
+`DataKey::ReputationIssued(contract_id)` (a persistent `bool` written by
+`issue_reputation` in `lib.rs:711`).
+
+**Why:** The summariser does not read `DataKey::ReputationIssued(contract_id)`
+at finalisation time. This is a known gap.
+
+**Impact:** Indexers cannot rely on `reputation_issued` to determine whether
+reputation has been issued. As a workaround, indexers can:
+
+- Call `env.storage().persistent().get::<_, bool>(&DataKey::ReputationIssued(contract_id))`
+  directly (off-chain indexers with archive-node access).
+- Ignore the field and derive reputation state from on-chain events
+  (`("rep_issd", contract_id)`).
+
+**Planned fix:** Tracked in the issue tracker. When implemented, the field will
+read `DataKey::ReputationIssued(contract_id)`:
+
+```rust
+let reputation_issued = env.storage()
+    .persistent()
+    .get::<_, bool>(&DataKey::ReputationIssued(contract_id))
+    .unwrap_or(false);
+```
+
+### No standalone `get_contract_summary` entrypoint
+
+`ContractSummary` is currently produced only at finalisation time. There is no
+`get_contract_summary(contract_id) -> ContractSummary` entrypoint for active
+(non-finalised) contracts. See `ghit-issues.md:520-532`.
+
+### `ContractSummary` and `MilestoneSummary` not publicly exported
+
+These types are defined in `types.rs` but are **not** re-exported from `lib.rs`
+(line 38-41). They exist only for internal use by `finalize.rs`. The types are
+still part of the public ABI because they appear in the contract's
+`FinalizationRecord` return type.
+
+---
+
+## Examples
+
+### Fully completed contract (3 milestones, all released)
+
+Three milestones of 200, 400, and 600 units. Total = 1200. All deposited, all
+released.
+
+```
+schema_version: 1
+client:         <client_addr>
+freelancer:     <freelancer_addr>
+arbiter:        None
+status:         Completed
+reputation_issued: false
+total_amount:         1200
+funded_amount:        1200
+released_amount:      1200
+refundable_balance:   0
+released_milestone_count: 3
+milestones:
+  [{index: 0, amount: 200, released: true,  refunded: false},
+   {index: 1, amount: 400, released: true,  refunded: false},
+   {index: 2, amount: 600, released: true,  refunded: false}]
+```
+
+### Disputed contract (funded, nothing released)
+
+Full deposit, no releases. Raised to Disputed.
+
+```
+schema_version: 1
+status:         Disputed
+total_amount:         1200
+funded_amount:        1200
+released_amount:      0
+refundable_balance:   1200
+released_milestone_count: 0
+milestones:
+  [{index: 0, amount: 200, released: false, refunded: false},
+   {index: 1, amount: 400, released: false, refunded: false},
+   {index: 2, amount: 600, released: false, refunded: false}]
+```
+
+### Mixed release/refund (2 released, 1 refunded)
+
+Milestones 0 and 1 released. Milestone 2 refunded. Status is Completed because
+not all milestones are refunded.
+
+```
+schema_version: 1
+status:         Completed
+total_amount:         1200
+funded_amount:        1200
+released_amount:      600   (200 + 400)
+refundable_balance:   0     (1200 - 600 - 600 = 0)
+released_milestone_count: 2
+milestones:
+  [{index: 0, amount: 200, released: true,  refunded: false},
+   {index: 1, amount: 400, released: true,  refunded: false},
+   {index: 2, amount: 600, released: false, refunded: true}]
+```


### PR DESCRIPTION
## Description

Documents the ContractSummary and MilestoneSummary indexer schema used by escrow finalization snapshots and defines a versioning policy for downstream indexers.

### Changes

* Added comprehensive Rust documentation comments to:

  * `CONTRACT_SUMMARY_SCHEMA_VERSION`
  * `ContractSummary`
  * `MilestoneSummary`
  * Summary-related fields

* Added `docs/escrow/indexer-schema.md` covering:

  * ContractSummary field definitions
  * MilestoneSummary field definitions
  * Stored vs derived field classification
  * `refundable_balance` derivation
  * `released_milestone_count` derivation
  * Schema versioning policy
  * Backward compatibility guidance
  * Indexer branching recommendations
  * Known limitations and caveats

* Added tests validating:

  * Schema version consistency
  * Documented refundable balance computation
  * Documented released milestone count computation

### Validation

* `cargo fmt --all -- --check` ✅
* Documentation verified against the implementation in escrow finalization logic
* Added tests validate documented derivations independently of implementation details

### Notes

The repository currently contains pre-existing compilation and test failures unrelated to this branch. No build failures originate from the files modified in this change set.

## Linked Issue

Closes #480
