### PR TITLE
security(contract): hard-cap batch sizes to prevent ledger budget exh…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -97,6 +97,8 @@ pub enum EscrowError {
     PotentialOverflow = 28,
     AlreadyFinalized = 29,
     AmountMustBePositive = 30,
+    /// Returned by `submit_work_evidence` when the evidence string exceeds 256 bytes.
+    EvidenceTooLong = 31,
 }
 
 
@@ -1093,6 +1095,44 @@ impl Escrow {
         );
 
         true
+    }
+
+    /// Returns the work evidence for a single milestone, or `None` if the
+    /// milestone index is out of bounds or no evidence was submitted.
+    ///
+    /// # Arguments
+    /// * `contract_id` - The escrow contract ID
+    /// * `milestone_index` - Zero-based index of the milestone
+    ///
+    /// # Returns
+    /// `Some(String)` with the evidence reference if it exists,
+    /// `None` when the index is out of bounds or the milestone has no evidence.
+    ///
+    /// # Panics
+    /// Panics with `ContractNotFound` if `contract_id` was never allocated.
+    ///
+    /// # TTL
+    /// Extends the milestones vector's persistent TTL on read,
+    /// consistent with `get_milestones`.
+    pub fn get_work_evidence(
+        env: Env,
+        contract_id: u32,
+        milestone_index: u32,
+    ) -> Option<String> {
+        let milestone_key = Symbol::new(&env, "milestones");
+        let milestones: Vec<Milestone> = env
+            .storage()
+            .persistent()
+            .get(&(DataKey::Contract(contract_id), milestone_key))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        ttl::extend_milestone_ttl(&env, contract_id);
+
+        if milestone_index >= milestones.len() {
+            return None;
+        }
+
+        milestones.get(milestone_index).unwrap().work_evidence
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -1,6 +1,6 @@
 use super::{create_contract, register_client};
 use crate::{ContractStatus, EscrowError, ReleaseAuthorization};
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, Symbol};
 
 /// Finalization succeeds from Completed status; record snapshot matches contract state.
 #[test]
@@ -841,6 +841,55 @@ fn get_milestones_read_extends_persistent_ttl() {
 
     let milestones_after = client.get_milestones(&contract_id);
     assert_eq!(milestones_after.len(), default_milestones(&env).len());
+}
+
+/// `get_work_evidence` extends the persistent TTL of the milestones vector entry.
+#[test]
+fn get_work_evidence_read_extends_persistent_ttl() {
+    let env = setup_ttl_env();
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) =
+        create_contract(&env, &client);
+    client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount());
+
+    let ev = soroban_sdk::String::from_str(&env, "ipfs://QmTtlEvidence");
+    assert!(client.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev));
+
+    let bump_threshold = ttl::PERSISTENT_BUMP_THRESHOLD as u32;
+    let extension = ttl::PERSISTENT_TTL_LEDGERS as u32;
+    let milestone_key = Symbol::new(&env, "milestones");
+
+    let initial_ttl: u32 = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&(crate::DataKey::Contract(contract_id), milestone_key.clone()))
+    });
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number =
+            li.sequence_number.saturating_add(initial_ttl.saturating_sub(bump_threshold) + 1);
+    });
+
+    let result = client.get_work_evidence(&contract_id, &0);
+    assert_eq!(result, Some(ev));
+
+    let ttl_after_read: u32 = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&(crate::DataKey::Contract(contract_id), milestone_key.clone()))
+    });
+    assert!(
+        ttl_after_read >= bump_threshold,
+        "get_work_evidence must extend milestones TTL to at least the bump threshold (got {})",
+        ttl_after_read
+    );
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = li.sequence_number.saturating_add(extension - 1);
+    });
+
+    let result_after = client.get_work_evidence(&contract_id, &0);
+    assert_eq!(result_after, Some(ev));
 }
 
 /// `get_refundable_balance` extends the persistent TTL of the contract entry.

--- a/contracts/escrow/src/test/release.rs
+++ b/contracts/escrow/src/test/release.rs
@@ -324,3 +324,69 @@ fn work_evidence_rejects_unknown_contract() {
     let result = escrow.try_submit_work_evidence(&9999, &freelancer, &0, &ev);
     assert_contract_error(result, Error::ContractNotFound);
 }
+
+// ---------------------------------------------------------------------------
+// get_work_evidence tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_work_evidence_returns_some_when_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let ev = evidence(&env, "ipfs://QmMilestone0Evidence");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev));
+
+    let result = escrow.get_work_evidence(&contract_id, &0);
+    assert_eq!(result, Some(ev));
+}
+
+#[test]
+fn get_work_evidence_returns_none_when_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let result = escrow.get_work_evidence(&contract_id, &1);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn get_work_evidence_returns_none_for_out_of_bounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let result = escrow.get_work_evidence(&contract_id, &99);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn get_work_evidence_panics_for_unknown_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let result = escrow.try_get_work_evidence(&9999, &0);
+    assert_contract_error(result, Error::ContractNotFound);
+}
+
+#[test]
+fn get_work_evidence_returns_none_for_unreleased_milestone_without_evidence() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &escrow);
+    // no deposit — contract stays in Created status, milestones exist but have no evidence
+    escrow.deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
+
+    let result = escrow.get_work_evidence(&contract_id, &2);
+    assert_eq!(result, None);
+}

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -36,6 +36,7 @@ Read-only queries:
 - `get_milestones(contract_id) -> Vec<Milestone>`
 - `get_refundable_balance(contract_id) -> i128`
 - `get_milestone_approvals(contract_id, milestone_index) -> Option<MilestoneApprovals>`
+- `get_work_evidence(contract_id, milestone_index) -> Option<String>`
 - `get_finalization_record(contract_id) -> Option<FinalizationRecord>`
 - `get_reputation(freelancer) -> Option<ReputationRecord>`
 - `get_average_rating(freelancer) -> Option<i128>` — scaled average (see [Average Rating](#average-rating))
@@ -91,6 +92,11 @@ Per-getter details:
   when the contract id is unknown. Does not extend persistent TTL because
   approvals live in temporary storage bounded by
   `PENDING_APPROVAL_TTL_LEDGERS`.
+- `get_work_evidence(contract_id, milestone_index)` returns `Some(String)`
+  if the milestone exists and work evidence was submitted via
+  `submit_work_evidence`. Returns `None` when the index is out of bounds or
+  no evidence was recorded. Panics `ContractNotFound` for an unknown id.
+  Reads persist the milestones entry's TTL, consistent with `get_milestones`.
 
 These properties are locked in by tests under
 `contracts/escrow/src/test/persistence.rs` (issue #475).


### PR DESCRIPTION
closes #541 

# feat: add `get_work_evidence` single-milestone reader with tests

## Summary

Adds `get_work_evidence(contract_id, milestone_index) -> Option<String>` — a targeted read-only accessor for deliverable references stored via `submit_work_evidence`. Previously, clients had to pull the entire milestone vector via `get_milestones` and index into it to find one milestone's evidence.

## Changes

### `contracts/escrow/src/lib.rs`

- **Added `EvidenceTooLong = 31` variant to `EscrowError`** (pre-existing bug — the variant was already used at line 1051 and tested, but was missing from the enum definition which ended at `AmountMustBePositive = 30`).

- **Added `get_work_evidence` entrypoint** (inserted after `submit_work_evidence` in the Work evidence section):

  | Scenario | Behavior | Rationale |
  |---|---|---|
  | Unknown `contract_id` | Panics `ContractNotFound` | Consistent with `get_milestones` — contract must exist |
  | Index >= milestones.len() | Returns `None` | Clean `Option` semantics, no new error variant |
  | Milestone exists, no evidence | Returns `None` | `work_evidence` is already `Option<String>` on the struct |
  | Milestone has evidence | Returns `Some(String)` | Direct access to the stored CID/URL |
  | TTL on read | Extends milestones TTL | Consistent with `get_milestones` |
  | Auth | Not required | Read-only view |

### `contracts/escrow/src/test/release.rs` — 5 new tests

| Test | Coverage |
|---|---|
| `get_work_evidence_returns_some_when_set` | Submit evidence, read it back via the new getter |
| `get_work_evidence_returns_none_when_unset` | Funded milestone without evidence returns `None` |
| `get_work_evidence_returns_none_for_out_of_bounds` | Index 99 on a 3-milestone contract returns `None` |
| `get_work_evidence_panics_for_unknown_contract` | ID 9999 triggers `ContractNotFound` panic |
| `get_work_evidence_returns_none_for_unreleased_milestone_without_evidence` | Sanity: funded milestone, no evidence -> `None` |

### `contracts/escrow/src/test/persistence.rs` — 1 new TTL test

`get_work_evidence_read_extends_persistent_ttl` follows the exact pattern from `get_milestones_read_extends_persistent_ttl`: advances the ledger close to the bump threshold, calls the getter, and asserts the milestones entry TTL was extended to at least `PERSISTENT_BUMP_THRESHOLD`.

### `docs/escrow/README.md` — Documentation

- Added `get_work_evidence(contract_id, milestone_index) -> Option<String>` to the read-only queries list.
- Added per-getter semantics paragraph documenting bounds checking, absence behavior, and TTL extension.

## Testing

```
$ cargo test
```

All existing tests continue to pass. 6 new tests added:

- 5 functional tests in `test/release.rs`
- 1 TTL extension test in `test/persistence.rs`

## Semantic specification

```
pub fn get_work_evidence(
    env: Env,
    contract_id: u32,
    milestone_index: u32,
) -> Option<String>
```

- **Panics** with `ContractNotFound` if `contract_id` was never allocated.
- **Returns `None`** when `milestone_index` >= milestones length (out of bounds).
- **Returns `None`** when the milestone exists but has no `work_evidence`.
- **Returns `Some(String)`** with the evidence reference when set.
- **Extends** the milestones vector's persistent TTL on read, consistent with `get_milestones`.

## Security

- Out-of-bounds indices are handled deterministically: returns `None`, no panic.
- No authentication required — read-only, no state mutation.
- Follows the same TTL extension pattern as other persistent-storage getters.
