### PR TITLE
test(escrow): cover client-migration TTL window boundary; doc migration window

### DIFF
--- a/contracts/escrow/src/test/client_migration.rs
+++ b/contracts/escrow/src/test/client_migration.rs
@@ -1,16 +1,14 @@
 #![cfg(test)]
 
+use crate::migration::PendingClientMigration;
+use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use crate::{
     types::{ContractStatus, DataKey},
     Contract, Escrow, EscrowClient, EscrowError,
 };
-use crate::migration::PendingClientMigration;
-use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use soroban_sdk::{
-    testutils::Address as _,
-    testutils::Ledger as _,
-    testutils::LedgerInfo,
-    Address, Env, IntoVal, Symbol, Val,
+    testutils::Address as _, testutils::Ledger as _, testutils::LedgerInfo, Address, Env, IntoVal,
+    Symbol, Val,
 };
 
 use super::{assert_contract_error, create_contract, register_client, total_milestone_amount};
@@ -120,7 +118,7 @@ fn non_proposed_address_cannot_accept_migration() {
 
     let (client_addr, freelancer_addr, id) = create_contract(&env, &client);
     let new_client = Address::generate(&env);
-    let attacker   = Address::generate(&env);
+    let attacker = Address::generate(&env);
 
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
 
@@ -158,14 +156,14 @@ fn expired_proposal_cannot_be_accepted() {
     // Set max_entry_ttl high enough so the proposal can be stored without hitting the cap.
     let initial = env.ledger().get();
     env.ledger().set(LedgerInfo {
-        sequence_number:          initial.sequence_number,
-        timestamp:                initial.timestamp,
-        protocol_version:         initial.protocol_version,
-        network_id:               initial.network_id.clone(),
-        base_reserve:             initial.base_reserve,
-        min_temp_entry_ttl:       1,
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
-        max_entry_ttl:            PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
     });
 
     let client = register_client(&env);
@@ -173,19 +171,22 @@ fn expired_proposal_cannot_be_accepted() {
     let new_client = Address::generate(&env);
 
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
-    assert!(client.has_pending_client_migration(&id), "proposal must exist before expiry");
+    assert!(
+        client.has_pending_client_migration(&id),
+        "proposal must exist before expiry"
+    );
 
     // Advance the ledger past the TTL. Soroban evicts temporary entries beyond max_entry_ttl.
     let current = env.ledger().get();
     env.ledger().set(LedgerInfo {
-        sequence_number:  current.sequence_number + PENDING_MIGRATION_TTL_LEDGERS + 1,
-        timestamp:        current.timestamp + u64::from(PENDING_MIGRATION_TTL_LEDGERS) * 5,
+        sequence_number: current.sequence_number + PENDING_MIGRATION_TTL_LEDGERS + 1,
+        timestamp: current.timestamp + u64::from(PENDING_MIGRATION_TTL_LEDGERS) * 5,
         protocol_version: current.protocol_version,
-        network_id:       [0u8; 32].into(),
-        base_reserve:     current.base_reserve,
-        min_temp_entry_ttl:       1,
+        network_id: [0u8; 32].into(),
+        base_reserve: current.base_reserve,
+        min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: 1,
-        max_entry_ttl:            65_536,
+        max_entry_ttl: 65_536,
     });
 
     // has_pending returns false — entry is evicted
@@ -198,6 +199,70 @@ fn expired_proposal_cannot_be_accepted() {
     assert_contract_error(
         client.try_accept_client_migration(&id, &new_client),
         EscrowError::InvalidState,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3b – acceptance at the last live ledger inside the TTL window succeeds
+// ---------------------------------------------------------------------------
+
+/// Complements `expired_proposal_cannot_be_accepted`: a proposal accepted on
+/// the final ledger *before* `expires_at_ledger` must still succeed and
+/// transfer client rights.  This pins the inclusive boundary of the migration
+/// window so an off-by-one in the TTL handling (evicting one ledger early)
+/// would be caught.
+#[test]
+fn proposal_accepted_at_window_boundary_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Give temporary entries enough head-room to live for the full TTL.
+    let initial = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+    });
+
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let new_client = Address::generate(&env);
+
+    assert!(client.propose_client_migration(&id, &client_addr, &new_client));
+
+    let pending: PendingClientMigration = client.get_pending_client_migration(&id);
+    let expires_at = pending.expires_at_ledger;
+
+    // Advance to the last ledger that is still strictly inside the window.
+    let current = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: expires_at - 1,
+        timestamp: current.timestamp + 5,
+        protocol_version: current.protocol_version,
+        network_id: current.network_id.clone(),
+        base_reserve: current.base_reserve,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+    });
+
+    // Still live at the boundary.
+    assert!(
+        client.has_pending_client_migration(&id),
+        "proposal must remain live on the last ledger before expiry"
+    );
+
+    // Acceptance at the boundary succeeds and updates contract.client.
+    assert!(client.accept_client_migration(&id, &new_client));
+    assert_eq!(client.get_contract(&id).client, new_client);
+    assert!(
+        !client.has_pending_client_migration(&id),
+        "pending record must be cleared after a boundary acceptance"
     );
 }
 
@@ -340,7 +405,7 @@ fn only_current_client_may_propose_migration() {
 
     let (_client_addr, freelancer_addr, id) = create_contract(&env, &client);
     let new_client = Address::generate(&env);
-    let attacker   = Address::generate(&env);
+    let attacker = Address::generate(&env);
 
     // Freelancer as proposer is rejected
     assert_contract_error(
@@ -433,7 +498,10 @@ fn migration_allowed_on_partially_funded_status() {
 
     // Deposit less than the full milestone total → PartiallyFunded
     client.deposit_funds(&id, &client_addr, &super::MILESTONE_ONE);
-    assert_eq!(client.get_contract(&id).status, ContractStatus::PartiallyFunded);
+    assert_eq!(
+        client.get_contract(&id).status,
+        ContractStatus::PartiallyFunded
+    );
 
     let new_client = Address::generate(&env);
     assert!(client.propose_client_migration(&id, &client_addr, &new_client));
@@ -480,8 +548,7 @@ fn pending_migration_expiry_matches_ttl_constant() {
         "expires_at_ledger must equal requested_at + PENDING_MIGRATION_TTL_LEDGERS"
     );
     assert_eq!(
-        pending.requested_at_ledger,
-        ledger_before,
+        pending.requested_at_ledger, ledger_before,
         "requested_at_ledger must equal the ledger at proposal time"
     );
 }

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -129,6 +129,41 @@ The contract writes one immutable `FinalizationRecord` containing the finalizer,
 ledger timestamp, and a `ContractSummary` snapshot. After the record exists,
 contract-specific mutating calls reject with `AlreadyFinalized`.
 
+## Client Migration
+
+```rust
+escrow.propose_client_migration(&contract_id, &current_client, &new_client);
+escrow.accept_client_migration(&contract_id, &new_client);
+```
+
+Client migration is a two-step, time-boxed handover of the `client` role on an
+existing contract:
+
+1. `propose_client_migration` requires `current_client.require_auth()`, the
+   caller must be the stored client, and the proposed address must not be the
+   current client or the freelancer. It stores a `PendingClientMigration` record
+   in temporary storage.
+2. `accept_client_migration` requires `new_client.require_auth()` and the
+   acceptor must match the proposed address; on success it updates
+   `contract.client` and clears the pending record.
+
+### Migration window (TTL)
+
+The pending record is stored with a fixed time-to-live of
+`PENDING_MIGRATION_TTL_LEDGERS = LEDGERS_PER_DAY * 21` ledgers — roughly **21
+days** at ~5s/ledger. The record's `expires_at_ledger` is set to
+`requested_at_ledger + PENDING_MIGRATION_TTL_LEDGERS`.
+
+- **Within the window** (current ledger `< expires_at_ledger`): acceptance by
+  the proposed address succeeds and transfers client rights.
+- **After the window**: Soroban auto-evicts the temporary entry, so
+  `read_if_live` returns `None`. `has_pending_client_migration` then reports
+  `false` and `accept_client_migration` fails with `InvalidState`.
+
+Security assumption: an expired proposal cannot transfer client rights. Once the
+TTL lapses the stale proposal is unrecoverable; the current client must submit a
+fresh `propose_client_migration` call to start a new window.
+
 ## Pause and Emergency Controls
 
 `pause`, `unpause`, `activate_emergency_pause`, and `resolve_emergency` require
@@ -168,9 +203,10 @@ deposit and fee events are planned in
 - Accounting is checked after balance-changing operations.
 - The contract stores accounting state only; token custody and token transfers
   are not implemented in `lib.rs` and must be handled by an audited integration.
-- Storage uses persistent keys. TTL constants exist for planned pending approval
-  and migration flows, but no current public entrypoint writes those pending
-  records.
+- Storage uses persistent keys for live contract state. Pending client
+  migrations are written to temporary storage with a 21-day TTL (see
+  [Client Migration](#client-migration)); the pending-approval TTL constant
+  exists for a planned approval flow with no current writing entrypoint.
 
 ## Planned Features
 


### PR DESCRIPTION

Adds a boundary-acceptance test to client_migration.rs that complements the existing expiry test: a proposal accepted on the last ledger before expires_at_ledger still succeeds and transfers contract.client. This pins the inclusive edge of the 21-day migration window so an off-by-one TTL eviction would be caught.

Documents the migration window in docs/escrow/README.md (new "Client Migration" section with the PENDING_MIGRATION_TTL_LEDGERS = 21-day TTL, the within-window vs expired behavior, and the security assumption that expired proposals cannot transfer client rights). Corrects the stale security note that claimed no entrypoint writes pending migration records.

No production change. Scoped strictly to issue #468.

Note: the crate does not currently compile on this branch's base (main); the pre-existing breakage is unrelated to #468 (duplicated type definitions in types.rs and duplicate release/refund entrypoints in lib.rs, plus a missing `mod migration;` declaration). cargo build/test therefore cannot be run to green here; cargo fmt --all --check passes for the changed test file.
closes #468 
