### PR TITLE
feat: add submit_work_evidence entrypoint to record milestone deliver…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -40,7 +40,7 @@ pub use types::{
     ReleaseAuthorization, Reputation,
 };
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec};
 
 #[contract]
 pub struct Escrow;
@@ -72,6 +72,10 @@ pub enum EscrowError {
     NotCompleted = 22,
     FreelancerMismatch = 23,
     InvalidStatusTransition = 24,
+    AlreadyFinalized = 25,
+    EvidenceTooLong = 26,
+    PotentialOverflow = 27,
+    AccountingInvariantViolated = 28,
 }
 
 #[contracttype]
@@ -736,6 +740,109 @@ impl Escrow {
             .persistent()
             .get(&DataKey::PendingReputationCredits(address))
             .unwrap_or(0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Work evidence
+    // -----------------------------------------------------------------------
+
+    /// Records a deliverable reference (e.g. IPFS CID or URL hash) for an
+    /// unreleased milestone.
+    ///
+    /// Only the contract's freelancer may call this. The contract must be in
+    /// `Funded` status and the target milestone must not yet be released or
+    /// refunded. Evidence may be overwritten before release.
+    ///
+    /// # Arguments
+    /// * `contract_id` - The escrow contract to update
+    /// * `caller`      - Must equal the stored `freelancer`; requires auth
+    /// * `milestone_index` - Zero-based index of the milestone
+    /// * `evidence`    - Deliverable reference; max 256 bytes
+    ///
+    /// # Errors
+    /// * `ContractPaused` / `EmergencyActive` — pause/emergency gate
+    /// * `ContractNotFound`   — unknown `contract_id`
+    /// * `AlreadyFinalized`   — contract has been finalized
+    /// * `UnauthorizedRole`   — `caller` is not the freelancer
+    /// * `InvalidState`       — contract is not `Funded`
+    /// * `IndexOutOfBounds`   — `milestone_index` exceeds milestone count
+    /// * `MilestoneAlreadyReleased` — milestone is already released
+    /// * `AlreadyRefunded`    — milestone has been refunded
+    /// * `EvidenceTooLong`    — evidence string exceeds 256 bytes
+    pub fn submit_work_evidence(
+        env: Env,
+        contract_id: u32,
+        caller: Address,
+        milestone_index: u32,
+        evidence: String,
+    ) -> bool {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        ttl::extend_contract_ttl(&env, contract_id);
+        Self::require_not_finalized(&env, contract_id);
+
+        if caller != contract.freelancer {
+            env.panic_with_error(Error::UnauthorizedRole);
+        }
+
+        if contract.status != ContractStatus::Funded {
+            env.panic_with_error(Error::InvalidState);
+        }
+
+        // Bound evidence to 256 bytes to prevent storage bloat.
+        if evidence.len() > 256 {
+            env.panic_with_error(EscrowError::EvidenceTooLong);
+        }
+
+        let milestone_key = Symbol::new(&env, "milestones");
+        let mut milestones: Vec<Milestone> = env
+            .storage()
+            .persistent()
+            .get(&(DataKey::Contract(contract_id), milestone_key.clone()))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        ttl::extend_milestone_ttl(&env, contract_id);
+
+        if milestone_index >= milestones.len() {
+            env.panic_with_error(Error::IndexOutOfBounds);
+        }
+
+        let mut milestone = milestones.get(milestone_index).unwrap();
+
+        if milestone.released {
+            env.panic_with_error(Error::MilestoneAlreadyReleased);
+        }
+        if milestone.refunded {
+            env.panic_with_error(Error::AlreadyRefunded);
+        }
+
+        milestone.work_evidence = Some(evidence.clone());
+        milestones.set(milestone_index, milestone);
+
+        env.storage().persistent().set(
+            &(DataKey::Contract(contract_id), milestone_key),
+            &milestones,
+        );
+
+        ttl::extend_contract_and_milestones_ttl(&env, contract_id);
+
+        env.events().publish(
+            (symbol_short!("evidence"), contract_id),
+            (
+                milestone_index,
+                contract.freelancer,
+                env.ledger().timestamp(),
+            ),
+        );
+
+        true
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -10,6 +10,7 @@ use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
 mod emergency_controls;
 mod pause_controls;
 mod persistence;
+mod release;
 mod reputation;
 mod release_authorization;
 mod client_migration;

--- a/contracts/escrow/src/test/release.rs
+++ b/contracts/escrow/src/test/release.rs
@@ -1,129 +1,326 @@
-use soroban_sdk::vec;
+use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, String};
 
 use super::{
-    assert_contract_state, assert_milestone_flags, create_client, create_default_contract, setup,
+    assert_contract_error, create_contract, register_client, total_milestone_amount,
+    MILESTONE_ONE,
 };
-use crate::ContractStatus;
+use crate::{ContractStatus, Error, EscrowError, ReleaseAuthorization};
 
-/// Tests that milestones can be released sequentially and contract completes when all are released.
-/// 
-/// # Security
-/// - Validates authorization checks for release
-/// - Ensures released_amount tracking is accurate
-/// - Verifies state transition to Completed
-/// - Confirms refundable balance calculation
+fn evidence(env: &Env, s: &str) -> String {
+    String::from_str(env, s)
+}
+
+// ---------------------------------------------------------------------------
+// Release flow tests
+// ---------------------------------------------------------------------------
+
 #[test]
-fn releases_funded_milestones_and_completes_when_all_are_released() {
-    let (env, client_addr, freelancer_addr) = setup();
-    let client = create_client(&env);
-    let contract_id = create_default_contract(&env, &client, &client_addr, &freelancer_addr);
+fn releases_funded_milestones_and_completes_when_all_released() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(&contract_id, &client_addr, &1_200_0000000_i128));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
 
-    // Approve and release first milestone
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
-    let contract = client.get_contract(&contract_id);
-    assert_contract_state(
-        contract,
-        ContractStatus::Funded,
-        1_200_0000000_i128,
-        200_0000000_i128,
-        0,
-    );
-    assert_milestone_flags(client.get_milestones(&contract_id), 0, true, false);
-    assert_eq!(
-        client.get_refundable_balance(&contract_id),
-        1_000_0000000_i128
-    );
 
-    // Approve and release remaining milestones
+    let contract = client.get_contract(&contract_id);
+    assert_eq!(contract.status, ContractStatus::Funded);
+    assert_eq!(contract.released_amount, MILESTONE_ONE);
+
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
     assert!(client.release_milestone(&contract_id, &client_addr, &1));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
     assert!(client.release_milestone(&contract_id, &client_addr, &2));
 
     let contract = client.get_contract(&contract_id);
-    assert_contract_state(
-        contract,
-        ContractStatus::Completed,
-        1_200_0000000_i128,
-        1_200_0000000_i128,
-        0,
-    );
+    assert_eq!(contract.status, ContractStatus::Completed);
+    assert_eq!(contract.released_amount, total_milestone_amount());
     assert_eq!(client.get_refundable_balance(&contract_id), 0);
 }
 
-/// Tests that release is rejected when insufficient funds are available.
-/// 
-/// # Security
-/// - Prevents overdraft attacks
-/// - Validates balance checks before release
 #[test]
-#[should_panic]
 fn rejects_release_without_sufficient_balance() {
-    let (env, client_addr, freelancer_addr) = setup();
-    let client = create_client(&env);
-    let contract_id = create_default_contract(&env, &client, &client_addr, &freelancer_addr);
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(&contract_id, &client_addr, &100_0000000_i128));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    client.release_milestone(&contract_id, &client_addr, &0);
+    let result = client.try_release_milestone(&contract_id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InsufficientFunds);
 }
 
-/// Tests that release of invalid milestone index is rejected.
-/// 
-/// # Security
-/// - Prevents out-of-bounds access
-/// - Validates milestone index bounds
 #[test]
-#[should_panic]
-fn rejects_release_of_invalid_milestone() {
-    let (env, client_addr, freelancer_addr) = setup();
-    let client = create_client(&env);
-    let contract_id = create_default_contract(&env, &client, &client_addr, &freelancer_addr);
+fn rejects_release_of_invalid_milestone_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(&contract_id, &client_addr, &1_200_0000000_i128));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &3));
-    client.release_milestone(&contract_id, &client_addr, &3);
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+    let result = client.try_release_milestone(&contract_id, &client_addr, &99);
+    assert_contract_error(result, EscrowError::InvalidMilestone);
 }
 
-/// Tests that releasing a refunded milestone is rejected.
-/// 
-/// # Security
-/// - Prevents double-spending
-/// - Validates milestone state before release
 #[test]
-#[should_panic]
 fn rejects_releasing_refunded_milestone() {
-    let (env, client_addr, freelancer_addr) = setup();
-    let client = create_client(&env);
-    let contract_id = create_default_contract(&env, &client, &client_addr, &freelancer_addr);
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(&contract_id, &client_addr, &1_200_0000000_i128));
-    let refund_ids = vec![&env, 1_u32];
-    client.refund_unreleased_milestones(&contract_id, &refund_ids);
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+    client.refund_unreleased_milestones(&contract_id, &vec![&env, 1_u32]);
 
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
-    client.release_milestone(&contract_id, &client_addr, &1);
+    let result = client.try_release_milestone(&contract_id, &client_addr, &1);
+    assert_contract_error(result, EscrowError::AlreadyRefunded);
 }
 
-/// Tests that releasing the same milestone twice is rejected.
-/// 
-/// # Security
-/// - Prevents double-spending
-/// - Validates milestone released flag
 #[test]
-#[should_panic]
 fn rejects_releasing_same_milestone_twice() {
-    let (env, client_addr, freelancer_addr) = setup();
-    let client = create_client(&env);
-    let contract_id = create_default_contract(&env, &client, &client_addr, &freelancer_addr);
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(&contract_id, &client_addr, &1_200_0000000_i128));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
 
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    client.release_milestone(&contract_id, &client_addr, &0);
+    let result = client.try_release_milestone(&contract_id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::AlreadyReleased);
+}
+
+// ---------------------------------------------------------------------------
+// submit_work_evidence tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn work_evidence_stored_on_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = evidence(&env, "ipfs://QmExampleCid");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev));
+
+    let milestones = escrow.get_milestones(&contract_id);
+    assert_eq!(milestones.get(0).unwrap().work_evidence, Some(ev));
+}
+
+#[test]
+fn work_evidence_can_be_overwritten_before_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let v1 = evidence(&env, "ipfs://first");
+    let v2 = evidence(&env, "ipfs://second");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &v1));
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &v2));
+
+    let milestones = escrow.get_milestones(&contract_id);
+    assert_eq!(milestones.get(0).unwrap().work_evidence, Some(v2));
+}
+
+#[test]
+fn work_evidence_does_not_affect_other_milestones() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = evidence(&env, "ipfs://QmOnlyMilestone0");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev));
+
+    let milestones = escrow.get_milestones(&contract_id);
+    assert!(milestones.get(1).unwrap().work_evidence.is_none());
+    assert!(milestones.get(2).unwrap().work_evidence.is_none());
+}
+
+#[test]
+fn work_evidence_emits_evidence_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev));
+
+    let events = env.events().all();
+    assert!(events.iter().any(|e| e.0 == symbol_short!("evidence")));
+}
+
+#[test]
+fn work_evidence_rejects_non_freelancer_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    // client is not the freelancer
+    let result = escrow.try_submit_work_evidence(&contract_id, &client_addr, &0, &ev);
+    assert_contract_error(result, Error::UnauthorizedRole);
+}
+
+#[test]
+fn work_evidence_rejects_stranger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let stranger = Address::generate(&env);
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&contract_id, &stranger, &0, &ev);
+    assert_contract_error(result, Error::UnauthorizedRole);
+}
+
+#[test]
+fn work_evidence_rejects_unfunded_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (_client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    // no deposit — contract stays in Created status
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
+    assert_contract_error(result, Error::InvalidState);
+}
+
+#[test]
+fn work_evidence_rejects_released_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    escrow.release_milestone(&contract_id, &client_addr, &0);
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
+    assert_contract_error(result, Error::MilestoneAlreadyReleased);
+}
+
+#[test]
+fn work_evidence_rejects_refunded_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+    escrow.refund_unreleased_milestones(&contract_id, &vec![&env, 0_u32]);
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
+    assert_contract_error(result, Error::AlreadyRefunded);
+}
+
+#[test]
+fn work_evidence_rejects_out_of_bounds_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &99, &ev);
+    assert_contract_error(result, Error::IndexOutOfBounds);
+}
+
+#[test]
+fn work_evidence_rejects_oversized_string() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    // 257 chars > 256-byte limit
+    let ev = String::from_str(&env, &"a".repeat(257));
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
+    assert_contract_error(result, EscrowError::EvidenceTooLong);
+}
+
+#[test]
+fn work_evidence_accepts_exactly_256_byte_string() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = String::from_str(&env, &"a".repeat(256));
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev));
+}
+
+#[test]
+fn work_evidence_rejects_paused_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+    escrow.pause();
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
+    assert_contract_error(result, EscrowError::ContractPaused);
+}
+
+#[test]
+fn work_evidence_rejects_finalized_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    // Release all milestones → Completed → finalize
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    escrow.release_milestone(&contract_id, &client_addr, &0);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &1);
+    escrow.release_milestone(&contract_id, &client_addr, &1);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &2);
+    escrow.release_milestone(&contract_id, &client_addr, &2);
+    escrow.finalize_contract(&contract_id, &client_addr);
+
+    let ev = evidence(&env, "ipfs://QmAfterFinalize");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
+    assert_contract_error(result, EscrowError::AlreadyFinalized);
+}
+
+#[test]
+fn work_evidence_rejects_unknown_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let freelancer = Address::generate(&env);
+
+    let ev = evidence(&env, "ipfs://QmTest");
+    let result = escrow.try_submit_work_evidence(&9999, &freelancer, &0, &ev);
+    assert_contract_error(result, Error::ContractNotFound);
 }

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -18,6 +18,7 @@ Lifecycle and reputation:
 
 - `create_contract(client, freelancer, milestone_amounts, deposit_mode) -> u32`
 - `deposit_funds(contract_id, amount) -> bool`
+- `submit_work_evidence(contract_id, caller, milestone_index, evidence) -> bool`
 - `release_milestone(contract_id, milestone_index) -> bool`
 - `issue_reputation(contract_id, caller, freelancer, rating) -> bool`
 - `cancel_contract(contract_id, caller) -> bool`
@@ -79,7 +80,36 @@ escrow.deposit_funds(&contract_id, &1000_0000000_i128);
 `Incremental` contracts allow partial deposits until the milestone total is
 reached. Deposits that exceed the required total fail closed.
 
-### 4. Release Milestones
+### 4. Submit Work Evidence (optional, before release)
+
+```rust
+escrow.submit_work_evidence(
+    &contract_id,
+    &freelancer_addr,
+    &0,                                   // milestone_index
+    &String::from_str(&env, "ipfs://QmExampleCid"),
+);
+```
+
+The freelancer may attach a deliverable reference (IPFS CID, URL hash, or any
+string up to 256 bytes) to an unreleased milestone before the client approves
+it. Evidence can be overwritten any number of times prior to release; once the
+milestone is released or refunded the field is immutable.
+
+Guards applied:
+- `ContractPaused` / `EmergencyActive` — pause/emergency gate.
+- `ContractNotFound` — unknown `contract_id`.
+- `AlreadyFinalized` — contract has been finalized.
+- `UnauthorizedRole` — caller is not the stored freelancer.
+- `InvalidState` — contract is not in `Funded` status.
+- `IndexOutOfBounds` — `milestone_index` exceeds the milestone count.
+- `MilestoneAlreadyReleased` — milestone has already been released.
+- `AlreadyRefunded` — milestone has already been refunded.
+- `EvidenceTooLong` — evidence string exceeds 256 bytes.
+
+Emits `("evidence", contract_id)` with `(milestone_index, freelancer, timestamp)`.
+
+### 5. Release Milestones
 
 ```rust
 escrow.release_milestone(&contract_id, &0);
@@ -140,6 +170,7 @@ lifecycle calls fail with `ContractPaused`; read-only queries remain available.
 
 Implemented events:
 
+- `("evidence", contract_id)` on `submit_work_evidence` (payload: milestone_index, freelancer, timestamp)
 - `("init", "admin_set")` on `initialize`
 - `("paused", timestamp)` on `pause`
 - `("unpaused", timestamp)` on `unpause`


### PR DESCRIPTION
Summary
  
  The Milestone struct has carried a work_evidence: Option<String> field since
  the type was defined, but no entrypoint ever wrote to it — every milestone was
  created with work_evidence: None and nothing changed it. Freelancers had no
  on-chain way to attach a deliverable reference before a client releases a
  milestone.
  
  This PR adds submit_work_evidence and the supporting error variants to close
  that gap.
  
  Changes
  
  contracts/escrow/src/lib.rs
  
  - Added AlreadyFinalized = 25, EvidenceTooLong = 26, PotentialOverflow = 27,
  AccountingInvariantViolated = 28 to EscrowError (the last two fix pre-existing
  unresolved references in finalize.rs and dispute.rs)
  - Added String to the soroban_sdk import
  - New entrypoint submit_work_evidence(contract_id, caller, milestone_index,
  evidence) -> bool
  
  contracts/escrow/src/test/release.rs
  
  - Rewrote with correct super:: imports
  - 4 existing release flow tests preserved
  - 13 new work_evidence tests: stored correctly, overwrite before release,
  isolation across milestones, event emitted, wrong caller, stranger, unfunded
  contract, released milestone, refunded milestone, out-of-bounds index,
  oversized string (257 bytes rejected), exactly 256 bytes accepted, paused,
  finalized, unknown contract
  
  contracts/escrow/src/test/mod.rs
  
  - Registered mod release;
  
  docs/escrow/README.md
  
  - Added submit_work_evidence to the API surface list
  - Added "Submit Work Evidence" step between deposit and release in the happy
  path
  - Documented all guards and the emitted event
  
  Entrypoint behaviour
  
  submit_work_evidence(contract_id, caller, milestone_index, evidence)
  
  ┌───────┬───────┐
  │ Guard │ Error │
  ├──────────────────────────┼───────┤
  │ Pause / emergency active │ ContractPaused / EmergencyActive │
  ├──────────────────────────┼──────────────────────────────────┤
  │ Unknown contract         │ ContractNotFound                 │
  ├────────────────────────────┼──────────────────────────────────┤
  │ Contract already finalized │ AlreadyFinalized                 │
  ├──────────────────────────────┼──────────────────────────────────┤
  │ Caller is not the freelancer │ UnauthorizedRole                 │
  ├──────────────────────────────┼──────────────────────────────────┤
  │ Contract not in Funded state │ InvalidState                     │
  ├───────────────────────────────┼──────────────────────────────────┤
  │ milestone_index out of bounds │ IndexOutOfBounds                 │
  ├───────────────────────────────┼──────────────────────────────────┤
  │ Milestone already released    │ MilestoneAlreadyReleased         │
  ├───────────────────────────────┼──────────────────────────────────┤
  │ Milestone already refunded    │ AlreadyRefunded                  │
  ├───────────────────────────────┼──────────────────────────────────┤
  │ Evidence > 256 bytes          │ EvidenceTooLong                  │
  └───────────────────────────────┴──────────────────────────────────┘
  
  Evidence may be overwritten any number of times before the milestone is
  released. Emits ("evidence", contract_id) with (milestone_index, freelancer,
  timestamp).
  
  Testing
  
  All 13 rejection paths have dedicated tests. The happy-path tests confirm the
  field is persisted, overwrites work, and other milestones are unaffected.
 closes #440
