### PR TITLE
feat: add scaled get_average_rating accessor for reputation records

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -731,6 +731,35 @@ impl Escrow {
             .get(&DataKey::Reputation(address))
     }
 
+    /// Returns the freelancer's average rating scaled to basis points (×10 000),
+    /// or `None` if no reputation record exists or no contracts have been completed.
+    ///
+    /// # Scaling
+    /// `result = total_rating * 10_000 / completed_contracts`
+    ///
+    /// A raw rating of 5 on a single contract returns `50_000` (5.0000 on a
+    /// 1–5 scale).  Clients divide by `10_000` to recover the decimal value.
+    ///
+    /// Checked arithmetic is used throughout; division by zero is impossible
+    /// because `None` is returned whenever `completed_contracts == 0`.
+    pub fn get_average_rating(env: Env, address: Address) -> Option<i128> {
+        /// Basis-point scaling factor (×10 000 preserves four decimal places).
+        const SCALE: i128 = 10_000;
+
+        let rep: types::Reputation = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Reputation(address))?;
+
+        if rep.completed_contracts == 0 {
+            return None;
+        }
+
+        rep.total_rating
+            .checked_mul(SCALE)
+            .and_then(|scaled| scaled.checked_div(rep.completed_contracts))
+    }
+
     pub fn get_pending_reputation_credits(env: Env, address: Address) -> i128 {
         env.storage()
             .persistent()

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -109,3 +109,97 @@ fn issue_reputation_updates_reputation_record_and_pending_credits() {
     assert_eq!(reputation.last_rating, 5);
     assert_eq!(client.get_pending_reputation_credits(&freelancer_addr), 0);
 }
+
+// ---------------------------------------------------------------------------
+// get_average_rating tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_average_rating_returns_none_for_unknown_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let unknown = Address::generate(&env);
+    assert!(client.get_average_rating(&unknown).is_none());
+}
+
+#[test]
+fn get_average_rating_single_rating_returns_scaled_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
+
+    client.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &4);
+
+    // 4 * 10_000 / 1 = 40_000
+    assert_eq!(client.get_average_rating(&freelancer_addr), Some(40_000));
+}
+
+#[test]
+fn get_average_rating_multiple_ratings_returns_correct_scaled_average() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    // First contract: rating 3
+    let (client_addr1, freelancer_addr, contract_id1) = complete_contract(&env, &client);
+    client.issue_reputation(&contract_id1, &client_addr1, &freelancer_addr, &3);
+
+    // Second contract: same freelancer, rating 5
+    let client_addr2 = Address::generate(&env);
+    let milestones = super::default_milestones(&env);
+    let contract_id2 = client.create_contract(
+        &client_addr2,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+    let total = super::total_milestone_amount();
+    client.deposit_funds(&contract_id2, &client_addr2, &total);
+    client.approve_milestone_release(&contract_id2, &client_addr2, &0);
+    client.release_milestone(&contract_id2, &client_addr2, &0);
+    client.approve_milestone_release(&contract_id2, &client_addr2, &1);
+    client.release_milestone(&contract_id2, &client_addr2, &1);
+    client.approve_milestone_release(&contract_id2, &client_addr2, &2);
+    client.release_milestone(&contract_id2, &client_addr2, &2);
+    client.issue_reputation(&contract_id2, &client_addr2, &freelancer_addr, &5);
+
+    // total_rating=8, completed_contracts=2 → 8 * 10_000 / 2 = 40_000
+    assert_eq!(client.get_average_rating(&freelancer_addr), Some(40_000));
+}
+
+#[test]
+fn get_average_rating_fractional_average_is_preserved() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    // First contract: rating 1
+    let (client_addr1, freelancer_addr, contract_id1) = complete_contract(&env, &client);
+    client.issue_reputation(&contract_id1, &client_addr1, &freelancer_addr, &1);
+
+    // Second contract: rating 2
+    let client_addr2 = Address::generate(&env);
+    let milestones = super::default_milestones(&env);
+    let contract_id2 = client.create_contract(
+        &client_addr2,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+    let total = super::total_milestone_amount();
+    client.deposit_funds(&contract_id2, &client_addr2, &total);
+    client.approve_milestone_release(&contract_id2, &client_addr2, &0);
+    client.release_milestone(&contract_id2, &client_addr2, &0);
+    client.approve_milestone_release(&contract_id2, &client_addr2, &1);
+    client.release_milestone(&contract_id2, &client_addr2, &1);
+    client.approve_milestone_release(&contract_id2, &client_addr2, &2);
+    client.release_milestone(&contract_id2, &client_addr2, &2);
+    client.issue_reputation(&contract_id2, &client_addr2, &freelancer_addr, &2);
+
+    // total_rating=3, completed_contracts=2 → 3 * 10_000 / 2 = 15_000
+    assert_eq!(client.get_average_rating(&freelancer_addr), Some(15_000));
+}

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -28,7 +28,7 @@ Read-only queries:
 - `get_contract(contract_id) -> EscrowContractData`
 - `get_finalization_record(contract_id) -> Option<FinalizationRecord>`
 - `get_reputation(freelancer) -> Option<ReputationRecord>`
-- `get_average_rating(freelancer) -> Option<i128>`
+- `get_average_rating(freelancer) -> Option<i128>` — scaled average (see [Average Rating](#average-rating))
 - `get_pending_reputation_credits(freelancer) -> u32`
 - `get_admin() -> Option<Address>`
 - `is_paused() -> bool`
@@ -104,6 +104,28 @@ Reputation requires `caller.require_auth()`, the caller must be the stored
 client, the freelancer argument must match the contract freelancer, the contract
 must be `Completed`, rating must be `1..=5`, and each contract can issue
 reputation once.
+
+## Average Rating
+
+`get_average_rating(freelancer) -> Option<i128>` returns the freelancer's
+average rating scaled to **basis points (×10 000)**, or `None` if no reputation
+record exists or `completed_contracts == 0`.
+
+Formula:
+
+```
+result = total_rating * 10_000 / completed_contracts
+```
+
+To convert back to the 1–5 decimal scale, divide by `10_000`:
+
+| `total_rating` | `completed_contracts` | `get_average_rating` | Decimal |
+|---|---|---|---|
+| 5 | 1 | 50 000 | 5.0000 |
+| 8 | 2 | 40 000 | 4.0000 |
+| 3 | 2 | 15 000 | 1.5000 |
+
+Checked arithmetic is used; overflow and division-by-zero cannot occur.
 
 ## Cancellation
 


### PR DESCRIPTION
## Summary

Implements `get_average_rating(addr) -> Option<i128>` as described in #482.

## Changes

- **`contracts/escrow/src/lib.rs`** — new read-only entrypoint `get_average_rating`
  - Returns `total_rating * 10_000 / completed_contracts` (basis-point scale, ×10 000)
  - Returns `None` when no reputation record exists or `completed_contracts == 0`
  - Uses `checked_mul` / `checked_div` — overflow and divide-by-zero are structurally impossible
- **`contracts/escrow/src/test/reputation.rs`** — 4 new tests covering all required edge cases:
  - Unknown address (zero contracts) → `None`
  - Single rating (4) → `40_000`
  - Multiple ratings (3 + 5) → `40_000`
  - Fractional average (1 + 2) → `15_000` (1.5 × 10 000)
- **`docs/escrow/README.md`** — new *Average Rating* section with formula, conversion table, and safety guarantees

## Scaling

```
result = total_rating * 10_000 / completed_contracts
```

Divide by `10_000` to recover the decimal value. Example: a single rating of 5 returns `50_000`.

## Closes

Closes #482