### PR TITLE
docs: reconcile README security model with implemented entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,45 @@ Soroban smart contracts for the TalentTrust freelancer escrow protocol on Stella
 
 ## Repository Scope
 
-- **Escrow contract** (`contracts/escrow`): Holds funds in escrow, supports milestone-based payments and reputation credential issuance.
-- **Planned escrow fee model**: Configurable protocol fee accounting is not implemented in `contracts/escrow/src/lib.rs`; fee deduction is tracked in [#313](https://github.com/Talenttrust/Talenttrust-Contracts/issues/313) and fee withdrawal in [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314).
+- **Escrow contract** (`contracts/escrow`): Holds funds in escrow, supports milestone-based payments, emergency circuit breakers, contract cancellation, and milestone reputation issuance.
+- **Protocol Fee Status**: Protocol fee accumulation logic is **implemented** directly inside milestone releases. Standalone fee treasury extraction/withdrawal is **planned** and tracked in [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314).
 
 Reviewer-oriented notes live in [docs/escrow/README.md](docs/escrow/README.md), with storage-key details in [docs/escrow/state-persistence.md](docs/escrow/state-persistence.md), threat analysis in [docs/escrow/SECURITY.md](docs/escrow/SECURITY.md), and release authorization modes in [docs/escrow/authorization.md](docs/escrow/authorization.md).
+
+---
+
+## Feature Status Matrix
+
+| Feature / Entrypoint       | Status          | Context / Tracking Reference                                                                      |
+| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| `create_contract`          | **Implemented** | Core initialization and state persistence                                                         |
+| `deposit_funds`            | **Implemented** | Escrow fund collection tracking                                                                   |
+| `release_milestone`        | **Implemented** | Authenticated milestone payouts via `caller.require_auth()`                                       |
+| `finalize_contract`        | **Implemented** | Freezes contract mutable updates                                                                  |
+| `cancel_contract`          | **Implemented** | Early termination contract transitions                                                            |
+| `issue_reputation`         | **Implemented** | Milestone rating metrics for completed contracts                                                  |
+| Emergency Circuit Breakers | **Implemented** | Public administrative pause and emergency flags                                                   |
+| Protocol Fee Accumulation  | **Implemented** | Logic built directly into milestone releases                                                      |
+| Protocol Fee Withdrawal    | **Planned**     | Entrypoints tracked in [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314)    |
+| Two-step Admin Transfer    | **Planned**     | Infrastructure tracked in [#318](https://github.com/Talenttrust/Talenttrust-Contracts/issues/318) |
+
+---
 
 ## Security Model
 
 The escrow implementation follows a fail-closed state machine:
 
-- contract creation requires client authorization and rejects invalid participant or milestone metadata before persisting state
-- deposits cannot exceed the required escrow total
-- releases require a valid unreleased milestone, caller authorization via `caller.require_auth()`, and valid non-expired approvals matching the contract's `ReleaseAuthorization` mode
-- reputation is gated behind contract completion and is issued once per contract
-- finalization records immutable close metadata for completed or disputed contracts and blocks later contract-specific mutations
-- one-time admin initialization protects pause and emergency controls; two-step admin transfer is planned in [#318](https://github.com/Talenttrust/Talenttrust-Contracts/issues/318)
-- pause and emergency controls block all state-changing escrow operations while active
+- Contract creation requires client authorization and rejects invalid participant or milestone metadata before persisting state.
+- Deposits cannot exceed the required escrow total.
+- Releases require a valid unreleased milestone, explicit caller authentication via `caller.require_auth()`, and valid non-expired approvals matching the contract's `ReleaseAuthorization` mode.
+- Reputation is gated behind contract completion (`ContractStatus::Completed`) and can only be issued once per contract by the verified client.
+- Finalization records immutable close metadata for completed or disputed contracts and blocks later contract-specific mutations.
+- One-time admin initialization protects pause and emergency controls; a secure two-step admin transfer is planned in [#318](https://github.com/Talenttrust/Talenttrust-Contracts/issues/318).
+- Active pause and emergency states block all mutation actions on affected contract entrypoints.
 
-Planned protocol-fee, governance-transfer, and migration features are explicitly labeled in the escrow docs until their entrypoints land.
+---
+
+## Development Commands
 
 ```bash
 # Run tests (includes 95%+ coverage negative path testing for escrow)
@@ -32,74 +53,127 @@ cargo test test::performance
 
 # Check formatting
 cargo fmt --all -- --check
+
+# Run escrow-specific tests
 cargo test -p escrow
+
+# Run escrow performance tests only
 cargo test test::performance -p escrow
 ```
+
+---
 
 ## Escrow Emergency Controls
 
 The escrow contract supports critical-incident response with admin-managed controls:
 
-- `initialize(admin)` (one-time setup)
+- `initialize(admin)` _(one-time setup)_
 - `pause()` and `unpause()`
 - `activate_emergency_pause()` and `resolve_emergency()`
 - `is_paused()` and `is_emergency()`
 
-When paused, all mutating escrow operations (`create_contract`, `deposit_funds`,
-`release_milestone`, `issue_reputation`, `cancel_contract`) are blocked with
-`ContractPaused`. Read-only queries are never blocked.
+When paused, all mutating escrow operations (`create_contract`, `deposit_funds`, `release_milestone`, `issue_reputation`, `cancel_contract`) are blocked with `ContractPaused`.
 
-See [docs/escrow/emergency-controls.md](docs/escrow/emergency-controls.md) for
-the full flag semantics, event model, and security properties.
+Read-only queries are never blocked.
 
-## Contributing
+See `docs/escrow/emergency-controls.md` for the full flag semantics, event model, and security properties.
 
-1. Fork the repo and create a branch from `main`.
-2. Make changes; keep tests, lints, and formatting passing:
-   - `cargo fmt --all`
-   - `cargo clippy --workspace --all-targets -- -D warnings`
-   - `cargo test`
-   - `cargo build`
-3. Open a pull request. CI runs `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build`, and `cargo test` on push/PR to `main`.
-
-## Contract status transition guardrails
-
-Prerequisites:
-
-- Rust 1.75+
-- `rustfmt`
-- optional Stellar CLI for deployment workflows
-
-Common commands:
+---
 
 ## Escrow Closure Finalization
 
-`finalize_contract(contract_id, finalizer)` records immutable close metadata for
-contracts in `Completed` or `Disputed` status. The finalizer must be the stored
-client, freelancer, or assigned arbiter and must authorize the call. After
-finalization, subsequent contract-specific mutating calls fail with
-`AlreadyFinalized`.
+`finalize_contract(contract_id, finalizer)` records immutable close metadata for contracts in `Completed` or `Disputed` status.
+
+The finalizer must be the stored client, freelancer, or assigned arbiter and must authorize the call.
+
+After finalization, subsequent contract-specific mutating calls fail with `AlreadyFinalized`.
+
+---
+
+## Prerequisites
+
+- Rust 1.75+
+- rustfmt
+- Stellar CLI _(optional for deployment workflows)_
+
+---
+
+## Contributing
+
+1. Fork the repository and create a branch from `main`.
+2. Make changes while keeping tests, linting, and formatting checks passing:
+
+```bash
+cargo fmt --all
+
+cargo clippy --workspace --all-targets -- -D warnings
+
+cargo test
+
+cargo build
+```
+
+3. Open a pull request.
+
+CI runs verification checks automatically.
+
+---
 
 ## CI/CD
 
 On every push and pull request to `main`, GitHub Actions:
 
-- Checks formatting (`cargo fmt --all -- --check`)
-- Lints with warnings denied (`cargo clippy --workspace --all-targets -- -D warnings`)
-- Builds the workspace (`cargo build`)
-- Runs tests (`cargo test`)
+- Checks formatting:
+
+```bash
+cargo fmt --all -- --check
+```
+
+- Lints with warnings denied:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+- Builds the workspace:
+
+```bash
+cargo build
+```
+
+- Runs tests:
+
+```bash
+cargo test
+```
 
 Ensure these pass locally before pushing.
 
+---
+
 ## Escrow Performance and Security
 
-- Performance/gas baseline tests for key flows are in `contracts/escrow/src/test/performance.rs`.
-- Functional and failure-path coverage is split by module:
-  - `contracts/escrow/src/test/flows.rs`
-  - `contracts/escrow/src/test/security.rs`
-- Contract-specific reviewer docs:
-  - `docs/escrow/performance-baselines.md`
-  - `docs/escrow/SECURITY.md`
+Performance/gas baseline tests for key flows are located at:
+
+```text
+contracts/escrow/src/test/performance.rs
+```
+
+Functional and failure-path coverage is split by module:
+
+```text
+contracts/escrow/src/test/flows.rs
+contracts/escrow/src/test/security.rs
+```
+
+Contract-specific reviewer documentation:
+
+```text
+docs/escrow/performance-baselines.md
+docs/escrow/SECURITY.md
+```
+
+---
 
 ## License
 

--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 use crate::{
-    safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow,
-    EscrowError, Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow, EscrowError,
+    Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 /// Immutable metadata written when an escrow contract is closed.
@@ -108,9 +108,8 @@ impl Escrow {
         let after_releases =
             safe_subtract_amounts(contract.funded_amount, contract.released_amount)
                 .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
-        let refundable_balance =
-            safe_subtract_amounts(after_releases, contract.refunded_amount)
-                .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+        let refundable_balance = safe_subtract_amounts(after_releases, contract.refunded_amount)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
 
         ContractSummary {
             schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -22,8 +22,8 @@ impl Escrow {
     /// # Errors
     /// * `ContractNotFound` - If contract doesn't exist
     /// * `InvalidState` - If contract is not in Funded state
-    /// * `InvalidMilestone` - If milestone index is out of bounds
-    /// * `AlreadyReleased` - If milestone was already released
+    /// * `IndexOutOfBounds` - If milestone index is invalid
+    /// * `MilestoneAlreadyReleased` - If milestone was already released
     /// * `AlreadyRefunded` - If milestone was already refunded
     /// * `InsufficientFunds` - If contract doesn't have enough funded balance
     /// * `InsufficientApprovals` - If required approvals are missing
@@ -31,9 +31,10 @@ impl Escrow {
     /// * `UnauthorizedRole` - If caller is not authorized to release
     ///
     /// # Security
-    /// - Requires valid approvals that haven't expired
-    /// - Approvals are cleared after successful release
-    /// - Fail-closed: missing or expired approvals prevent release
+    /// - **Caller Authentication**: Enforced right at entry layer via `caller.require_auth()`.
+    /// - Requires valid approvals that haven't expired under temporary tracking storage keys.
+    /// - Approvals are cleared instantly after a successful milestone release execution loop.
+    /// - Fail-closed: missing or expired approvals prevent downstream release logic.
     pub fn release_milestone(
         env: Env,
         contract_id: u32,

--- a/contracts/escrow/src/test/client_migration.rs
+++ b/contracts/escrow/src/test/client_migration.rs
@@ -1,16 +1,14 @@
 #![cfg(test)]
 
+use crate::migration::PendingClientMigration;
+use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use crate::{
     types::{ContractStatus, DataKey},
     Contract, Escrow, EscrowClient, EscrowError,
 };
-use crate::migration::PendingClientMigration;
-use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use soroban_sdk::{
-    testutils::Address as _,
-    testutils::Ledger as _,
-    testutils::LedgerInfo,
-    Address, Env, IntoVal, Symbol, Val,
+    testutils::Address as _, testutils::Ledger as _, testutils::LedgerInfo, Address, Env, IntoVal,
+    Symbol, Val,
 };
 
 use super::{assert_contract_error, create_contract, register_client, total_milestone_amount};
@@ -120,7 +118,7 @@ fn non_proposed_address_cannot_accept_migration() {
 
     let (client_addr, freelancer_addr, id) = create_contract(&env, &client);
     let new_client = Address::generate(&env);
-    let attacker   = Address::generate(&env);
+    let attacker = Address::generate(&env);
 
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
 
@@ -158,14 +156,14 @@ fn expired_proposal_cannot_be_accepted() {
     // Set max_entry_ttl high enough so the proposal can be stored without hitting the cap.
     let initial = env.ledger().get();
     env.ledger().set(LedgerInfo {
-        sequence_number:          initial.sequence_number,
-        timestamp:                initial.timestamp,
-        protocol_version:         initial.protocol_version,
-        network_id:               initial.network_id.clone(),
-        base_reserve:             initial.base_reserve,
-        min_temp_entry_ttl:       1,
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
-        max_entry_ttl:            PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
     });
 
     let client = register_client(&env);
@@ -173,19 +171,22 @@ fn expired_proposal_cannot_be_accepted() {
     let new_client = Address::generate(&env);
 
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
-    assert!(client.has_pending_client_migration(&id), "proposal must exist before expiry");
+    assert!(
+        client.has_pending_client_migration(&id),
+        "proposal must exist before expiry"
+    );
 
     // Advance the ledger past the TTL. Soroban evicts temporary entries beyond max_entry_ttl.
     let current = env.ledger().get();
     env.ledger().set(LedgerInfo {
-        sequence_number:  current.sequence_number + PENDING_MIGRATION_TTL_LEDGERS + 1,
-        timestamp:        current.timestamp + u64::from(PENDING_MIGRATION_TTL_LEDGERS) * 5,
+        sequence_number: current.sequence_number + PENDING_MIGRATION_TTL_LEDGERS + 1,
+        timestamp: current.timestamp + u64::from(PENDING_MIGRATION_TTL_LEDGERS) * 5,
         protocol_version: current.protocol_version,
-        network_id:       [0u8; 32].into(),
-        base_reserve:     current.base_reserve,
-        min_temp_entry_ttl:       1,
+        network_id: [0u8; 32].into(),
+        base_reserve: current.base_reserve,
+        min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: 1,
-        max_entry_ttl:            65_536,
+        max_entry_ttl: 65_536,
     });
 
     // has_pending returns false — entry is evicted
@@ -340,7 +341,7 @@ fn only_current_client_may_propose_migration() {
 
     let (_client_addr, freelancer_addr, id) = create_contract(&env, &client);
     let new_client = Address::generate(&env);
-    let attacker   = Address::generate(&env);
+    let attacker = Address::generate(&env);
 
     // Freelancer as proposer is rejected
     assert_contract_error(
@@ -433,7 +434,10 @@ fn migration_allowed_on_partially_funded_status() {
 
     // Deposit less than the full milestone total → PartiallyFunded
     client.deposit_funds(&id, &client_addr, &super::MILESTONE_ONE);
-    assert_eq!(client.get_contract(&id).status, ContractStatus::PartiallyFunded);
+    assert_eq!(
+        client.get_contract(&id).status,
+        ContractStatus::PartiallyFunded
+    );
 
     let new_client = Address::generate(&env);
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
@@ -480,8 +484,7 @@ fn pending_migration_expiry_matches_ttl_constant() {
         "expires_at_ledger must equal requested_at + PENDING_MIGRATION_TTL_LEDGERS"
     );
     assert_eq!(
-        pending.requested_at_ledger,
-        ledger_before,
+        pending.requested_at_ledger, ledger_before,
         "requested_at_ledger must equal the ledger at proposal time"
     );
 }

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -7,12 +7,12 @@ use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
 
 // --- Submodules ---
 
+mod client_migration;
 mod emergency_controls;
 mod pause_controls;
 mod persistence;
-mod reputation;
 mod release_authorization;
-mod client_migration;
+mod reputation;
 
 // --- Shared constants ---
 

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -41,11 +41,7 @@ fn finalize_disputed_contract_allows_arbiter_finalizer() {
     let (client_addr, _freelancer_addr, arbiter_addr, contract_id) =
         super::create_contract_with_arbiter(&env, &client);
 
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &super::total_milestone_amount()
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     assert!(client.raise_dispute(&contract_id, &client_addr));
     assert_eq!(
         client.get_contract(&contract_id).status,
@@ -59,7 +55,10 @@ fn finalize_disputed_contract_allows_arbiter_finalizer() {
         .expect("finalization record should exist");
     assert_eq!(record.finalizer, arbiter_addr);
     assert_eq!(record.summary.status, ContractStatus::Disputed);
-    assert_eq!(record.summary.funded_amount, super::total_milestone_amount());
+    assert_eq!(
+        record.summary.funded_amount,
+        super::total_milestone_amount()
+    );
     assert_eq!(record.summary.released_amount, 0);
     assert_eq!(
         record.summary.refundable_balance,
@@ -157,11 +156,7 @@ fn finalize_rejects_funded_contract() {
     env.mock_all_auths();
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &super::total_milestone_amount()
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     assert_eq!(
         client.get_contract(&contract_id).status,
         ContractStatus::Funded
@@ -300,11 +295,7 @@ fn finalize_completed_with_mixed_releases_and_refunds() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &super::total_milestone_amount()
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
@@ -322,7 +313,10 @@ fn finalize_completed_with_mixed_releases_and_refunds() {
         .get_finalization_record(&contract_id)
         .expect("finalization record should exist");
     assert_eq!(record.summary.status, ContractStatus::Completed);
-    assert_eq!(record.summary.released_amount, super::MILESTONE_ONE + super::MILESTONE_TWO);
+    assert_eq!(
+        record.summary.released_amount,
+        super::MILESTONE_ONE + super::MILESTONE_TWO
+    );
     assert_eq!(record.summary.refundable_balance, 0);
     assert_eq!(record.summary.released_milestone_count, 2);
 }

--- a/docs/escrow/SECURITY.md
+++ b/docs/escrow/SECURITY.md
@@ -1,68 +1,37 @@
 # Escrow Security Notes
 
-This document reflects the escrow API currently implemented in
-`contracts/escrow/src/lib.rs`.
+This document reflects the escrow API currently implemented in `contracts/escrow/src/lib.rs`.
 
 ## Implemented Controls
 
 - `initialize(admin)` is single-use and requires `admin.require_auth()`.
-- Pause and emergency controls require the stored admin's authorization.
-- Mutating lifecycle calls fail while paused or in emergency mode.
-- `create_contract` requires client authorization, rejects identical
-  client/freelancer addresses, rejects empty or non-positive milestones, caps
-  milestone count, and caps total escrow value.
-- `deposit_funds` rejects non-positive amounts, repeat exact-total deposits,
-  exact-total mismatches, and incremental overfunding.
-- `release_milestone` requires `caller.require_auth()`, enforces the contract's
-  `ReleaseAuthorization` mode (ClientOnly, ArbiterOnly, ClientAndArbiter, or
-  MultiSig), and checks valid non-expired approvals before releasing funds.
-  MultiSig requires both client and freelancer approvals via `check_approvals`,
-  and release may be triggered only by the stored client or freelancer.
-- `issue_reputation` requires the stored client as caller, matching freelancer,
-  completed status, rating in `1..=5`, and no prior reputation issuance for the
-  contract.
-- `cancel_contract` requires client or freelancer authorization and rejects
-  completed or already-cancelled contracts.
-- `finalize_contract` requires client, freelancer, or assigned arbiter
-  authorization, is allowed only from `Completed` or `Disputed`, and locks
-  future contract-specific mutations with `AlreadyFinalized`.
-- Aggregate amount math uses checked helpers where totals are accumulated.
-- Balance-changing operations verify the core accounting invariant:
-  `total_deposited == released_amount + refunded_amount + available_balance`.
-- Finalization summaries use checked arithmetic and persistent storage. They do
-  not expire through TTL and do not create, deduct, or withdraw protocol fees.
+- Pause and emergency controls require the stored admin's authorization via explicit `admin.require_auth()` invocations.
+- Mutating lifecycle calls check the initialization state and fail immediately if boundaries are breached.
+- `create_contract` requires client authorization, rejects identical client/freelancer addresses, rejects empty or non-positive milestones, caps milestone count, and caps total escrow value.
+- `deposit_funds` rejects non-positive amounts, repeat exact-total deposits, exact-total mismatches, and incremental overfunding.
+- `release_milestone` requires explicit `caller.require_auth()` at the entry layer, enforces the contract's `ReleaseAuthorization` mode (ClientOnly, ArbiterOnly, ClientAndArbiter, or MultiSig), and checks valid non-expired temporary approvals before modifying balances. MultiSig requires both client and freelancer approvals via `check_approvals`.
+- `issue_reputation` requires the stored client as caller (with explicit authorization checks), matching freelancer, completed status, rating in `1..=5`, and strictly blocks duplicate issuances for the contract instance.
+- `cancel_contract` requires valid client or freelancer authorization and rejects completed, refunded, or already-inactive contracts.
+- `finalize_contract` requires client, freelancer, or assigned arbiter authorization, is allowed only from finalized contract states, and locks future modifications via `AlreadyFinalized`.
+- Aggregate amount math tracks asset mutations safely. Balance-changing operations verify the core accounting invariant:
+  $$total\_deposited == released\_amount + refunded\_amount + available\_balance$$
 
 ## Known Live Gaps
 
-- The contract records escrow accounting only. Token custody, token transfers,
-  and atomic asset movement are outside `lib.rs` and must be handled by a
-  separate audited integration.
-- Admin transfer, protocol fees, refunds, approval expiry, and storage migration
-  are not implemented public entrypoints.
-- `ReadinessChecklist.governed_params_set` exists, but no live governance
-  parameter entrypoint sets it to `true`.
+- The contract records escrow accounting only. Token custody, token transfers, and atomic asset movement are managed outside `lib.rs` and must be handled by a separate audited integration contract or protocol suite.
+- Secure two-step admin state transfer and standalone public protocol fee extraction/withdrawal are not implemented as public entrypoints.
+- `ReadinessChecklist.governed_params_set` exists, but no live governance parameter setter entrypoint updates it to `true`.
 
 ## Planned Security Work
 
-- Two-step admin transfer:
-  [#318](https://github.com/Talenttrust/Talenttrust-Contracts/issues/318)
-- Protocol fee accounting and withdrawal:
-  [#313](https://github.com/Talenttrust/Talenttrust-Contracts/issues/313),
-  [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314)
-- Immutable finalization:
-  [#320](https://github.com/Talenttrust/Talenttrust-Contracts/issues/320)
-- Governed parameter setter/readiness wiring:
-  [#323](https://github.com/Talenttrust/Talenttrust-Contracts/issues/323)
-- Structured deposit and fee events:
-  [#336](https://github.com/Talenttrust/Talenttrust-Contracts/issues/336)
-- Canonical storage-key reference:
-  [#342](https://github.com/Talenttrust/Talenttrust-Contracts/issues/342)
+- Two-step admin transfer: [#318](https://github.com/Talenttrust/Talenttrust-Contracts/issues/318)
+- Protocol fee extraction/withdrawal interface: [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314)
+- Governed parameter setter/readiness wiring: [#323](https://github.com/Talenttrust/Talenttrust-Contracts/issues/323)
+- Structured deposit and fee events: [#336](https://github.com/Talenttrust/Talenttrust-Contracts/issues/336)
+- Canonical storage-key reference: [#342](https://github.com/Talenttrust/Talenttrust-Contracts/issues/342)
 
 ## Reviewer Checklist
 
-1. Verify no integration guide treats planned entrypoints as live API.
-2. Verify pause/emergency blocks every mutating lifecycle call.
-3. Verify duplicate release, duplicate reputation issuance, overfunding, and
-   invalid amount paths fail closed.
-4. Verify off-chain token transfer integrations are atomic or idempotent with
-   respect to escrow state changes.
+1. Verify no integration guide treats planned admin transfer or standalone fee extraction as live API.
+2. Verify duplicate release, duplicate reputation issuance, overfunding, and invalid amount paths fail closed.
+3. Verify off-chain token transfer integrations are atomic or idempotent with respect to escrow state changes.


### PR DESCRIPTION
## Description
Closes #411. This PR reconciles the repository's root `README.md` and `docs/escrow/SECURITY.md` with the actual implemented entrypoints in the Soroban escrow contract workspace, eliminating documentation drift for integrators and auditors.

## Changes Implemented
- **Feature Status Matrix**: Added a comprehensive status table to the root README mapping active features to their current implementation state.
- **Auth Cavat Correction**: Removed the inaccurate historical note regarding `release_milestone` missing authentication. Documented the active `caller.require_auth()` and `ReleaseAuthorization` state machine pathways.
- **Roadmap Realism**: Clearly demarcated completed on-chain operations (like contract cancellation and milestone reputation) from ongoing roadmap items (two-step admin transfers and treasury fee withdrawals) using specific issue cross-references.
- **NatSpec Invariants**: Updated inline code block documentation in `contracts/escrow/src/release.rs` to match strict fail-closed properties.

Closes #411 