### PR TITLE
test: cover comment length bounds in issue_reputation

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -871,6 +871,11 @@ impl Escrow {
 
     /// Issues reputation credit for a completed contract.
     ///
+    /// # Comment length
+    /// `comment` must be between 1 and 200 **bytes** (inclusive). Because Soroban
+    /// `String::len()` returns the UTF-8 byte length, a multi-byte character (e.g.
+    /// a 3-byte emoji) counts as 3 toward the limit. ASCII characters are 1 byte each.
+    ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode
     /// * `EmergencyActive` - If the contract is in an active emergency pause
@@ -878,6 +883,8 @@ impl Escrow {
     /// * `UnauthorizedRole` - If caller is not the stored client
     /// * `FreelancerMismatch` - If `freelancer` does not match the stored freelancer
     /// * `InvalidRating` - If rating is not in [1, 5]
+    /// * `EmptyComment` - If comment is 0 bytes
+    /// * `CommentTooLong` - If comment exceeds 200 bytes
     /// * `NotCompleted` - If contract status is not `Completed`
     /// * `ReputationAlreadyIssued` - If reputation was already issued
     /// * `SelfRating` - If client and freelancer are the same address
@@ -885,6 +892,7 @@ impl Escrow {
     /// # Security
     /// * Pause/emergency gate runs BEFORE contract state read so paused
     ///   contracts cannot have reputation mutated while paused.
+    /// * The 200-byte cap prevents unbounded on-chain storage growth.
     pub fn issue_reputation(
         env: Env,
         contract_id: u32,

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -220,3 +220,76 @@ fn get_average_rating_fractional_average_is_preserved() {
     // total_rating=3, completed_contracts=2 → 3 * 10_000 / 2 = 15_000
     assert_eq!(client.get_average_rating(&freelancer_addr), Some(15_000));
 }
+
+// ---------------------------------------------------------------------------
+// Comment length boundary tests (byte-length: 1..=200)
+// ---------------------------------------------------------------------------
+
+/// Length 0 must panic with EmptyComment.
+#[test]
+fn issue_reputation_comment_length_0_rejects_with_empty_comment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = complete_contract(&env, &client);
+
+    let result = client.try_issue_reputation(
+        &contract_id,
+        &client_addr,
+        &5,
+        &String::from_str(&env, ""),
+    );
+    super::assert_contract_error(result, EscrowError::EmptyComment);
+}
+
+/// Length 1 (minimum valid) must succeed.
+#[test]
+fn issue_reputation_comment_length_1_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = complete_contract(&env, &client);
+
+    assert!(client.issue_reputation(
+        &contract_id,
+        &client_addr,
+        &5,
+        &String::from_str(&env, "x"),
+    ));
+}
+
+/// Length 200 (maximum valid) must succeed.
+#[test]
+fn issue_reputation_comment_length_200_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = complete_contract(&env, &client);
+
+    // Exactly 200 ASCII bytes.
+    let s = "a".repeat(200);
+    assert!(client.issue_reputation(
+        &contract_id,
+        &client_addr,
+        &5,
+        &String::from_str(&env, &s),
+    ));
+}
+
+/// Length 201 must panic with CommentTooLong.
+#[test]
+fn issue_reputation_comment_length_201_rejects_with_comment_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (client_addr, _, contract_id) = complete_contract(&env, &client);
+
+    let s = "a".repeat(201);
+    let result = client.try_issue_reputation(
+        &contract_id,
+        &client_addr,
+        &5,
+        &String::from_str(&env, &s),
+    );
+    super::assert_contract_error(result, EscrowError::CommentTooLong);
+}


### PR DESCRIPTION
 test: cover comment length bounds in issue_reputation
  
  Summary
  
  Adds boundary tests for the comment parameter of issue_reputation and documents that the
  200-character limit is a byte limit, not a character limit.
  
  Changes
  
  contracts/escrow/src/lib.rs
  
  Added a /// Comment length section to the issue_reputation doc comment:
  
  - The bound is 1..=200 bytes (UTF-8 byte length).
  - Multi-byte characters (e.g. a 3-byte emoji) count as multiple bytes toward the limit.
  - Documents EmptyComment and CommentTooLong errors inline.
  - Notes that the 200-byte cap prevents unbounded on-chain storage growth.
  
  contracts/escrow/src/test/reputation.rs
  
  Four new boundary tests:
  
  ┌──────┬──────────────┬──────────┐
  │ Test                                        │ Input length │ Expected │
  ├─────────────────────────────────────────────┼──────────────┼──────────────┤
  │ comment_length_0_rejects_with_empty_comment │ 0 bytes      │ EmptyComment │
  ├─────────────────────────────────────────────┼──────────────┼──────────────┤
  │ comment_length_1_succeeds                   │ 1 byte       │ success      │
  ├─────────────────────────────────────────────┼──────────────┼──────────────┤
  │ comment_length_200_succeeds                      │ 200 bytes    │ success      │
  ├──────────────────────────────────────────────────┼──────────────┼────────────────┤
  │ comment_length_201_rejects_with_comment_too_long │ 201 bytes    │ CommentTooLong │
  └──────────────────────────────────────────────────┴──────────────┴────────────────┘
  
  All tests use ASCII input so byte length equals character length, making the boundary
  unambiguous.
  
  Testing
  
  cargo test -p escrow

closes #547 