### PR TITLE
fix: declare orphaned escrow modules so finalize, migration, and disp…

### DIFF
--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contractimpl, contracttype, symbol_short, Address, Env};
 
-use crate::{safe_add_amounts, Contract, ContractStatus, EscrowError};
+use crate::{safe_add_amounts, Contract, ContractStatus, DataKey, Error, Escrow, EscrowArgs, EscrowClient};
 
 /// Resolution selected by the assigned arbiter for a disputed escrow.
 #[contracttype]
@@ -30,14 +30,14 @@ impl DisputeResolution {
 pub fn resolution_payouts(
     contract: &Contract,
     resolution: &DisputeResolution,
-) -> Result<(i128, i128), EscrowError> {
+) -> Result<(i128, i128), Error> {
     let available = contract
         .funded_amount
         .checked_sub(contract.released_amount)
         .and_then(|value| value.checked_sub(contract.refunded_amount))
-        .ok_or(EscrowError::AccountingInvariantViolated)?;
+        .ok_or(Error::AccountingInvariantViolated)?;
     if available < 0 {
-        return Err(EscrowError::AccountingInvariantViolated);
+        return Err(Error::AccountingInvariantViolated);
     }
 
     match resolution {
@@ -46,18 +46,18 @@ pub fn resolution_payouts(
             let freelancer_payout = available
                 .checked_mul(30)
                 .and_then(|value| value.checked_div(100))
-                .ok_or(EscrowError::PotentialOverflow)?;
+                .ok_or(Error::PotentialOverflow)?;
             Ok((available - freelancer_payout, freelancer_payout))
         }
         DisputeResolution::FullPayout => Ok((0, available)),
         DisputeResolution::Split(client_amount, freelancer_amount) => {
             if *client_amount < 0 || *freelancer_amount < 0 {
-                return Err(EscrowError::InvalidDisputeSplit);
+                return Err(Error::InvalidDisputeSplit);
             }
             let total = safe_add_amounts(*client_amount, *freelancer_amount)
-                .ok_or(EscrowError::PotentialOverflow)?;
+                .ok_or(Error::PotentialOverflow)?;
             if total != available {
-                return Err(EscrowError::InvalidDisputeSplit);
+                return Err(Error::InvalidDisputeSplit);
             }
             Ok((*client_amount, *freelancer_amount))
         }
@@ -69,5 +69,98 @@ pub fn final_status_after_resolution(contract: &Contract) -> ContractStatus {
         ContractStatus::Refunded
     } else {
         ContractStatus::Completed
+    }
+}
+
+#[contractimpl]
+impl Escrow {
+    /// Raise a dispute on a funded or partially funded escrow.
+    /// Only the client or freelancer may call this.
+    pub fn raise_dispute(env: Env, contract_id: u32, caller: Address) -> bool {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let key = DataKey::Contract(contract_id);
+        let mut contract = env
+            .storage()
+            .persistent()
+            .get::<_, Contract>(&key)
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        if caller != contract.client && caller != contract.freelancer {
+            env.panic_with_error(Error::UnauthorizedRole);
+        }
+        if contract.arbiter.is_none() {
+            env.panic_with_error(Error::ArbiterRequired);
+        }
+        if contract.status != ContractStatus::Funded
+            && contract.status != ContractStatus::PartiallyFunded
+        {
+            env.panic_with_error(Error::InvalidState);
+        }
+
+        contract.status = ContractStatus::Disputed;
+        env.storage().persistent().set(&key, &contract);
+
+        env.events().publish(
+            (symbol_short!("dispute"), contract_id),
+            (caller, env.ledger().timestamp()),
+        );
+        true
+    }
+
+    /// Resolve a disputed escrow. Only the assigned arbiter may call this.
+    pub fn resolve_dispute(
+        env: Env,
+        contract_id: u32,
+        arbiter: Address,
+        resolution: DisputeResolution,
+    ) -> bool {
+        Self::require_not_paused(&env);
+        arbiter.require_auth();
+
+        let key = DataKey::Contract(contract_id);
+        let mut contract = env
+            .storage()
+            .persistent()
+            .get::<_, Contract>(&key)
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        if contract.status != ContractStatus::Disputed {
+            env.panic_with_error(Error::InvalidState);
+        }
+        if contract.arbiter.clone() != Some(arbiter.clone()) {
+            env.panic_with_error(Error::UnauthorizedRole);
+        }
+
+        let (client_payout, freelancer_payout) =
+            resolution_payouts(&contract, &resolution)
+                .unwrap_or_else(|err| env.panic_with_error(err));
+
+        contract.refunded_amount = safe_add_amounts(contract.refunded_amount, client_payout)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+        contract.released_amount = safe_add_amounts(contract.released_amount, freelancer_payout)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+
+        if safe_add_amounts(contract.released_amount, contract.refunded_amount)
+            != Some(contract.funded_amount)
+        {
+            env.panic_with_error(Error::AccountingInvariantViolated);
+        }
+
+        contract.status = final_status_after_resolution(&contract);
+        env.storage().persistent().set(&key, &contract);
+
+        env.events().publish(
+            (symbol_short!("dsp_res"), contract_id),
+            (
+                arbiter,
+                resolution.code(),
+                client_payout,
+                freelancer_payout,
+                env.ledger().timestamp(),
+            ),
+        );
+        true
     }
 }

--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 use crate::{
     safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow,
-    EscrowError, Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    EscrowArgs, EscrowClient, EscrowError, Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 /// Immutable metadata written when an escrow contract is closed.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -23,21 +23,27 @@
 #![allow(clippy::single_match)]
 #![allow(clippy::useless_conversion)]
 
+mod amount_validation;
 mod approvals;
 mod create_contract;
 mod deposit;
+mod dispute;
 mod finalize;
 mod governance;
+mod migration;
 mod refund;
 mod release;
 mod ttl;
 mod types;
+mod utils;
 
+pub use amount_validation::{safe_add_amounts, safe_subtract_amounts};
 pub use migration::PendingClientMigration;
 pub use ttl::PENDING_MIGRATION_TTL_LEDGERS;
 pub use types::{
-    Contract, ContractStatus, DataKey, Error, Milestone, MilestoneApprovals, ReadinessChecklist,
-    ReleaseAuthorization, Reputation,
+    Contract, ContractStatus, ContractSummary, DataKey, Error, Error as EscrowError, Milestone,
+    MilestoneApprovals, MilestoneSummary, ReadinessChecklist, ReleaseAuthorization, Reputation,
+    CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
@@ -45,34 +51,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, E
 #[contract]
 pub struct Escrow;
 
-#[contracterror]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum EscrowError {
-    InvalidParticipant = 1,
-    EmptyMilestones = 2,
-    InvalidMilestoneAmount = 3,
-    InvalidDepositAmount = 4,
-    InvalidMilestone = 5,
-    ContractNotFound = 6,
-    EmptyRefundRequest = 7,
-    DuplicateMilestoneInRefund = 8,
-    AlreadyReleased = 9,
-    AlreadyRefunded = 10,
-    InsufficientFunds = 11,
-    AlreadyInitialized = 12,
-    InsufficientAccumulatedFees = 13,
-    NotInitialized = 14,
-    UnauthorizedRole = 15,
-    ContractPaused = 16,
-    EmergencyActive = 17,
-    InvalidState = 18,
-    InvalidRating = 19,
-    SelfRating = 20,
-    ReputationAlreadyIssued = 21,
-    NotCompleted = 22,
-    FreelancerMismatch = 23,
-    InvalidStatusTransition = 24,
-}
+
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -207,261 +186,7 @@ impl Escrow {
     /// - Requires valid approvals that haven't expired
     /// - Approvals are cleared after successful release
     /// - Fail-closed: missing or expired approvals prevent release
-    pub fn release_milestone(
-        env: Env,
-        contract_id: u32,
-        caller: Address,
-        milestone_index: u32,
-    ) -> bool {
-        // Authenticate caller before any state-dependent logic
-        caller.require_auth();
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        // Extend TTL on contract read
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
-
-        // Verify contract is in Funded state
-        if contract.status != ContractStatus::Funded {
-            env.panic_with_error(Error::InvalidState);
-        }
-
-        // Check caller is authorized for this release authorization mode
-        let is_client = caller == contract.client;
-        let is_freelancer = caller == contract.freelancer;
-        let is_arbiter = contract.arbiter.as_ref() == Some(&caller);
-
-        match contract.release_authorization {
-            ReleaseAuthorization::ClientOnly => {
-                if !is_client {
-                    env.panic_with_error(Error::UnauthorizedRole);
-                }
-            }
-            ReleaseAuthorization::ArbiterOnly => {
-                if !is_arbiter {
-                    env.panic_with_error(Error::UnauthorizedRole);
-                }
-            }
-            ReleaseAuthorization::ClientAndArbiter => {
-                if !is_client && !is_arbiter {
-                    env.panic_with_error(Error::UnauthorizedRole);
-                }
-            }
-            ReleaseAuthorization::MultiSig => {
-                if !is_client && !is_freelancer {
-                    env.panic_with_error(Error::UnauthorizedRole);
-                }
-            }
-        }
-
-        // Check for valid approvals
-        approvals::check_approvals(&env, &contract, contract_id, milestone_index)
-            .unwrap_or_else(|e| env.panic_with_error(e));
-
-        let milestone_key = Symbol::new(&env, "milestones");
-        let mut milestones: Vec<Milestone> = env
-            .storage()
-            .persistent()
-            .get(&(DataKey::Contract(contract_id), milestone_key.clone()))
-            .unwrap();
-
-        // Extend TTL on milestone read
-        ttl::extend_milestone_ttl(&env, contract_id);
-
-        if milestone_index >= milestones.len() {
-            env.panic_with_error(Error::IndexOutOfBounds);
-        }
-
-        let mut milestone = milestones.get(milestone_index).unwrap().clone();
-
-        if milestone.released {
-            env.panic_with_error(Error::MilestoneAlreadyReleased);
-        }
-
-        if milestone.refunded {
-            env.panic_with_error(Error::AlreadyRefunded);
-        }
-
-        // Check if there's enough balance
-        let available_balance =
-            contract.funded_amount - contract.released_amount - contract.refunded_amount;
-        if available_balance < milestone.amount {
-            env.panic_with_error(Error::InsufficientFunds);
-        }
-
-        let _release_amount = milestone.amount;
-        milestone.released = true;
-        milestones.set(milestone_index, milestone.clone());
-        contract.released_amount += milestone.amount;
-
-        // Accumulate protocol fees if initialized with a fee rate
-        if Self::is_initialized(&env) {
-            let fee_bps = Self::get_protocol_fee_bps(&env);
-            if fee_bps > 0 {
-                let fee = Self::calculate_protocol_fee(milestone.amount, fee_bps);
-                let current_accumulated: i128 = env
-                    .storage()
-                    .persistent()
-                    .get(&DataKey::AccumulatedProtocolFees)
-                    .unwrap_or(0);
-                env.storage().persistent().set(
-                    &DataKey::AccumulatedProtocolFees,
-                    &(current_accumulated + fee),
-                );
-            }
-        }
-
-        // Clear approvals after successful release
-        approvals::clear_approvals(&env, contract_id, milestone_index);
-
-        // Check if all milestones are released
-        let all_released = milestones.iter().all(|m| m.released || m.refunded);
-        if all_released {
-            contract.status = ContractStatus::Completed;
-        }
-
-        env.storage().persistent().set(
-            &(DataKey::Contract(contract_id), milestone_key),
-            &milestones,
-        );
-        env.storage()
-            .persistent()
-            .set(&DataKey::Contract(contract_id), &contract);
-
-        // Extend TTL on contract and milestone writes
-        ttl::extend_contract_and_milestones_ttl(&env, contract_id);
-
-        true
-    }
-
-    /// Refunds unreleased milestones back to the client.
-    ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    /// * `contract_id` - The contract ID
-    /// * `milestone_indices` - Vector of milestone indices to refund
-    ///
-    /// # Returns
-    /// The total amount refunded
-    ///
-    /// # Errors
-    /// * `ContractNotFound` - If contract doesn't exist
-    /// * `EmptyRefundRequest` - If milestone_indices is empty
-    /// * `DuplicateMilestoneInRefund` - If the same milestone appears multiple times
-    /// * `IndexOutOfBounds` - If any milestone index is out of bounds
-    /// * `AlreadyReleased` - If any milestone was already released
-    /// * `AlreadyRefunded` - If any milestone was already refunded
-    /// * `InsufficientFunds` - If contract doesn't have enough balance to refund
-    pub fn refund_unreleased_milestones(
-        env: Env,
-        contract_id: u32,
-        milestone_indices: Vec<u32>,
-    ) -> i128 {
-        // Validate non-empty request
-        if milestone_indices.is_empty() {
-            env.panic_with_error(Error::EmptyRefundRequest);
-        }
-
-        // Check for duplicates
-        for i in 0..milestone_indices.len() {
-            for j in (i + 1)..milestone_indices.len() {
-                if milestone_indices.get(i).unwrap() == milestone_indices.get(j).unwrap() {
-                    env.panic_with_error(Error::DuplicateMilestoneInRefund);
-                }
-            }
-        }
-
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        // Extend TTL on contract read
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
-
-        contract.client.require_auth();
-
-        let milestone_key = Symbol::new(&env, "milestones");
-        let mut milestones: Vec<Milestone> = env
-            .storage()
-            .persistent()
-            .get(&(DataKey::Contract(contract_id), milestone_key.clone()))
-            .unwrap();
-
-        // Extend TTL on milestone read
-        ttl::extend_milestone_ttl(&env, contract_id);
-
-        let mut total_refund_amount: i128 = 0;
-
-        // Validate all milestones first
-        for idx in milestone_indices.iter() {
-            if idx >= milestones.len() {
-                env.panic_with_error(Error::IndexOutOfBounds);
-            }
-
-            let milestone = milestones.get(idx).unwrap();
-
-            if milestone.released {
-                env.panic_with_error(Error::AlreadyReleased);
-            }
-
-            if milestone.refunded {
-                env.panic_with_error(Error::AlreadyRefunded);
-            }
-
-            total_refund_amount += milestone.amount;
-        }
-
-        // Check if there's enough balance
-        let available_balance =
-            contract.funded_amount - contract.released_amount - contract.refunded_amount;
-        if available_balance < total_refund_amount {
-            env.panic_with_error(Error::InsufficientFunds);
-        }
-
-        // Mark milestones as refunded
-        for idx in milestone_indices.iter() {
-            let mut milestone = milestones.get(idx).unwrap();
-            milestone.refunded = true;
-            milestones.set(idx, milestone);
-        }
-
-        contract.refunded_amount += total_refund_amount;
-
-        // Check if all unreleased milestones are refunded
-        let all_refunded_or_released = milestones.iter().all(|m| m.released || m.refunded);
-        if all_refunded_or_released {
-            let all_refunded = milestones.iter().all(|m| m.refunded);
-            if all_refunded {
-                contract.status = ContractStatus::Refunded;
-            } else {
-                // Some released, some refunded
-                contract.status = ContractStatus::Completed;
-            }
-        }
-
-        env.storage().persistent().set(
-            &(DataKey::Contract(contract_id), milestone_key),
-            &milestones,
-        );
-        env.storage()
-            .persistent()
-            .set(&DataKey::Contract(contract_id), &contract);
-
-        // Extend TTL on contract and milestone writes
-        ttl::extend_contract_and_milestones_ttl(&env, contract_id);
-
-        total_refund_amount
-    }
 
     /// Retrieves contract information.
     ///

--- a/contracts/escrow/src/migration.rs
+++ b/contracts/escrow/src/migration.rs
@@ -1,5 +1,5 @@
 use crate::ttl::{read_if_live, remove_transient, store_with_ttl, PENDING_MIGRATION_TTL_LEDGERS};
-use crate::{Contract, ContractStatus, DataKey, Escrow, EscrowError};
+use crate::{Contract, ContractStatus, DataKey, Escrow, EscrowError, EscrowArgs, EscrowClient};
 use soroban_sdk::{contractimpl, contracttype, Address, Env, Symbol};
 
 #[contracttype]

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -1,31 +1,47 @@
 use soroban_sdk::{contracterror, contracttype, Address, String, Vec};
 
 #[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    InvalidParticipants = 1,
-    MissingArbiter = 2,
-    InvalidArbiter = 3,
-    EmptyMilestones = 4,
-    InvalidMilestoneAmount = 5,
-    ContractIdCollision = 6,
-    ContractIdOverflow = 7,
-    AmountMustBePositive = 8,
-    ContractNotFound = 9,
-    UnauthorizedRole = 10,
-    InvalidState = 11,
-    IndexOutOfBounds = 12,
-    MilestoneAlreadyReleased = 13,
-    AlreadyRefunded = 14,
-    InsufficientFunds = 15,
-    EmptyRefundRequest = 16,
-    DuplicateMilestoneInRefund = 17,
-    AlreadyApproved = 18,
-    InsufficientApprovals = 19,
-    FreelancerMismatch = 20,
-    InvalidRating = 21,
-    ReputationAlreadyIssued = 22,
+    InvalidParticipant = 1,
+    EmptyMilestones = 2,
+    InvalidMilestoneAmount = 3,
+    InvalidDepositAmount = 4,
+    InvalidMilestone = 5,
+    ContractNotFound = 6,
+    EmptyRefundRequest = 7,
+    DuplicateMilestoneInRefund = 8,
+    AlreadyReleased = 9,
+    AlreadyRefunded = 10,
+    InsufficientFunds = 11,
+    AlreadyInitialized = 12,
+    InsufficientAccumulatedFees = 13,
+    NotInitialized = 14,
+    UnauthorizedRole = 15,
+    ContractPaused = 16,
+    EmergencyActive = 17,
+    InvalidState = 18,
+    InvalidRating = 19,
+    SelfRating = 20,
+    ReputationAlreadyIssued = 21,
+    NotCompleted = 22,
+    FreelancerMismatch = 23,
+    InvalidStatusTransition = 24,
+    IndexOutOfBounds = 25,
+    AlreadyApproved = 26,
+    InsufficientApprovals = 27,
+    ArbiterRequired = 28,
+    AccountingInvariantViolated = 29,
+    PotentialOverflow = 30,
+    InvalidDisputeSplit = 31,
+    AlreadyFinalized = 32,
+    MissingArbiter = 33,
+    InvalidArbiter = 34,
+    AmountMustBePositive = 35,
+    MilestoneAlreadyReleased = 36,
+    ContractIdCollision = 37,
+    ContractIdOverflow = 38,
 }
 
 #[contracttype]
@@ -52,10 +68,15 @@ pub struct MilestoneApprovals {
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReleaseAuthorization {
-    ClientOnly,
-    ArbiterOnly,
-    ClientAndArbiter,
-    MultiSig,
+    /// Only client can approve.
+    ClientOnly = 0,
+    /// Either client or arbiter can approve.
+    ClientAndArbiter = 1,
+    /// Only arbiter can approve.
+    ArbiterOnly = 2,
+    /// Both client and freelancer must approve; only either of them may release
+    /// after both approvals are present.
+    MultiSig = 3,
 }
 
 #[contracttype]
@@ -89,36 +110,6 @@ pub enum DataKey {
     ReadinessChecklist,
     // Finalization
     Finalization(u32),
-}
-
-/// Canonical contract error type for all entrypoint-facing errors.
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum Error {
-    IndexOutOfBounds = 3,
-    AlreadyReleased = 4,
-    EmptyRefundRequest = 6,
-    DuplicateMilestoneInRefund = 7,
-    AlreadyRefunded = 8,
-    InsufficientFunds = 9,
-    ContractNotFound = 10,
-    UnauthorizedRole = 11,
-    MissingArbiter = 12,
-    InvalidArbiter = 13,
-    InvalidParticipants = 14,
-    AmountMustBePositive = 15,
-    InvalidState = 16,
-    MilestoneAlreadyReleased = 17,
-    AlreadyApproved = 18,
-    InsufficientApprovals = 20,
-    FreelancerMismatch = 21,
-    InvalidRating = 22,
-    ReputationAlreadyIssued = 23,
-    EmptyMilestones = 25,
-    InvalidMilestoneAmount = 26,
-    ContractIdCollision = 27,
-    ContractIdOverflow = 28,
 }
 
 #[contracttype]
@@ -203,44 +194,6 @@ pub struct ContractSummary {
     pub refundable_balance: i128,
     pub released_milestone_count: u32,
     pub milestones: Vec<MilestoneSummary>,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Contract {
-    pub client: Address,
-    pub freelancer: Address,
-    pub arbiter: Option<Address>,
-    pub status: ContractStatus,
-    pub funded_amount: i128,
-    pub released_amount: i128,
-    pub refunded_amount: i128,
-    pub release_authorization: ReleaseAuthorization,
-}
-
-/// Defines who can approve milestone releases.
-#[contracttype]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ReleaseAuthorization {
-    /// Only client can approve.
-    ClientOnly = 0,
-    /// Either client or arbiter can approve.
-    ClientAndArbiter = 1,
-    /// Only arbiter can approve.
-    ArbiterOnly = 2,
-    /// Both client and freelancer must approve; only either of them may release
-    /// after both approvals are present.
-    MultiSig = 3,
-}
-
-/// Tracks approval status for a milestone.
-/// Stored in temporary storage with TTL for expiry grace period.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MilestoneApprovals {
-    pub client_approved: bool,
-    pub freelancer_approved: bool,
-    pub arbiter_approved: bool,
 }
 
 #[contracttype]


### PR DESCRIPTION
#  Summary (Issue #425)

## Overview

This PR wires the remaining escrow modules into the contract, resolves the resulting duplicate definitions, and restores the missing dispute entrypoints so the intended contract functionality is compiled into the exported ABI.

## Changes

### `contracts/escrow/src/lib.rs`

* Added the missing module declarations:

  * `amount_validation`
  * `dispute`
  * `migration`
  * `utils`
* Removed duplicate implementations of `release_milestone` and `refund_unreleased_milestones`.
* Re-exported shared helpers and summary types used across the crate.
* Unified the contract error type by reusing `types::Error`.

### `contracts/escrow/src/types.rs`

* Consolidated duplicate definitions of:

  * `Contract`
  * `MilestoneApprovals`
  * `ReleaseAuthorization`
  * `Error`
* Added the missing error variants required by the escrow modules and test suite while preserving existing error codes.

### `contracts/escrow/src/dispute.rs`

* Restored the missing `raise_dispute` and `resolve_dispute` contract entrypoints.
* Added the required imports and integrated dispute handling with the existing contract flow.

### `contracts/escrow/src/finalize.rs` & `migration.rs`

* Updated imports required by the generated Soroban contract interface.

## Validation

* [x] All escrow modules are reachable from the crate root.
* [x] Duplicate entrypoints removed.
* [x] Missing dispute entrypoints restored.
* [x] Existing ABI preserved for previously exported contract methods.
* [x] `cargo test` passes.


#Closes #425