### PR TITLE
test(escrow): fix #423 by covering dispute payout math

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,5 +1,18 @@
 # Step-by-Step Testing Procedure for Cancel Contract State Guardrails
 
+## Dispute Payout Test Matrix
+
+Issue #423 adds focused tests for the pure dispute payout helpers in `contracts/escrow/src/test/dispute.rs`.
+
+| Resolution | Expected client refund | Expected freelancer payout | Security property |
+| --- | --- | --- | --- |
+| `FullRefund` | `available` | `0` | Conserves all available balance for the client |
+| `PartialRefund` | `available - floor(available * 30 / 100)` | `floor(available * 30 / 100)` | Conserves balance with deterministic integer rounding |
+| `FullPayout` | `0` | `available` | Conserves all available balance for the freelancer |
+| `Split(client, freelancer)` | `client` | `freelancer` | Requires non-negative legs and `client + freelancer == available` |
+
+Coverage includes zero available balance, one-stroop rounding, exact split conservation, undersized split rejection, oversized split rejection, checked-add overflow rejection, negative split rejection, and accounting invariant violation when released plus refunded exceeds deposited funds.
+
 ## Quick Summary of What Was Done
 
 You have successfully implemented security guardrails for the `cancel_contract` function in the TalentTrust escrow contract. The fix prevents fund stranding and double-resolution by rejecting cancellation attempts from `Disputed` and `Refunded` states.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -26,6 +26,7 @@
 mod approvals;
 mod create_contract;
 mod deposit;
+mod dispute;
 mod finalize;
 mod governance;
 mod refund;
@@ -33,6 +34,7 @@ mod release;
 mod ttl;
 mod types;
 
+pub use dispute::DisputeResolution;
 pub use migration::PendingClientMigration;
 pub use ttl::PENDING_MIGRATION_TTL_LEDGERS;
 pub use types::{
@@ -40,7 +42,9 @@ pub use types::{
     ReleaseAuthorization, Reputation,
 };
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
+};
 
 #[contract]
 pub struct Escrow;
@@ -72,6 +76,9 @@ pub enum EscrowError {
     NotCompleted = 22,
     FreelancerMismatch = 23,
     InvalidStatusTransition = 24,
+    InvalidDisputeSplit = 25,
+    AccountingInvariantViolated = 26,
+    PotentialOverflow = 27,
 }
 
 #[contracttype]
@@ -80,6 +87,10 @@ pub struct ContractData {
     pub client: Address,
     pub freelancer: Address,
     pub milestones: Vec<i128>,
+}
+
+pub fn safe_add_amounts(a: i128, b: i128) -> Option<i128> {
+    a.checked_add(b)
 }
 
 #[contractimpl]

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -1,4 +1,8 @@
-use crate::{ContractStatus, DepositMode, DisputeResolution, Escrow, EscrowClient, EscrowError};
+use crate::dispute::{final_status_after_resolution, resolution_payouts};
+use crate::{
+    Contract, ContractStatus, DepositMode, DisputeResolution, Escrow, EscrowClient, EscrowError,
+    ReleaseAuthorization,
+};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 fn setup_initialized() -> (Env, Address) {
@@ -13,6 +17,24 @@ fn setup_initialized() -> (Env, Address) {
 
 fn create_client<'a>(env: &'a Env, contract_id: &Address) -> EscrowClient<'a> {
     EscrowClient::new(env, contract_id)
+}
+
+fn payout_contract(
+    env: &Env,
+    funded_amount: i128,
+    released_amount: i128,
+    refunded_amount: i128,
+) -> Contract {
+    Contract {
+        client: Address::generate(env),
+        freelancer: Address::generate(env),
+        arbiter: Some(Address::generate(env)),
+        status: ContractStatus::Disputed,
+        funded_amount,
+        released_amount,
+        refunded_amount,
+        release_authorization: ReleaseAuthorization::ClientAndArbiter,
+    }
 }
 
 fn funded_contract_with_arbiter(
@@ -34,6 +56,149 @@ fn funded_contract_with_arbiter(
     );
     assert!(client.deposit_funds(&contract_id, &deposit_amount));
     (client_addr, freelancer_addr, arbiter_addr, contract_id)
+}
+
+/// Verifies FullRefund conserves all available balance for the client.
+#[test]
+fn resolution_payouts_full_refund_returns_available_to_client() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 100, 20, 10);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::FullRefund),
+        Ok((70, 0))
+    );
+}
+
+/// Verifies FullPayout conserves all available balance for the freelancer.
+#[test]
+fn resolution_payouts_full_payout_returns_available_to_freelancer() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 100, 20, 10);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::FullPayout),
+        Ok((0, 70))
+    );
+}
+
+/// Verifies PartialRefund applies the documented 70/30 split with floor rounding.
+#[test]
+fn resolution_payouts_partial_refund_uses_floor_rounded_70_30_split() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 101, 0, 0);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::PartialRefund),
+        Ok((71, 30))
+    );
+}
+
+/// Verifies PartialRefund handles zero and one-stroop balances without creating value.
+#[test]
+fn resolution_payouts_partial_refund_handles_rounding_boundaries() {
+    let env = Env::default();
+    let zero_available = payout_contract(&env, 0, 0, 0);
+    let one_stroop_available = payout_contract(&env, 1, 0, 0);
+
+    assert_eq!(
+        resolution_payouts(&zero_available, &DisputeResolution::PartialRefund),
+        Ok((0, 0))
+    );
+    assert_eq!(
+        resolution_payouts(&one_stroop_available, &DisputeResolution::PartialRefund),
+        Ok((1, 0))
+    );
+}
+
+/// Verifies Split rejects negative client or freelancer payouts.
+#[test]
+fn resolution_payouts_split_rejects_negative_legs() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 100, 0, 0);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(-1, 101)),
+        Err(EscrowError::InvalidDisputeSplit)
+    );
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(101, -1)),
+        Err(EscrowError::InvalidDisputeSplit)
+    );
+}
+
+/// Verifies Split rejects under-sized and oversized sums that do not equal available balance.
+#[test]
+fn resolution_payouts_split_rejects_non_conserving_sums() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 100, 0, 0);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(40, 59)),
+        Err(EscrowError::InvalidDisputeSplit)
+    );
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(40, 61)),
+        Err(EscrowError::InvalidDisputeSplit)
+    );
+}
+
+/// Verifies Split accepts exact conservation, including zero available balance.
+#[test]
+fn resolution_payouts_split_accepts_exact_splits() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 100, 0, 0);
+    let zero_available = payout_contract(&env, 0, 0, 0);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(40, 60)),
+        Ok((40, 60))
+    );
+    assert_eq!(
+        resolution_payouts(&zero_available, &DisputeResolution::Split(0, 0)),
+        Ok((0, 0))
+    );
+}
+
+/// Verifies Split uses checked addition and rejects overflowing payout sums.
+#[test]
+fn resolution_payouts_split_rejects_overflowing_sum() {
+    let env = Env::default();
+    let contract = payout_contract(&env, i128::MAX, 0, 0);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(i128::MAX, 1)),
+        Err(EscrowError::PotentialOverflow)
+    );
+}
+
+/// Verifies payout math fails closed when released and refunded amounts exceed deposits.
+#[test]
+fn resolution_payouts_rejects_accounting_invariant_violation() {
+    let env = Env::default();
+    let contract = payout_contract(&env, 100, 70, 31);
+
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::FullRefund),
+        Err(EscrowError::AccountingInvariantViolated)
+    );
+}
+
+/// Verifies final status is Refunded only when the full deposit has been refunded.
+#[test]
+fn final_status_after_resolution_marks_refunded_only_for_full_refund() {
+    let env = Env::default();
+    let fully_refunded = payout_contract(&env, 100, 0, 100);
+    let partially_refunded = payout_contract(&env, 100, 30, 70);
+
+    assert_eq!(
+        final_status_after_resolution(&fully_refunded),
+        ContractStatus::Refunded
+    );
+    assert_eq!(
+        final_status_after_resolution(&partially_refunded),
+        ContractStatus::Completed
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #423 

# PR Description

This PR fixes #423 by adding focused coverage for the dispute payout math in the escrow contract.

The tests now call `resolution_payouts` and `final_status_after_resolution` directly, so the most sensitive dispute settlement paths are checked without depending only on higher-level dispute flows. The payout tests verify that each resolution mode conserves the available escrow balance, rejects invalid custom splits, and handles integer rounding deterministically.

The dispute module is also wired into the crate so the tests exercise the real production helper functions in `contracts/escrow/src/dispute.rs`. The public `DisputeResolution` type is re-exported for existing dispute tests, and the payout-specific `EscrowError` variants are defined so the helper can return typed errors for invalid splits, accounting invariant violations, and checked arithmetic overflow.

This matters because dispute resolution controls how escrowed funds are allocated between client and freelancer after a dispute. The new tests cover full refund, partial refund, full payout, custom split conservation, zero balance behavior, rounding boundaries, and overflow protection.

# Changes Made

- Updated `contracts/escrow/src/test/dispute.rs` with direct tests for `resolution_payouts`.
- Covered `FullRefund` returning `(available, 0)`.
- Covered `FullPayout` returning `(0, available)`.
- Covered `PartialRefund` using the documented 70/30 split with integer floor rounding.
- Covered zero available balance and one-stroop rounding boundaries.
- Covered `Split` accepting exact conserving splits, including `(0, 0)`.
- Covered `Split` rejecting negative legs, undersized sums, oversized sums, and checked-add overflow.
- Covered `AccountingInvariantViolated` when released plus refunded funds exceed funded amount.
- Covered `final_status_after_resolution` returning `Refunded` only for full refunds and `Completed` otherwise.
- Updated `contracts/escrow/src/lib.rs` to wire the dispute module, re-export `DisputeResolution`, add payout error variants, and expose the checked-add helper used by the payout function.
- #423 updated `TESTING_GUIDE.md` with the dispute payout test matrix.

# Testing

Commands run:

```bash
rustfmt --check contracts/escrow/src/test/dispute.rs
```

Result: passed.

```bash
git diff --check
```

Result: passed.

```bash
cargo check -p escrow --lib
```

Result: failed on pre-existing repository compile blockers outside #423. The first blockers are duplicate definitions in `contracts/escrow/src/types.rs`, unresolved `migration` module wiring, missing finalization exports, and duplicate generated contract client methods for release/refund entrypoints.

Earlier validation attempts also ran:

```bash
cargo fmt --all -- --check
cargo build
cargo test
cargo test -p escrow dispute --lib
```

Result: blocked by the same existing formatting and compile issues outside the dispute payout test scope.

# Scope Notes

- Test-focused escrow contract change.
- Minimal contract module wiring was added so the tests exercise the real dispute payout helpers.
- No frontend changes.
- No backend service changes.
- No dependency changes.
- No dispute payout business logic changes.