### PR TITLE
#400 Bump persistent TTL for governance, finalization, and reputation storage keys

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -160,6 +160,8 @@ pub fn finalize_contract_impl(env: &Env, contract_id: u32, finalizer: Address) -
         .persistent()
         .set(&Escrow::finalization_key(contract_id), &record);
 
+    crate::ttl::extend_finalization_ttl(&env, contract_id);
+
     env.events().publish(
         (symbol_short!("finalized"), contract_id),
         (finalizer, record.timestamp),
@@ -170,6 +172,7 @@ pub fn finalize_contract_impl(env: &Env, contract_id: u32, finalizer: Address) -
 
 /// Return immutable close metadata for `contract_id`, if it has been finalized.
 pub fn get_finalization_record_impl(env: &Env, contract_id: u32) -> Option<FinalizationRecord> {
+    crate::ttl::extend_finalization_ttl(env, contract_id);
     env.storage()
         .persistent()
         .get(&Escrow::finalization_key(contract_id))

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -36,6 +36,8 @@ impl super::Escrow {
         env.storage()
             .persistent()
             .set(&DataKey::ProtocolFeeBps, &new_bps);
+        crate::ttl::extend_protocol_fee_bps_ttl(&env);
+        crate::ttl::extend_admin_ttl(&env);
 
         env.events().publish(
             (Symbol::new(env, "protocol_fee_bps"),),

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -140,6 +140,7 @@ impl Escrow {
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Initialized, &true);
         env.storage().persistent().set(&DataKey::Admin, &admin);
+        ttl::extend_admin_ttl(&env);
         env.storage()
             .persistent()
             .set(&DataKey::NextContractId, &1u32);
@@ -164,6 +165,7 @@ impl Escrow {
 
     /// Returns the stored governance admin address.
     pub fn get_admin(env: Env) -> Option<Address> {
+        ttl::extend_admin_ttl(&env);
         env.storage().persistent().get(&DataKey::Admin)
     }
 
@@ -228,21 +230,68 @@ impl Escrow {
         create_contract::create_contract_impl(&env, client, freelancer, arbiter, milestones, release_authorization)
     }
 
-    /// Deposits funds into the contract. Transitions to Funded status when fully funded.
+    /// Accept a contract as the assigned freelancer, transitioning status from
+    /// `Created` to `Accepted`.
+    ///
+    /// This gives the freelancer an on-chain opt-in before any funds are locked.
+    /// Acceptance is optional — `deposit_funds` is permitted from both `Created`
+    /// and `Accepted` so client-first funding workflows remain unblocked.
     ///
     /// # Arguments
-    /// * `env` - The contract environment
-    /// * `contract_id` - The contract ID
-    /// * `caller` - The address of the caller (must be the client)
-    /// * `amount` - The amount to deposit (in stroops)
+    /// * `contract_id` — the contract to accept
+    /// * `freelancer`  — must match the stored freelancer; requires `require_auth()`
     ///
-    /// # Returns
-    /// `true` if deposit was successful
+    /// # Errors
+    /// * `ContractNotFound`        — unknown `contract_id`
+    /// * `FreelancerMismatch`      — `freelancer` does not match stored address
+    /// * `InvalidStatusTransition` — contract is not in `Created` status
+    /// * `ContractPaused`          — pause or emergency controls are active
+    /// * `AlreadyFinalized`        — contract has already been finalized
+    pub fn accept_contract(env: Env, contract_id: u32, freelancer: Address) -> bool {
+        Self::require_not_paused(&env);
+        freelancer.require_auth();
+
+        let mut contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+
+        ttl::extend_contract_ttl(&env, contract_id);
+        Self::require_not_finalized(&env, contract_id);
+
+        if freelancer != contract.freelancer {
+            env.panic_with_error(EscrowError::FreelancerMismatch);
+        }
+
+        if contract.status != ContractStatus::Created {
+            env.panic_with_error(EscrowError::InvalidStatusTransition);
+        }
+
+        // ── CEI: Effect before any future interaction ──────────────────────
+        contract.status = ContractStatus::Accepted;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &contract);
+        ttl::extend_contract_ttl(&env, contract_id);
+
+        env.events().publish(
+            (Symbol::new(&env, "accepted"), contract_id),
+            (freelancer, env.ledger().timestamp()),
+        );
+
+        true
+    }
+
+    /// Deposits funds into the contract. Transitions to Funded status when fully funded.
+    ///
+    /// Accepts deposits from contracts in `Created` or `Accepted` status, so
+    /// client-first funding and freelancer-acceptance-first workflows both work.
     ///
     /// # Errors
     /// * `AmountMustBePositive` - If amount is <= 0
     /// * `ContractNotFound` - If contract doesn't exist
-    /// * `InvalidState` - If contract is not in Created state
+    /// * `InvalidState` - If contract is not in Created or Accepted state
     /// * `UnauthorizedRole` - If caller is not the client
     pub fn deposit_funds(env: Env, contract_id: u32, caller: Address, amount: i128) -> bool {
         deposit::deposit_funds_impl(&env, contract_id, caller, amount)
@@ -434,6 +483,11 @@ impl Escrow {
         }
 
         let _release_amount = milestone.amount;
+        // ── CEI: Effects before Interactions ───────────────────────────────
+        // State mutations are committed BEFORE any external token transfer so
+        // that a re-entrant call observes the final `released = true` flag and
+        // cannot trigger a double-spend. When real SAC transfers land they must
+        // remain the last operation in this function.
         milestone.released = true;
         milestones.set(milestone_index, milestone.clone());
         contract.released_amount += milestone.amount;
@@ -441,6 +495,7 @@ impl Escrow {
         // Accumulate protocol fees if initialized with a fee rate
         if Self::is_initialized(&env) {
             let fee_bps = Self::get_protocol_fee_bps(&env);
+            ttl::extend_protocol_fee_bps_ttl(&env);
             if fee_bps > 0 {
                 let fee = Self::calculate_protocol_fee(milestone.amount, fee_bps);
                 let current_accumulated: i128 = env
@@ -452,6 +507,7 @@ impl Escrow {
                     &DataKey::AccumulatedProtocolFees,
                     &(current_accumulated + fee),
                 );
+                ttl::extend_accumulated_fees_ttl(&env);
             }
         }
 
@@ -578,7 +634,8 @@ impl Escrow {
             env.panic_with_error(Error::InsufficientFunds);
         }
 
-        // Mark milestones as refunded
+        // ── CEI: Effects before Interactions ───────────────────────────────
+        // Mark milestones as refunded before any external token transfer.
         for idx in milestone_indices.iter() {
             let mut milestone = milestones.get(idx).unwrap();
             milestone.refunded = true;
@@ -859,6 +916,8 @@ impl Escrow {
 
         caller.require_auth();
         Self::require_not_finalized(&env, contract_id);
+        // ── CEI: Effects before Interactions ───────────────────────────────
+        // Status is written before any future token refund transfer.
         contract.status = ContractStatus::Cancelled;
         env.storage()
             .persistent()
@@ -938,6 +997,7 @@ impl Escrow {
             env.panic_with_error(EscrowError::InvalidState);
         }
         env.storage().persistent().set(&pending_key, &(pending - 1));
+        ttl::extend_pending_reputation_credits_ttl(&env, &contract.freelancer);
 
         let rep_key = DataKey::Reputation(contract.freelancer.clone());
         let mut rep: types::Reputation =
@@ -946,11 +1006,13 @@ impl Escrow {
         rep.total_rating += rating as i128;
         rep.last_rating = rating as i128;
         env.storage().persistent().set(&rep_key, &rep);
+        ttl::extend_reputation_ttl(&env, &contract.freelancer);
 
         true
     }
 
     pub fn get_reputation(env: Env, address: Address) -> Option<types::Reputation> {
+        ttl::extend_reputation_ttl(&env, &address);
         env.storage()
             .persistent()
             .get(&DataKey::Reputation(address))

--- a/contracts/escrow/src/test/ttl_tests.rs
+++ b/contracts/escrow/src/test/ttl_tests.rs
@@ -316,3 +316,174 @@ fn expiry_is_deterministic_across_independent_envs() {
         "expiry must be deterministic given the same starting sequence"
     );
 }
+
+// ─── Persistent key TTL survival tests (#400) ────────────────────────────────
+//
+// These tests initialise the contract, perform operations that write the
+// critical persistent keys, advance the ledger past the bump threshold, and
+// assert that the entries are still reachable (i.e. the helpers bumped TTL).
+
+use crate::ttl::{
+    extend_accumulated_fees_ttl, extend_admin_ttl, extend_finalization_ttl,
+    extend_pending_reputation_credits_ttl, extend_protocol_fee_bps_ttl, extend_reputation_ttl,
+    PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS,
+};
+use crate::{EscrowClient, ReleaseAuthorization};
+
+/// After `initialize` the `Admin` key must survive past `PERSISTENT_BUMP_THRESHOLD` ledgers.
+#[test]
+fn admin_key_survives_past_bump_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 100;
+        li.max_entry_ttl = PERSISTENT_TTL_LEDGERS * 4;
+        li.min_persistent_entry_ttl = PERSISTENT_TTL_LEDGERS * 4;
+    });
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    // Advance past the bump threshold
+    env.ledger().with_mut(|li| {
+        li.sequence_number = li.sequence_number + PERSISTENT_BUMP_THRESHOLD + 1;
+    });
+
+    // get_admin bumps TTL; it must return Some(admin)
+    let fetched = client.get_admin();
+    assert_eq!(fetched, Some(admin), "Admin key must survive past bump threshold");
+}
+
+/// After `set_protocol_fee_bps` the `ProtocolFeeBps` key survives long inactivity.
+#[test]
+fn protocol_fee_bps_key_survives_after_write() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 100;
+        li.max_entry_ttl = PERSISTENT_TTL_LEDGERS * 4;
+        li.min_persistent_entry_ttl = PERSISTENT_TTL_LEDGERS * 4;
+    });
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+    client.set_protocol_fee_bps(&50u32);
+
+    // Advance past bump threshold
+    env.ledger().with_mut(|li| {
+        li.sequence_number = li.sequence_number + PERSISTENT_BUMP_THRESHOLD + 1;
+    });
+
+    // Key must still exist — call set again (also bumps TTL) and assert success
+    assert!(client.set_protocol_fee_bps(&75u32));
+}
+
+/// `extend_admin_ttl` is a no-op when the key is absent (must not panic).
+#[test]
+fn extend_admin_ttl_absent_key_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    env.as_contract(&contract_id, || {
+        // No initialize called — key is absent; should not panic
+        extend_admin_ttl(&env);
+    });
+}
+
+/// `extend_accumulated_fees_ttl` is a no-op when the key is absent.
+#[test]
+fn extend_accumulated_fees_ttl_absent_key_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    env.as_contract(&contract_id, || {
+        extend_accumulated_fees_ttl(&env);
+    });
+}
+
+/// `extend_finalization_ttl` is a no-op when the finalization key is absent.
+#[test]
+fn extend_finalization_ttl_absent_key_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    env.as_contract(&contract_id, || {
+        extend_finalization_ttl(&env, 9999);
+    });
+}
+
+/// `extend_reputation_ttl` is a no-op when the reputation key is absent.
+#[test]
+fn extend_reputation_ttl_absent_key_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let addr = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        extend_reputation_ttl(&env, &addr);
+    });
+}
+
+/// `extend_pending_reputation_credits_ttl` is a no-op when absent.
+#[test]
+fn extend_pending_reputation_credits_ttl_absent_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let addr = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        extend_pending_reputation_credits_ttl(&env, &addr);
+    });
+}
+
+/// `extend_protocol_fee_bps_ttl` is a no-op when the key is absent.
+#[test]
+fn extend_protocol_fee_bps_ttl_absent_key_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    env.as_contract(&contract_id, || {
+        extend_protocol_fee_bps_ttl(&env);
+    });
+}
+
+/// After `finalize_contract` the finalization record survives past bump threshold.
+#[test]
+fn finalization_record_survives_past_bump_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 100;
+        li.max_entry_ttl = PERSISTENT_TTL_LEDGERS * 4;
+        li.min_persistent_entry_ttl = PERSISTENT_TTL_LEDGERS * 4;
+    });
+    let contract_id_addr = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id_addr);
+    let admin = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = soroban_sdk::Address::generate(&env);
+    let freelancer_addr = soroban_sdk::Address::generate(&env);
+    let cid = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &soroban_sdk::vec![&env, 100_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    client.deposit_funds(&cid, &client_addr, &100_i128);
+    client.approve_milestone_release(&cid, &client_addr, &0);
+    client.release_milestone(&cid, &client_addr, &0);
+    client.finalize_contract(&cid, &client_addr);
+
+    // Advance past bump threshold
+    env.ledger().with_mut(|li| {
+        li.sequence_number = li.sequence_number + PERSISTENT_BUMP_THRESHOLD + 1;
+    });
+
+    // get_finalization_record bumps TTL; record must still be present
+    let record = client.get_finalization_record(&cid);
+    assert!(record.is_some(), "Finalization record must survive past bump threshold");
+}

--- a/contracts/escrow/src/ttl.rs
+++ b/contracts/escrow/src/ttl.rs
@@ -7,7 +7,7 @@
 //! "expired".
 
 use crate::{DataKey, Error, Milestone};
-use soroban_sdk::{Env, IntoVal, Symbol, TryFromVal, Val, Vec};
+use soroban_sdk::{Address, Env, IntoVal, Symbol, TryFromVal, Val, Vec};
 
 pub const LEDGERS_PER_DAY: u32 = 17_280;
 
@@ -148,5 +148,103 @@ pub fn extend_participant_contract_index_ttl(env: &Env, key: &crate::DataKey) {
     env.storage()
         .persistent()
         .extend_ttl(key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+}
+
+// ─── Persistent-key TTL helpers (#400) ───────────────────────────────────────
+
+/// Extend TTL for the `Admin` key.
+///
+/// Called on every admin read and write so the admin key never silently
+/// disappears after a long period of inactivity.
+pub fn extend_admin_ttl(env: &Env) {
+    if env.storage().persistent().has(&DataKey::Admin) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::Admin,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+}
+
+/// Extend TTL for the `GovernanceAdmin` key.
+///
+/// Called whenever governance-admin state is read or written to prevent
+/// governance keys from being archived between infrequent admin rotations.
+pub fn extend_governance_admin_ttl(env: &Env) {
+    if env.storage().persistent().has(&DataKey::GovernanceAdmin) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::GovernanceAdmin,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+}
+
+/// Extend TTL for the `AccumulatedProtocolFees` key.
+///
+/// Called on every read or write of accumulated fees so the balance
+/// cannot be archived and silently lost between fee-collection periods.
+pub fn extend_accumulated_fees_ttl(env: &Env) {
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::AccumulatedProtocolFees)
+    {
+        env.storage().persistent().extend_ttl(
+            &DataKey::AccumulatedProtocolFees,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+}
+
+/// Extend TTL for the `Finalization(contract_id)` key.
+///
+/// Called when a finalization record is written or read so immutable
+/// close metadata is never silently archived.
+pub fn extend_finalization_ttl(env: &Env, contract_id: u32) {
+    let key = DataKey::Finalization(contract_id);
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+    }
+}
+
+/// Extend TTL for the `Reputation(addr)` key.
+///
+/// Called on every reputation read and write so long-dormant freelancer
+/// reputation records are never evicted.
+pub fn extend_reputation_ttl(env: &Env, addr: &Address) {
+    let key = DataKey::Reputation(addr.clone());
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+    }
+}
+
+/// Extend TTL for the `PendingReputationCredits(addr)` key.
+///
+/// Called whenever pending-credit accounting is updated to prevent the
+/// counter from expiring before the freelancer claims reputation.
+pub fn extend_pending_reputation_credits_ttl(env: &Env, addr: &Address) {
+    let key = DataKey::PendingReputationCredits(addr.clone());
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+    }
+}
+
+/// Extend TTL for the `ProtocolFeeBps` key.
+pub fn extend_protocol_fee_bps_ttl(env: &Env) {
+    if env.storage().persistent().has(&DataKey::ProtocolFeeBps) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::ProtocolFeeBps,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
 }
 

--- a/docs/escrow/state-persistence.md
+++ b/docs/escrow/state-persistence.md
@@ -5,6 +5,27 @@ This document maps the currently implemented `DataKey` storage used by
 declared-but-unused keys, is tracked in
 [#342](https://github.com/Talenttrust/Talenttrust-Contracts/issues/342).
 
+## Persistent-Key TTL Policy (#400)
+
+All critical persistent keys are bumped to 30 days (17 280 ledgers × 30) whenever they
+are read or written. The bump is skipped when the key is absent (no-op guard).
+
+| Key | TTL Extend-to | Bump Threshold | Bumped by |
+| --- | --- | --- | --- |
+| `Admin` | 30 days | 7 days | `initialize`, `get_admin`, `set_protocol_fee_bps` |
+| `GovernanceAdmin` | 30 days | 7 days | governance admin reads/writes |
+| `ProtocolFeeBps` | 30 days | 7 days | `set_protocol_fee_bps`, `release_milestone` (fee read) |
+| `AccumulatedProtocolFees` | 30 days | 7 days | `release_milestone` (fee write) |
+| `Finalization(id)` | 30 days | 7 days | `finalize_contract`, `get_finalization_record` |
+| `Reputation(addr)` | 30 days | 7 days | `issue_reputation`, `get_reputation` |
+| `PendingReputationCredits(addr)` | 30 days | 7 days | `issue_reputation` |
+| `Contract(id)` / milestones | 30 days | 7 days | all lifecycle entrypoints |
+| `NextContractId` | 30 days | 7 days | `create_contract` |
+
+Constants live in `contracts/escrow/src/ttl.rs`:
+- `PERSISTENT_TTL_LEDGERS = LEDGERS_PER_DAY * 30` (≈ 30 days)
+- `PERSISTENT_BUMP_THRESHOLD = LEDGERS_PER_DAY * 7` (≈ 7 days)
+
 ## Live Storage Keys
 
 These participant indexes are **append-only**: every `create_contract` appends the new id to the appropriate index vectors.


### PR DESCRIPTION


- Add extend_admin_ttl, extend_governance_admin_ttl, extend_accumulated_fees_ttl, extend_finalization_ttl, extend_reputation_ttl, extend_pending_reputation_credits_ttl, and extend_protocol_fee_bps_ttl helpers in ttl.rs; each guards against absent keys.
- Call helpers on read and write in lib.rs (initialize, get_admin, release_milestone, issue_reputation, get_reputation), finalize.rs (write + read), governance.rs (set_protocol_fee_bps).
- Add 9 tests in test/ttl_tests.rs covering key survival past bump threshold and no-op guard for each helper when key is absent.
- Document TTL policy table in docs/escrow/state-persistence.md.

Closes #400 