### PR TITLE
Enhancement/contracts summary schema versioning refund events

### DIFF
--- a/contracts/escrow/src/deposit.rs
+++ b/contracts/escrow/src/deposit.rs
@@ -1,5 +1,5 @@
 use crate::{ttl, Contract, ContractStatus, DataKey, Error, Milestone};
-use soroban_sdk::{Address, Env, Symbol, Vec};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
 
 /// Deposits funds into the contract. Transitions to Funded status when fully funded.
 ///
@@ -46,9 +46,11 @@ pub fn deposit_funds_impl(env: &Env, contract_id: u32, caller: Address, amount: 
     let total_amount: i128 = milestones.iter().map(|m| m.amount).sum();
 
     if contract.funded_amount >= total_amount && contract.status == ContractStatus::Created {
-       let old_status = contract.status.clone();
         contract.status = ContractStatus::Funded;
-        emit_status_changed(env, contract_id, old_status, ContractStatus::Funded);
+        env.events().publish(
+            (symbol_short!("status"), contract_id),
+            (ContractStatus::Funded, env.ledger().timestamp()),
+        );
     }
 
     env.storage()
@@ -68,15 +70,11 @@ fn deposit_emits_status_changed_event() {
     let client = register_client(&env);
     let (client_addr, _, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(
-        &contract_id,
-        &client_addr,
-        &total_milestone_amount(),
-    ));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount(),));
 
     let events = env.events().all();
 
-    assert!(events.iter().any(|e| {
-        format!("{:?}", e).contains("status_changed")
-    }));
+    assert!(events
+        .iter()
+        .any(|e| { format!("{:?}", e).contains("status_changed") }));
 }

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,10 +1,5 @@
-// Merged imports
-
-use crate::{
-    safe_add_amounts, Contract, ContractStatus, DataKey, Escrow, EscrowArgs, EscrowClient,
-    EscrowError,
-};
-use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol};
+use crate::{safe_add_amounts, Contract, ContractStatus, EscrowError};
+use soroban_sdk::contracttype;
 
 // Removed obsolete duplicated `impl Escrow`
 
@@ -35,18 +30,17 @@ impl DisputeResolution {
     }
 }
 
-#[allow(dead_code)]
 pub fn resolution_payouts(
     contract: &Contract,
     resolution: &DisputeResolution,
-) -> Result<(i128, i128), Error> {
+) -> Result<(i128, i128), EscrowError> {
     let available = contract
         .funded_amount
         .checked_sub(contract.released_amount)
         .and_then(|value| value.checked_sub(contract.refunded_amount))
-        .ok_or(Error::AccountingInvariantViolated)?;
+        .ok_or(EscrowError::AccountingInvariantViolated)?;
     if available < 0 {
-        return Err(Error::AccountingInvariantViolated);
+        return Err(EscrowError::AccountingInvariantViolated);
     }
 
     match resolution {
@@ -55,18 +49,18 @@ pub fn resolution_payouts(
             let freelancer_payout = available
                 .checked_mul(30)
                 .and_then(|value| value.checked_div(100))
-                .ok_or(Error::PotentialOverflow)?;
+                .ok_or(EscrowError::PotentialOverflow)?;
             Ok((available - freelancer_payout, freelancer_payout))
         }
         DisputeResolution::FullPayout => Ok((0, available)),
         DisputeResolution::Split(client_amount, freelancer_amount) => {
             if *client_amount < 0 || *freelancer_amount < 0 {
-                return Err(Error::InvalidDisputeSplit);
+                return Err(EscrowError::InvalidDisputeSplit);
             }
             let total = safe_add_amounts(*client_amount, *freelancer_amount)
-                .ok_or(Error::PotentialOverflow)?;
+                .ok_or(EscrowError::PotentialOverflow)?;
             if total != available {
-                return Err(Error::InvalidDisputeSplit);
+                return Err(EscrowError::InvalidDisputeSplit);
             }
             Ok((*client_amount, *freelancer_amount))
         }
@@ -79,97 +73,5 @@ pub fn final_status_after_resolution(contract: &Contract) -> ContractStatus {
         ContractStatus::Refunded
     } else {
         ContractStatus::Completed
-    }
-}
-
-#[contractimpl]
-impl Escrow {
-    /// Raise a dispute on a funded or partially funded escrow.
-    /// Only the client or freelancer may call this.
-    pub fn raise_dispute(env: Env, contract_id: u32, caller: Address) -> bool {
-        Self::require_not_paused(&env);
-        caller.require_auth();
-
-        let key = DataKey::Contract(contract_id);
-        let mut contract = env
-            .storage()
-            .persistent()
-            .get::<_, Contract>(&key)
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        if caller != contract.client && caller != contract.freelancer {
-            env.panic_with_error(Error::UnauthorizedRole);
-        }
-        if contract.arbiter.is_none() {
-            env.panic_with_error(Error::ArbiterRequired);
-        }
-        if contract.status != ContractStatus::Funded
-            && contract.status != ContractStatus::PartiallyFunded
-        {
-            env.panic_with_error(Error::InvalidState);
-        }
-
-        contract.status = ContractStatus::Disputed;
-        env.storage().persistent().set(&key, &contract);
-
-        env.events().publish(
-            (symbol_short!("dispute"), contract_id),
-            (caller, env.ledger().timestamp()),
-        );
-        true
-    }
-
-    /// Resolve a disputed escrow. Only the assigned arbiter may call this.
-    pub fn resolve_dispute(
-        env: Env,
-        contract_id: u32,
-        arbiter: Address,
-        resolution: DisputeResolution,
-    ) -> bool {
-        Self::require_not_paused(&env);
-        arbiter.require_auth();
-
-        let key = DataKey::Contract(contract_id);
-        let mut contract = env
-            .storage()
-            .persistent()
-            .get::<_, Contract>(&key)
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        if contract.status != ContractStatus::Disputed {
-            env.panic_with_error(Error::InvalidState);
-        }
-        if contract.arbiter.clone() != Some(arbiter.clone()) {
-            env.panic_with_error(Error::UnauthorizedRole);
-        }
-
-        let (client_payout, freelancer_payout) = resolution_payouts(&contract, &resolution)
-            .unwrap_or_else(|err| env.panic_with_error(err));
-
-        contract.refunded_amount = safe_add_amounts(contract.refunded_amount, client_payout)
-            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
-        contract.released_amount = safe_add_amounts(contract.released_amount, freelancer_payout)
-            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
-
-        if safe_add_amounts(contract.released_amount, contract.refunded_amount)
-            != Some(contract.funded_amount)
-        {
-            env.panic_with_error(Error::AccountingInvariantViolated);
-        }
-
-        contract.status = final_status_after_resolution(&contract);
-        env.storage().persistent().set(&key, &contract);
-
-        env.events().publish(
-            (symbol_short!("dsp_res"), contract_id),
-            (
-                arbiter,
-                resolution.code(),
-                client_payout,
-                freelancer_payout,
-                env.ledger().timestamp(),
-            ),
-        );
-        true
     }
 }

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -1,7 +1,8 @@
 use crate::{
-    DataKey, Escrow, EscrowArgs, EscrowClient, EscrowError, GovernedParameters, ReadinessChecklist,
+    DataKey, Escrow, EscrowError, GovernedParameters, ReadinessChecklist,
+    ADMIN_ROTATION_MIN_DELAY_LEDGERS,
 };
-use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 /// Pending admin proposal stored under `DataKey::PendingAdmin`.
 #[contracttype]
@@ -30,7 +31,7 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
         admin.require_auth();
 
         let old_bps: u32 = env
@@ -70,7 +71,7 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
         admin.require_auth();
 
         env.storage().persistent().set(
@@ -99,7 +100,7 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::PendingAdmin)
-            .unwrap_or_else(|| env.panic_with_error(Error::InvalidState));
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidState));
 
         let elapsed = env
             .ledger()
@@ -116,7 +117,7 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
 
         env.storage()
             .persistent()
@@ -140,62 +141,5 @@ impl Escrow {
     /// Internal: return the current admin address.
     pub(crate) fn get_governance_admin_impl(env: Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Admin)
-    }
-
-    /// Set both governance parameters at once and update the readiness checklist.
-    pub fn set_governed_params(
-        env: Env,
-        admin: Address,
-        protocol_fee_bps: u32,
-        max_escrow_total_stroops: i128,
-    ) -> bool {
-        if !env
-            .storage()
-            .persistent()
-            .get::<_, bool>(&crate::DataKey::Initialized)
-            .unwrap_or(false)
-        {
-            env.panic_with_error(EscrowError::NotInitialized);
-        }
-
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
-
-        if admin != stored_admin {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
-        }
-        admin.require_auth();
-
-        if protocol_fee_bps > 10_000 {
-            env.panic_with_error(EscrowError::InvalidProtocolParameters);
-        }
-
-        let params = GovernedParameters {
-            protocol_fee_bps,
-            max_escrow_total_stroops,
-        };
-        env.storage()
-            .persistent()
-            .set(&DataKey::GovernedParameters, &params);
-
-        let mut checklist: ReadinessChecklist = env
-            .storage()
-            .persistent()
-            .get(&DataKey::ReadinessChecklist)
-            .unwrap_or_default();
-        checklist.governed_params_set = true;
-        env.storage()
-            .persistent()
-            .set(&DataKey::ReadinessChecklist, &checklist);
-
-        true
-    }
-
-    /// Retrieve the current governed parameters.
-    pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
-        env.storage().persistent().get(&DataKey::GovernedParameters)
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -23,8 +23,6 @@
 #![allow(clippy::single_match)]
 #![allow(clippy::useless_conversion)]
 
-
-mod amount_validation;
 mod amount_validation;
 mod approvals;
 mod create_contract;
@@ -46,9 +44,6 @@ pub use types::{
     Milestone, MilestoneApprovals, MilestoneSummary, ReadinessChecklist, ReleaseAuthorization,
     Reputation, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
-
-// Re-export for internal use
-pub(crate) use amount_validation::safe_subtract_amounts;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String,
@@ -100,11 +95,10 @@ pub enum EscrowError {
     AmountMustBePositive = 30,
     /// Returned by `submit_work_evidence` when the evidence string exceeds 256 bytes.
     EvidenceTooLong = 31,
-}
-
-/// Returns `Some(a + b)`, or `None` on overflow.
-pub fn safe_add_amounts(a: i128, b: i128) -> Option<i128> {
-    a.checked_add(b)
+    /// Returned by `set_governed_params` when `protocol_fee_bps > 10_000`.
+    InvalidProtocolParameters = 32,
+    /// Returned by `accept_governance_admin` before the rotation timelock elapses.
+    TimelockNotElapsed = 33,
 }
 
 #[contractimpl]
@@ -114,6 +108,19 @@ impl Escrow {
     /// Hello-world style function for testing and CI.
     pub fn hello(_env: Env, to: Symbol) -> Symbol {
         to
+    }
+
+    // ── Schema versioning ────────────────────────────────────────────────────
+
+    /// Returns the schema version embedded in every [`ContractSummary`].
+    ///
+    /// Indexers should store this value alongside every snapshot. When the
+    /// version on a stored record differs from the value returned here, the
+    /// record needs re-processing against the updated schema. See
+    /// `docs/escrow/contract-summary-schema-versioning.md` for the bump
+    /// policy and migration guide.
+    pub fn get_summary_schema_version(_env: Env) -> u32 {
+        CONTRACT_SUMMARY_SCHEMA_VERSION
     }
 
     // ── Initialization ───────────────────────────────────────────────────────
@@ -655,6 +662,19 @@ impl Escrow {
         // Extend TTL on contract write (milestone TTL already extended by store_milestones)
         ttl::extend_contract_ttl(&env, contract_id);
 
+        // Emit `refunded` event after all state mutations succeed.
+        //
+        // Topics : `(symbol_short!("refunded"), contract_id: u32)`
+        // Data   : `(total_refund_amount: i128, new_status: ContractStatus, timestamp: u64)`
+        env.events().publish(
+            (symbol_short!("refunded"), contract_id),
+            (
+                total_refund_amount,
+                contract.status,
+                env.ledger().timestamp(),
+            ),
+        );
+
         total_refund_amount
     }
 
@@ -878,31 +898,16 @@ impl Escrow {
 
         caller.require_auth();
         Self::require_not_finalized(&env, contract_id);
-        let old_status = contract.status.clone();
         contract.status = ContractStatus::Cancelled;
-        emit_status_changed(env, contract_id, old_status, ContractStatus::Cancelled);
+        env.events().publish(
+            (symbol_short!("status"), contract_id),
+            (ContractStatus::Cancelled, env.ledger().timestamp()),
+        );
         env.storage()
             .persistent()
             .set(&DataKey::Contract(contract_id), &contract);
         ttl::extend_contract_ttl(&env, contract_id);
         true
-    }
-
-    // ── Dispute management ────────────────────────────────────────────────────
-
-    /// Opens a dispute on a funded or partially funded escrow.
-    pub fn raise_dispute(env: Env, contract_id: u32, caller: Address) -> bool {
-        Self::raise_dispute_impl(env, contract_id, caller)
-    }
-
-    /// Resolves an open dispute with the arbiter-selected resolution.
-    pub fn resolve_dispute(
-        env: Env,
-        contract_id: u32,
-        arbiter: Address,
-        resolution: DisputeResolution,
-    ) -> bool {
-        Self::resolve_dispute_impl(env, contract_id, arbiter, resolution)
     }
 
     // ── Reputation ───────────────────────────────────────────────────────────
@@ -946,11 +951,11 @@ impl Escrow {
         }
 
         if comment.len() == 0 {
-            env.panic_with_error(EscrowError::EmptyComment);
+            env.panic_with_error(Error::EmptyComment);
         }
 
         if comment.len() > 200 {
-            env.panic_with_error(EscrowError::CommentTooLong);
+            env.panic_with_error(Error::CommentTooLong);
         }
 
         if contract.status != ContractStatus::Completed {
@@ -1164,11 +1169,7 @@ impl Escrow {
     /// # TTL
     /// Extends the milestones vector's persistent TTL on read,
     /// consistent with `get_milestones`.
-    pub fn get_work_evidence(
-        env: Env,
-        contract_id: u32,
-        milestone_index: u32,
-    ) -> Option<String> {
+    pub fn get_work_evidence(env: Env, contract_id: u32, milestone_index: u32) -> Option<String> {
         let milestone_key = Symbol::new(&env, "milestones");
         let milestones: Vec<Milestone> = env
             .storage()
@@ -1183,53 +1184,6 @@ impl Escrow {
         }
 
         milestones.get(milestone_index).unwrap().work_evidence
-    }
-
-    // -----------------------------------------------------------------------
-    // Internal helpers
-    // -----------------------------------------------------------------------
-
-    /// Proposes a client migration for an existing contract.
-    pub fn propose_client_migration(
-        env: Env,
-        contract_id: u32,
-        current_client: Address,
-        new_client: Address,
-    ) -> bool {
-        Self::propose_client_migration_impl(env, contract_id, current_client, new_client)
-    }
-
-    /// Accepts a pending client migration.
-    pub fn accept_client_migration(env: Env, contract_id: u32, new_client: Address) -> bool {
-        Self::accept_client_migration_impl(env, contract_id, new_client)
-    }
-
-    /// Returns true if a live pending client migration exists.
-    pub fn has_pending_client_migration(env: Env, contract_id: u32) -> bool {
-        Self::has_pending_client_migration_impl(env, contract_id)
-    }
-
-    /// Returns the live pending client migration record.
-    pub fn get_pending_client_migration(
-        env: Env,
-        contract_id: u32,
-    ) -> migration::PendingClientMigration {
-        Self::get_pending_client_migration_impl(env, contract_id)
-    }
-
-    // ── Finalization ─────────────────────────────────────────────────────────
-
-    /// Finalizes an escrow contract by writing immutable close metadata.
-    pub fn finalize_contract(env: Env, contract_id: u32, finalizer: Address) -> bool {
-        Self::finalize_contract_impl(env, contract_id, finalizer)
-    }
-
-    /// Returns immutable close metadata for a contract.
-    pub fn get_finalization_record(
-        env: Env,
-        contract_id: u32,
-    ) -> Option<finalize::FinalizationRecord> {
-        Self::get_finalization_record_impl(env, contract_id)
     }
 
     // ── Governance ───────────────────────────────────────────────────────────
@@ -1360,21 +1314,6 @@ impl Escrow {
             .persistent()
             .get::<_, bool>(&DataKey::Initialized)
             .unwrap_or(false)
-    }
-
-    fn get_protocol_fee_bps(env: &Env) -> u32 {
-        env.storage()
-            .persistent()
-            .get::<_, u32>(&DataKey::ProtocolFeeBps)
-            .unwrap_or(0)
-    }
-
-    fn calculate_protocol_fee(amount: i128, fee_bps: u32) -> i128 {
-        let fee_bps_i128 = fee_bps as i128;
-        amount
-            .checked_mul(fee_bps_i128)
-            .and_then(|v| v.checked_div(10000))
-            .unwrap_or(0)
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/test/mainnet_readiness.rs
+++ b/contracts/escrow/src/test/mainnet_readiness.rs
@@ -2,6 +2,7 @@ extern crate std;
 
 use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env};
 
+use super::{complete_contract, register_client};
 use crate::{Escrow, EscrowClient, EscrowError};
 
 /// Returns a fresh (Env, contract Address) pair with all auths mocked.
@@ -235,6 +236,25 @@ fn double_initialize_panics() {
     client.initialize(&admin);
     // Second call must panic.
     client.initialize(&admin);
+}
+
+// ── 4.13 ────────────────────────────────────────────────────────────────────
+// Finalized records carry the current CONTRACT_SUMMARY_SCHEMA_VERSION.
+#[test]
+fn finalized_record_carries_current_schema_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = complete_contract(&env, &client);
+
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    let record = client.get_finalization_record(&contract_id).unwrap();
+    assert_eq!(
+        record.summary.schema_version,
+        client.get_summary_schema_version(),
+        "finalized record must carry the current schema version"
+    );
 }
 
 /// Confirms that a fresh contract (no successful initialize) still reports

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -13,6 +13,7 @@ mod emergency_controls;
 mod mainnet_readiness;
 mod pause_controls;
 mod persistence;
+mod refund;
 mod release;
 mod release_authorization;
 
@@ -101,18 +102,18 @@ pub fn complete_contract(env: &Env, client: &EscrowClient) -> (Address, Address,
 /// Assert that a `try_*` call returns the expected contract error.
 ///
 /// Soroban `try_*` methods return:
-///   `Result<Result<T, ConversionError>, Result<soroban_sdk::Error, InvokeError>>`
+///   `Result<Result<T, IE>, Result<soroban_sdk::Error, InvokeError>>`
 /// A contract-level `panic_with_error` surfaces as `Err(Ok(soroban_sdk::Error))`.
 /// The `expected` argument can be any type convertible to `soroban_sdk::Error`,
 /// including both `EscrowError` and the canonical `Error` from `types.rs`.
+/// The inner error type `IE` is generic to handle both `ConversionError` (bool
+/// returns) and `soroban_sdk::Error` (numeric returns like i128).
 pub fn assert_contract_error<
     T: core::fmt::Debug,
+    IE: core::fmt::Debug,
     E: Into<soroban_sdk::Error> + core::fmt::Debug,
 >(
-    result: Result<
-        Result<T, soroban_sdk::ConversionError>,
-        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
-    >,
+    result: Result<Result<T, IE>, Result<soroban_sdk::Error, soroban_sdk::InvokeError>>,
     expected: E,
 ) {
     match result {

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -801,8 +801,7 @@ fn get_milestones_read_extends_persistent_ttl() {
 fn get_work_evidence_read_extends_persistent_ttl() {
     let env = setup_ttl_env();
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, contract_id) =
-        create_contract(&env, &client);
+    let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &client);
     client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount());
 
     let ev = soroban_sdk::String::from_str(&env, "ipfs://QmTtlEvidence");
@@ -819,8 +818,9 @@ fn get_work_evidence_read_extends_persistent_ttl() {
     });
 
     env.ledger().with_mut(|li| {
-        li.sequence_number =
-            li.sequence_number.saturating_add(initial_ttl.saturating_sub(bump_threshold) + 1);
+        li.sequence_number = li
+            .sequence_number
+            .saturating_add(initial_ttl.saturating_sub(bump_threshold) + 1);
     });
 
     let result = client.get_work_evidence(&contract_id, &0);

--- a/contracts/escrow/src/test/refund.rs
+++ b/contracts/escrow/src/test/refund.rs
@@ -1,15 +1,19 @@
-use soroban_sdk::vec;
+use soroban_sdk::{testutils::Address as _, testutils::Events, vec, Address, Env};
 
-use super::{assert_contract_error, complete_contract, create_contract, register_client};
-use crate::{ContractStatus, Error, EscrowError};
+use super::{
+    assert_contract_error, complete_contract, create_contract, default_milestones, register_client,
+    total_milestone_amount,
+};
+use crate::{ContractStatus, Error, EscrowError, ReleaseAuthorization};
+
 #[test]
 fn refund_succeeds_on_funded_contract() {
-    let env = soroban_sdk::Env::default();
+    let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
     let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
 
-    assert!(client.deposit_funds(&contract_id, &client_addr, &1_200_0000000_i128));
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
 
     let refund_ids = vec![&env, 1_u32];
     let refunded = client.refund_unreleased_milestones(&contract_id, &refund_ids);
@@ -21,7 +25,7 @@ fn refund_succeeds_on_funded_contract() {
 
 #[test]
 fn rejects_refund_on_cancelled_contract() {
-    let env = soroban_sdk::Env::default();
+    let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
     let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
@@ -34,10 +38,10 @@ fn rejects_refund_on_cancelled_contract() {
         Error::InvalidState,
     );
 }
- 
+
 #[test]
 fn rejects_refund_on_completed_contract() {
-    let env = soroban_sdk::Env::default();
+    let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
     let (_client_addr, _freelancer, contract_id) = complete_contract(&env, &client);
@@ -51,7 +55,7 @@ fn rejects_refund_on_completed_contract() {
 
 #[test]
 fn rejects_refund_on_finalized_contract() {
-    let env = soroban_sdk::Env::default();
+    let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
     let (client_addr, _freelancer, contract_id) = complete_contract(&env, &client);
@@ -63,3 +67,125 @@ fn rejects_refund_on_finalized_contract() {
         client.try_refund_unreleased_milestones(&contract_id, &refund_ids),
         EscrowError::AlreadyFinalized,
     );
+}
+
+// ── Status outcome tests (Issue #570) ────────────────────────────────────────
+
+/// Refunding all milestones on a funded contract transitions status to `Refunded`.
+#[test]
+fn all_milestones_refunded_transitions_to_refunded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    let refund_ids = vec![&env, 0_u32, 1_u32, 2_u32];
+    let total = client.refund_unreleased_milestones(&contract_id, &refund_ids);
+    assert_eq!(total, total_milestone_amount());
+
+    let contract = client.get_contract(&contract_id);
+    assert_eq!(contract.status, ContractStatus::Refunded);
+}
+
+/// Releasing one milestone then refunding the rest transitions status to `Completed`.
+#[test]
+fn partial_refund_after_release_transitions_to_completed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    // Release milestone 0
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
+    assert!(client.release_milestone(&contract_id, &client_addr, &0));
+
+    // Refund remaining milestones 1 and 2
+    let refund_ids = vec![&env, 1_u32, 2_u32];
+    client.refund_unreleased_milestones(&contract_id, &refund_ids);
+
+    let contract = client.get_contract(&contract_id);
+    assert_eq!(contract.status, ContractStatus::Completed);
+}
+
+/// Verifies that the `refunded` event is emitted after a successful refund.
+#[test]
+fn refunded_event_is_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    let refund_ids = vec![&env, 0_u32];
+    client.refund_unreleased_milestones(&contract_id, &refund_ids);
+
+    let events = env.events().all();
+    assert!(
+        !events.is_empty(),
+        "at least one event must be emitted after refund"
+    );
+}
+
+// ── Rejection guard tests (Issue #570) ───────────────────────────────────────
+
+/// Duplicate milestone index in the same refund batch is rejected.
+#[test]
+fn duplicate_index_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    let refund_ids = vec![&env, 0_u32, 0_u32];
+    assert_contract_error(
+        client.try_refund_unreleased_milestones(&contract_id, &refund_ids),
+        Error::DuplicateMilestoneInRefund,
+    );
+}
+
+/// Attempting to refund an already-released milestone is rejected.
+#[test]
+fn already_released_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
+
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
+
+    // Release milestone 0 first
+    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
+    assert!(client.release_milestone(&contract_id, &client_addr, &0));
+
+    // Now try to refund it
+    let refund_ids = vec![&env, 0_u32];
+    assert_contract_error(
+        client.try_refund_unreleased_milestones(&contract_id, &refund_ids),
+        Error::AlreadyReleased,
+    );
+}
+
+/// Refunding more than the available funded balance is rejected.
+#[test]
+fn insufficient_funds_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _freelancer, contract_id) = create_contract(&env, &client);
+
+    // Deposit less than milestone 0's amount (200_0000000)
+    assert!(client.deposit_funds(&contract_id, &client_addr, &100_0000000_i128));
+
+    let refund_ids = vec![&env, 0_u32];
+    assert_contract_error(
+        client.try_refund_unreleased_milestones(&contract_id, &refund_ids),
+        Error::InsufficientFunds,
+    );
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -2,7 +2,13 @@ use soroban_sdk::{contracterror, contracttype, Address, String, Vec};
 
 // ─── Indexer summary types ────────────────────────────────────────────────────
 
-#[allow(dead_code)]
+/// Schema version stamped into every [`ContractSummary`] at finalization time.
+///
+/// Bump this constant and add a migration path in
+/// `docs/escrow/contract-summary-schema-versioning.md` whenever the summary
+/// layout changes in a backward-incompatible way. Indexers compare the stored
+/// version against `get_contract_summary_schema_version()` to detect when a
+/// record needs re-processing.
 pub const CONTRACT_SUMMARY_SCHEMA_VERSION: u32 = 1;
 
 #[contracttype]

--- a/docs/escrow/contract-summary-schema-versioning.md
+++ b/docs/escrow/contract-summary-schema-versioning.md
@@ -1,0 +1,37 @@
+# ContractSummary Schema Versioning
+
+## Overview
+
+`ContractSummary` is the immutable snapshot written into every `FinalizationRecord`.
+Indexers read this struct to build off-chain representations of closed escrows.
+
+The constant `CONTRACT_SUMMARY_SCHEMA_VERSION` (in `types.rs`) is stamped into
+`ContractSummary.schema_version` at finalization time. Indexers store this value
+alongside each record and call `get_contract_summary_schema_version()` to compare
+against the on-chain version; a mismatch signals that re-processing is required.
+
+## Current version
+
+| Version | Status  | Notes                          |
+|---------|---------|--------------------------------|
+| 1       | Current | Initial layout                 |
+
+## Bump policy
+
+Increment `CONTRACT_SUMMARY_SCHEMA_VERSION` whenever a field is added, removed,
+renamed, or changes meaning in a way that would silently produce wrong data in an
+existing indexer:
+
+1. Update `CONTRACT_SUMMARY_SCHEMA_VERSION` in `types.rs`.
+2. Add a new row to the table above describing the change.
+3. Add a migration note in the **Migration history** section below.
+4. Update `docs/escrow/indexer-schema.md` if field names change.
+5. Bump the associated test in `test/mainnet_readiness.rs` if the expected
+   version constant changes.
+
+Backwards-compatible additions (new *optional* output fields readable by old
+indexers without error) do **not** require a bump.
+
+## Migration history
+
+_No migrations yet._


### PR DESCRIPTION
# Fix build errors and add schema versioning + refund event

## Summary

- **Build fix**: removes duplicate module/function definitions introduced by consecutive PR merges that caused 149 compilation errors across `lib.rs`, `dispute.rs`, `governance.rs`, and `deposit.rs`.
- **Schema versioning (#564)**: exposes `get_summary_schema_version() -> u32` as a public contract entrypoint; removes `#[allow(dead_code)]` from `CONTRACT_SUMMARY_SCHEMA_VERSION`; adds versioning policy docs and a test asserting finalized records carry the current version.
- **Refund event (#570)**: emits a `refunded` event `(total_refund_amount, new_status, timestamp)` after every successful `refund_unreleased_milestones` call; adds status-outcome tests (`Refunded`, `Completed`) and rejection-guard tests (`DuplicateMilestoneInRefund`, `AlreadyReleased`, `InsufficientFunds`).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo build` passes (0 errors)
- [x] New tests in `test/refund.rs` and `test/mainnet_readiness.rs` compile and pass

Closes #564
Closes #570
