### PR TITLE
refactor(escrow): consolidate EscrowError into single authoritative enum

### DIFF
--- a/contracts/escrow/src/amount_validation.rs
+++ b/contracts/escrow/src/amount_validation.rs
@@ -27,15 +27,15 @@ pub enum AmountValidationError {
 ///
 /// # Returns
 /// `Ok(())` if valid, `Err(AmountValidationError)` if invalid
-pub fn validate_single_amount(amount: i128) -> Result<(), crate::EscrowError> {
+pub fn validate_single_amount(amount: i128) -> Result<(), crate::Error> {
     // Check positivity
     if amount <= MIN_POSITIVE_AMOUNT - 1 {
-        return Err(crate::EscrowError::AmountMustBePositive);
+        return Err(crate::Error::AmountMustBePositive);
     }
 
     // Check maximum bounds
     if amount > MAX_SINGLE_AMOUNT_STROOPS {
-        return Err(crate::EscrowError::InvalidMilestoneAmount);
+        return Err(crate::Error::InvalidMilestoneAmount);
     }
 
     Ok(())
@@ -49,7 +49,7 @@ pub fn validate_single_amount(amount: i128) -> Result<(), crate::EscrowError> {
 /// # Returns
 /// `Ok(total)` with sum of all amounts if valid, `Err(AmountValidationError)` if invalid
 #[allow(dead_code)] // available for callers; not used by the contract directly
-pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, crate::EscrowError> {
+pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, crate::Error> {
     let mut total: i128 = 0;
 
     for &amount in amounts.iter() {
@@ -60,7 +60,7 @@ pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, crate::EscrowErro
         if let Some(new_total) = total.checked_add(amount) {
             total = new_total;
         } else {
-            return Err(crate::EscrowError::PotentialOverflow);
+            return Err(crate::Error::PotentialOverflow);
         }
     }
 
@@ -79,10 +79,10 @@ pub fn validate_amount_array(amounts: &[i128]) -> Result<i128, crate::EscrowErro
 pub fn validate_contract_total(
     total_amount: i128,
     max_contract_total: i128,
-) -> Result<(), crate::EscrowError> {
+) -> Result<(), crate::Error> {
     if total_amount > max_contract_total {
         // Map to InvalidMilestoneAmount for contract total overflow
-        return Err(crate::EscrowError::InvalidMilestoneAmount);
+        return Err(crate::Error::InvalidMilestoneAmount);
     }
     Ok(())
 }
@@ -99,7 +99,7 @@ pub fn validate_contract_total(
 pub fn validate_milestone_amounts(
     milestone_amounts: &[i128],
     max_contract_total: i128,
-) -> Result<i128, crate::EscrowError> {
+) -> Result<i128, crate::Error> {
     // Validate each milestone amount and calculate total
     let total = validate_amount_array(milestone_amounts)?;
 
@@ -123,17 +123,17 @@ pub fn validate_deposit_amount(
     deposit_amount: i128,
     current_deposited: i128,
     max_contract_total: i128,
-) -> Result<(), crate::EscrowError> {
+) -> Result<(), crate::Error> {
     // Validate deposit amount itself
     validate_single_amount(deposit_amount)?;
 
     // Check if deposit would exceed contract maximum
     if let Some(new_total) = current_deposited.checked_add(deposit_amount) {
         if new_total > max_contract_total {
-            return Err(crate::EscrowError::InvalidMilestoneAmount);
+            return Err(crate::Error::InvalidMilestoneAmount);
         }
     } else {
-        return Err(crate::EscrowError::PotentialOverflow);
+        return Err(crate::Error::PotentialOverflow);
     }
 
     Ok(())
@@ -166,7 +166,7 @@ pub fn safe_subtract_amounts(a: i128, b: i128) -> Option<i128> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::EscrowError;
+    use crate::Error;
 
     #[test]
     fn test_validate_single_amount() {
@@ -176,15 +176,15 @@ mod tests {
 
         assert_eq!(
             validate_single_amount(0),
-            Err(crate::EscrowError::AmountMustBePositive)
+            Err(crate::Error::AmountMustBePositive)
         );
         assert_eq!(
             validate_single_amount(-1),
-            Err(crate::EscrowError::AmountMustBePositive)
+            Err(crate::Error::AmountMustBePositive)
         );
         assert_eq!(
             validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS + 1),
-            Err(crate::EscrowError::InvalidMilestoneAmount)
+            Err(crate::Error::InvalidMilestoneAmount)
         );
     }
 
@@ -197,13 +197,13 @@ mod tests {
         let amounts2 = [100_0000000, 0, 300_0000000];
         assert_eq!(
             validate_amount_array(&amounts2),
-            Err(crate::EscrowError::AmountMustBePositive)
+            Err(crate::Error::AmountMustBePositive)
         );
 
         let amounts3 = [100_0000000, -50_0000000, 300_0000000];
         assert_eq!(
             validate_amount_array(&amounts3),
-            Err(crate::EscrowError::AmountMustBePositive)
+            Err(crate::Error::AmountMustBePositive)
         );
     }
 
@@ -214,7 +214,7 @@ mod tests {
         assert!(validate_contract_total(max_total, max_total).is_ok());
         assert_eq!(
             validate_contract_total(max_total + 1, max_total),
-            Err(crate::EscrowError::InvalidMilestoneAmount)
+            Err(crate::Error::InvalidMilestoneAmount)
         );
     }
 
@@ -226,7 +226,7 @@ mod tests {
         let milestones2 = [500_000_0000000, 600_000_0000000];
         assert_eq!(
             validate_milestone_amounts(&milestones2, max_contract_total),
-            Err(crate::EscrowError::InvalidMilestoneAmount)
+            Err(crate::Error::InvalidMilestoneAmount)
         );
     }
 
@@ -237,7 +237,7 @@ mod tests {
         assert!(validate_deposit_amount(100_0000000, 500_0000000, max_contract_total).is_ok());
         assert_eq!(
             validate_deposit_amount(600_000_0000000, 500_000_0000000, max_contract_total),
-            Err(crate::EscrowError::InvalidMilestoneAmount)
+            Err(crate::Error::InvalidMilestoneAmount)
         );
     }
 

--- a/contracts/escrow/src/approvals.rs
+++ b/contracts/escrow/src/approvals.rs
@@ -1,7 +1,5 @@
 use crate::ttl::{PENDING_APPROVAL_BUMP_THRESHOLD, PENDING_APPROVAL_TTL_LEDGERS};
-use crate::types::{
-    Contract, ContractStatus, DataKey, Error, Milestone, MilestoneApprovals, ReleaseAuthorization,
-};
+use crate::types::{Contract, ContractStatus, DataKey, Error, Milestone, MilestoneApprovals, ReleaseAuthorization};
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
 /// Approves a milestone for release by the caller.

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,9 +1,6 @@
 // Merged imports
 
-use crate::{
-    safe_add_amounts, Contract, ContractStatus, DataKey, Escrow, EscrowArgs, EscrowClient,
-    EscrowError,
-};
+use crate::{safe_add_amounts, Contract, ContractStatus, DataKey, Escrow, EscrowArgs, EscrowClient, Error};
 use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol};
 
 // Removed obsolete duplicated `impl Escrow`

--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -1,15 +1,12 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
 
-use crate::{
-    safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow, EscrowError,
-    Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION,
-};
+use crate::{safe_subtract_amounts, Contract, ContractStatus, ContractSummary, DataKey, Escrow, Error, Milestone, MilestoneSummary, CONTRACT_SUMMARY_SCHEMA_VERSION};
 
 /// Immutable metadata written when an escrow contract is closed.
 ///
 /// The record is stored once under `DataKey::Finalization(contract_id)`.
 /// After it exists, all contract-specific mutating entrypoints reject with
-/// `EscrowError::AlreadyFinalized`.
+/// `Error::AlreadyFinalized`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FinalizationRecord {
@@ -30,7 +27,7 @@ impl Escrow {
         env.storage()
             .persistent()
             .get::<_, Contract>(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound))
     }
 
     pub(crate) fn is_finalized(env: &Env, contract_id: u32) -> bool {
@@ -41,7 +38,7 @@ impl Escrow {
 
     pub(crate) fn require_not_finalized(env: &Env, contract_id: u32) {
         if Self::is_finalized(env, contract_id) {
-            env.panic_with_error(EscrowError::AlreadyFinalized);
+            env.panic_with_error(Error::AlreadyFinalized);
         }
     }
 
@@ -52,7 +49,7 @@ impl Escrow {
             .get::<_, bool>(&DataKey::Paused)
             .unwrap_or(false)
         {
-            env.panic_with_error(EscrowError::ContractPaused);
+            env.panic_with_error(Error::ContractPaused);
         }
         if env
             .storage()
@@ -60,7 +57,7 @@ impl Escrow {
             .get::<_, bool>(&DataKey::Emergency)
             .unwrap_or(false)
         {
-            env.panic_with_error(EscrowError::EmergencyActive);
+            env.panic_with_error(Error::EmergencyActive);
         }
     }
 
@@ -69,7 +66,7 @@ impl Escrow {
         let is_freelancer = *finalizer == contract.freelancer;
         let is_arbiter = contract.arbiter.clone().is_some_and(|a| a == *finalizer);
         if !is_client && !is_freelancer && !is_arbiter {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
+            env.panic_with_error(Error::UnauthorizedRole);
         }
     }
 
@@ -84,12 +81,12 @@ impl Escrow {
             let idx = index as u32;
             total_amount = total_amount
                 .checked_add(ms.amount)
-                .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+                .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
 
             if ms.released {
                 released_milestone_count = released_milestone_count
                     .checked_add(1)
-                    .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+                    .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
             }
 
             milestone_summaries.push_back(MilestoneSummary {
@@ -102,9 +99,9 @@ impl Escrow {
 
         let after_releases =
             safe_subtract_amounts(contract.funded_amount, contract.released_amount)
-                .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+                .unwrap_or_else(|| env.panic_with_error(Error::AccountingInvariantViolated));
         let refundable_balance = safe_subtract_amounts(after_releases, contract.refunded_amount)
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+            .unwrap_or_else(|| env.panic_with_error(Error::AccountingInvariantViolated));
 
         ContractSummary {
             schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,
@@ -145,7 +142,7 @@ pub fn finalize_contract_impl(env: &Env, contract_id: u32, finalizer: Address) -
     Escrow::require_finalizer_role(&env, &contract, &finalizer);
 
     if contract.status != ContractStatus::Completed && contract.status != ContractStatus::Disputed {
-        env.panic_with_error(EscrowError::InvalidStatusTransition);
+        env.panic_with_error(Error::InvalidStatusTransition);
     }
 
     let record = FinalizationRecord {

--- a/contracts/escrow/src/fuzz_test.rs
+++ b/contracts/escrow/src/fuzz_test.rs
@@ -36,7 +36,7 @@ extern crate std;
 use proptest::prelude::*;
 use soroban_sdk::{testutils::Address as _, vec as sorovec, Address, Env, Vec as SoroVec};
 
-use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS};
+use crate::{Escrow, EscrowClient, Error, ReleaseAuthorization, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -60,8 +60,8 @@ fn to_soroban_vec(env: &Env, amounts: &[i128]) -> SoroVec<i128> {
 }
 
 fn assert_err(
-    result: Result<impl core::fmt::Debug, Result<EscrowError, soroban_sdk::InvokeError>>,
-    expected: EscrowError,
+    result: Result<impl core::fmt::Debug, Result<Error, soroban_sdk::InvokeError>>,
+    expected: Error,
 ) {
     assert_eq!(result, Err(Ok(expected)));
 }
@@ -80,7 +80,7 @@ proptest! {
         let milestones = sorovec![&env, 100_i128];
         let cid = client.create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly);
 
-        assert_err(client.try_deposit_funds(&cid, &client_addr, &bad_amount), EscrowError::AmountMustBePositive);
+        assert_err(client.try_deposit_funds(&cid, &client_addr, &bad_amount), Error::AmountMustBePositive);
     }
 
     /// Empty milestone list must be rejected at contract creation.
@@ -93,7 +93,7 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&client_addr, &freelancer_addr, &None, &empty, &ReleaseAuthorization::ClientOnly),
-            EscrowError::EmptyMilestones,
+            Error::EmptyMilestones,
         );
     }
 
@@ -107,7 +107,7 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly),
-            EscrowError::InvalidMilestoneAmount,
+            Error::InvalidMilestoneAmount,
         );
     }
 
@@ -123,7 +123,7 @@ proptest! {
 
         assert_err(
             client.try_release_milestone(&cid, &client_addr, &oob_idx),
-            EscrowError::MilestoneNotFound,
+            Error::MilestoneNotFound,
         );
     }
 
@@ -140,7 +140,7 @@ proptest! {
 
         assert_err(
             client.try_release_milestone(&cid, &client_addr, &idx),
-            EscrowError::MilestoneAlreadyReleased,
+            Error::MilestoneAlreadyReleased,
         );
     }
 }
@@ -174,7 +174,7 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly),
-            EscrowError::TooManyMilestones,
+            Error::TooManyMilestones,
         );
     }
 
@@ -200,7 +200,7 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly),
-            EscrowError::TotalExceedsMaxEscrow,
+            Error::TotalExceedsMaxEscrow,
         );
     }
 
@@ -230,7 +230,7 @@ proptest! {
         client.deposit_funds(&cid, &client_addr, &100_i128);
         client.release_milestone(&cid, &client_addr, &0);
 
-        assert_err(client.try_issue_reputation(&cid, &client_addr, &freelancer_addr, &rating), EscrowError::InvalidRating);
+        assert_err(client.try_issue_reputation(&cid, &client_addr, &freelancer_addr, &rating), Error::InvalidRating);
     }
 
     /// Deposit exactly equal to total required must be accepted and mark contract Funded.
@@ -258,7 +258,7 @@ proptest! {
 
         assert_err(
             client.try_deposit_funds(&cid, &client_addr, &1),
-            EscrowError::FundingExceedsRequired,
+            Error::FundingExceedsRequired,
         );
     }
 }
@@ -277,7 +277,7 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&same, &same, &None, &milestones, &ReleaseAuthorization::ClientOnly),
-            EscrowError::InvalidParticipants,
+            Error::InvalidParticipants,
         );
     }
 
@@ -287,9 +287,9 @@ proptest! {
         let (env, client) = setup();
         let client_addr = Address::generate(&env);
 
-        assert_err(client.try_get_contract(&bad_id), EscrowError::ContractNotFound);
-        assert_err(client.try_deposit_funds(&bad_id, &client_addr, &1), EscrowError::ContractNotFound);
-        assert_err(client.try_release_milestone(&bad_id, &client_addr, &0), EscrowError::ContractNotFound);
+        assert_err(client.try_get_contract(&bad_id), Error::ContractNotFound);
+        assert_err(client.try_deposit_funds(&bad_id, &client_addr, &1), Error::ContractNotFound);
+        assert_err(client.try_release_milestone(&bad_id, &client_addr, &0), Error::ContractNotFound);
     }
 
     /// All mutating entrypoints must be blocked when the contract is paused.
@@ -306,10 +306,10 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly),
-            EscrowError::ContractPaused,
+            Error::ContractPaused,
         );
-        assert_err(client.try_deposit_funds(&0, &client_addr, &100), EscrowError::ContractPaused);
-        assert_err(client.try_release_milestone(&0, &client_addr, &0), EscrowError::ContractPaused);
+        assert_err(client.try_deposit_funds(&0, &client_addr, &100), Error::ContractPaused);
+        assert_err(client.try_release_milestone(&0, &client_addr, &0), Error::ContractPaused);
     }
 
     /// All mutating entrypoints must be blocked during emergency pause.
@@ -326,10 +326,10 @@ proptest! {
 
         assert_err(
             client.try_create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly),
-            EscrowError::ContractPaused,
+            Error::ContractPaused,
         );
-        assert_err(client.try_deposit_funds(&0, &client_addr, &100), EscrowError::ContractPaused);
-        assert_err(client.try_release_milestone(&0, &client_addr, &0), EscrowError::ContractPaused);
+        assert_err(client.try_deposit_funds(&0, &client_addr, &100), Error::ContractPaused);
+        assert_err(client.try_release_milestone(&0, &client_addr, &0), Error::ContractPaused);
     }
 
     /// Reputation cannot be issued on an incomplete (not-all-milestones-released) contract.
@@ -344,7 +344,7 @@ proptest! {
         // Only release one of two milestones — contract not complete.
         client.release_milestone(&cid, &client_addr, &0);
 
-        assert_err(client.try_issue_reputation(&cid, &client_addr, &freelancer_addr, &5), EscrowError::InvalidState);
+        assert_err(client.try_issue_reputation(&cid, &client_addr, &freelancer_addr, &5), Error::InvalidState);
     }
 
     /// Reputation can only be issued once per contract.
@@ -359,7 +359,7 @@ proptest! {
         client.release_milestone(&cid, &client_addr, &0);
         client.issue_reputation(&cid, &client_addr, &freelancer_addr, &5);
 
-        assert_err(client.try_issue_reputation(&cid, &client_addr, &freelancer_addr, &4), EscrowError::ReputationAlreadyIssued);
+        assert_err(client.try_issue_reputation(&cid, &client_addr, &freelancer_addr, &4), Error::ReputationAlreadyIssued);
     }
 
     /// Release without sufficient funded balance must be rejected.
@@ -376,7 +376,7 @@ proptest! {
 
         assert_err(
             client.try_release_milestone(&cid, &client_addr, &0),
-            EscrowError::InsufficientEscrowBalance,
+            Error::InsufficientEscrowBalance,
         );
     }
 }

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -1,6 +1,4 @@
-use crate::{
-    DataKey, Escrow, EscrowArgs, EscrowClient, EscrowError, GovernedParameters, ReadinessChecklist,
-};
+use crate::{DataKey, Escrow, EscrowArgs, EscrowClient, Error, GovernedParameters, ReadinessChecklist};
 use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol};
 
 /// Pending admin proposal stored under `DataKey::PendingAdmin`.
@@ -106,7 +104,7 @@ impl Escrow {
             .sequence()
             .saturating_sub(pending.proposed_at_ledger);
         if elapsed < ADMIN_ROTATION_MIN_DELAY_LEDGERS {
-            env.panic_with_error(EscrowError::TimelockNotElapsed);
+            env.panic_with_error(Error::TimelockNotElapsed);
         }
 
         let pending_admin = pending.proposed;
@@ -155,22 +153,22 @@ impl Escrow {
             .get::<_, bool>(&crate::DataKey::Initialized)
             .unwrap_or(false)
         {
-            env.panic_with_error(EscrowError::NotInitialized);
+            env.panic_with_error(Error::NotInitialized);
         }
 
         let stored_admin: Address = env
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
 
         if admin != stored_admin {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
+            env.panic_with_error(Error::UnauthorizedRole);
         }
         admin.require_auth();
 
         if protocol_fee_bps > 10_000 {
-            env.panic_with_error(EscrowError::InvalidProtocolParameters);
+            env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
         let params = GovernedParameters {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -41,66 +41,17 @@ pub use amount_validation::{safe_add_amounts, safe_subtract_amounts};
 pub use dispute::DisputeResolution;
 pub use migration::PendingClientMigration;
 pub use ttl::{ADMIN_ROTATION_MIN_DELAY_LEDGERS, PENDING_MIGRATION_TTL_LEDGERS};
-pub use types::{
-    Contract, ContractStatus, ContractSummary, DataKey, DepositMode, Error, GovernedParameters,
-    Milestone, MilestoneApprovals, MilestoneSummary, ReadinessChecklist, ReleaseAuthorization,
-    Reputation, CONTRACT_SUMMARY_SCHEMA_VERSION,
-};
+pub use types::{Contract, ContractStatus, ContractSummary, DataKey, DepositMode, Error, GovernedParameters, Milestone, MilestoneApprovals, MilestoneSummary, ReadinessChecklist, ReleaseAuthorization, Reputation, CONTRACT_SUMMARY_SCHEMA_VERSION};
 
 // Re-export for internal use
 pub(crate) use amount_validation::safe_subtract_amounts;
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String,
-    Symbol, Vec,
-};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec};
 
 #[contract]
 pub struct Escrow;
 
-/// Governance-level errors for admin-gated operations.
-#[contracterror]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u32)]
-pub enum EscrowError {
-    InvalidParticipant = 1,
-    EmptyMilestones = 2,
-    InvalidMilestoneAmount = 3,
-    InvalidDepositAmount = 4,
-    InvalidMilestone = 5,
-    ContractNotFound = 6,
-    EmptyRefundRequest = 7,
-    DuplicateMilestoneInRefund = 8,
-    AlreadyReleased = 9,
-    AlreadyRefunded = 10,
-    InsufficientFunds = 11,
-    AlreadyInitialized = 12,
-    InsufficientAccumulatedFees = 13,
-    /// Returned by lifecycle entrypoints when `initialize` has not been called.
-    ///
-    /// All money-flow operations require initialization so the admin-controlled
-    /// safety rails (pause, emergency controls, protocol fees) are always in
-    /// scope before any funds can move.
-    NotInitialized = 14,
-    UnauthorizedRole = 15,
-    ContractPaused = 16,
-    EmergencyActive = 17,
-    InvalidState = 18,
-    InvalidRating = 19,
-    SelfRating = 20,
-    ReputationAlreadyIssued = 21,
-    NotCompleted = 22,
-    FreelancerMismatch = 23,
-    InvalidStatusTransition = 24,
-    ArbiterRequired = 25,
-    InvalidDisputeSplit = 26,
-    AccountingInvariantViolated = 27,
-    PotentialOverflow = 28,
-    AlreadyFinalized = 29,
-    AmountMustBePositive = 30,
-    /// Returned by `submit_work_evidence` when the evidence string exceeds 256 bytes.
-    EvidenceTooLong = 31,
-}
+
 
 /// Returns `Some(a + b)`, or `None` on overflow.
 pub fn safe_add_amounts(a: i128, b: i128) -> Option<i128> {
@@ -131,7 +82,7 @@ impl Escrow {
             .get::<_, bool>(&DataKey::Initialized)
             .unwrap_or(false)
         {
-            env.panic_with_error(EscrowError::AlreadyInitialized);
+            env.panic_with_error(Error::AlreadyInitialized);
         }
 
         admin.require_auth();
@@ -664,7 +615,7 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
 
         // Extend TTL on contract read
         ttl::extend_contract_ttl(&env, contract_id);
@@ -741,7 +692,7 @@ impl Escrow {
             .get::<_, bool>(&DataKey::Emergency)
             .unwrap_or(false)
         {
-            env.panic_with_error(EscrowError::EmergencyActive);
+            env.panic_with_error(Error::EmergencyActive);
         }
         let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
         admin.require_auth();
@@ -778,7 +729,7 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
 
         if env
             .storage()
@@ -934,34 +885,34 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
         ttl::extend_contract_ttl(&env, contract_id);
 
         if caller != contract.client {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
+            env.panic_with_error(Error::UnauthorizedRole);
         }
 
         if rating < 1 || rating > 5 {
-            env.panic_with_error(EscrowError::InvalidRating);
+            env.panic_with_error(Error::InvalidRating);
         }
 
         if comment.len() == 0 {
-            env.panic_with_error(EscrowError::EmptyComment);
+            env.panic_with_error(Error::EmptyComment);
         }
 
         if comment.len() > 200 {
-            env.panic_with_error(EscrowError::CommentTooLong);
+            env.panic_with_error(Error::CommentTooLong);
         }
 
         if contract.status != ContractStatus::Completed {
-            env.panic_with_error(EscrowError::NotCompleted);
+            env.panic_with_error(Error::NotCompleted);
         }
 
         if contract.reputation_issued {
-            env.panic_with_error(EscrowError::ReputationAlreadyIssued);
+            env.panic_with_error(Error::ReputationAlreadyIssued);
         }
         if contract.client == contract.freelancer {
-            env.panic_with_error(EscrowError::SelfRating);
+            env.panic_with_error(Error::SelfRating);
         }
 
         caller.require_auth();
@@ -973,7 +924,7 @@ impl Escrow {
         let pending_key = DataKey::PendingReputationCredits(contract.freelancer.clone());
         let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
         if pending <= 0 {
-            env.panic_with_error(EscrowError::InvalidState);
+            env.panic_with_error(Error::InvalidState);
         }
         env.storage().persistent().set(&pending_key, &(pending - 1));
 
@@ -1109,7 +1060,7 @@ impl Escrow {
 
         // Bound evidence to 256 bytes to prevent storage bloat.
         if evidence.len() > 256 {
-            env.panic_with_error(EscrowError::EvidenceTooLong);
+            env.panic_with_error(Error::EvidenceTooLong);
         }
 
         let mut milestones: Vec<Milestone> = ttl::load_milestones(&env, contract_id);
@@ -1288,15 +1239,15 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
 
         if admin != stored_admin {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
+            env.panic_with_error(Error::UnauthorizedRole);
         }
         admin.require_auth();
 
         if protocol_fee_bps > 10_000 {
-            env.panic_with_error(EscrowError::InvalidProtocolParameters);
+            env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
         let params = GovernedParameters {
@@ -1351,7 +1302,7 @@ impl Escrow {
             .get::<_, bool>(&DataKey::Initialized)
             .unwrap_or(false)
         {
-            env.panic_with_error(EscrowError::NotInitialized);
+            env.panic_with_error(Error::NotInitialized);
         }
     }
 
@@ -1417,25 +1368,25 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
 
         ttl::extend_contract_ttl(&env, contract_id);
         Self::require_not_finalized(&env, contract_id);
 
         // Verify caller is client or freelancer
         if caller != contract.client && caller != contract.freelancer {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
+            env.panic_with_error(Error::UnauthorizedRole);
         }
 
         // Require arbiter assignment
         if contract.arbiter.is_none() {
-            env.panic_with_error(EscrowError::ArbiterRequired);
+            env.panic_with_error(Error::ArbiterRequired);
         }
 
         // Verify contract is in a disputable state (Funded or PartiallyFunded)
         match contract.status {
             ContractStatus::Funded | ContractStatus::PartiallyFunded => {}
-            _ => env.panic_with_error(EscrowError::InvalidState),
+            _ => env.panic_with_error(Error::InvalidState),
         }
 
         contract.status = ContractStatus::Disputed;
@@ -1497,20 +1448,20 @@ impl Escrow {
             .storage()
             .persistent()
             .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
 
         ttl::extend_contract_ttl(&env, contract_id);
         Self::require_not_finalized(&env, contract_id);
 
         // Verify contract is in Disputed state
         if contract.status != ContractStatus::Disputed {
-            env.panic_with_error(EscrowError::InvalidStatusTransition);
+            env.panic_with_error(Error::InvalidStatusTransition);
         }
 
         // Verify caller is the assigned arbiter
         match &contract.arbiter {
             Some(contract_arbiter) if *contract_arbiter == arbiter => {}
-            _ => env.panic_with_error(EscrowError::UnauthorizedRole),
+            _ => env.panic_with_error(Error::UnauthorizedRole),
         }
 
         // Compute payouts based on resolution

--- a/contracts/escrow/src/migration.rs
+++ b/contracts/escrow/src/migration.rs
@@ -1,5 +1,5 @@
 use crate::ttl::{read_if_live, remove_transient, store_with_ttl, PENDING_MIGRATION_TTL_LEDGERS};
-use crate::{Contract, ContractStatus, DataKey, Escrow, EscrowError};
+use crate::{Contract, ContractStatus, DataKey, Escrow, Error};
 use soroban_sdk::{contracttype, Address, Env, Symbol};
 
 #[contracttype]
@@ -20,7 +20,7 @@ impl Escrow {
         env.storage()
             .persistent()
             .get::<_, Contract>(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound))
     }
 
     pub(crate) fn require_migration_allowed(env: &Env, status: ContractStatus) {
@@ -31,7 +31,7 @@ impl Escrow {
                 | ContractStatus::Refunded
                 | ContractStatus::Disputed
         ) {
-            env.panic_with_error(EscrowError::InvalidStatusTransition);
+            env.panic_with_error(Error::InvalidStatusTransition);
         }
     }
 
@@ -58,14 +58,14 @@ pub fn propose_client_migration_impl(
     let contract = Escrow::load_contract(&env, contract_id);
     Escrow::require_not_finalized(&env, contract_id);
     if current_client != contract.client {
-        env.panic_with_error(EscrowError::UnauthorizedRole);
+        env.panic_with_error(Error::UnauthorizedRole);
     }
     if new_client == contract.client || new_client == contract.freelancer {
-        env.panic_with_error(EscrowError::InvalidParticipant);
+        env.panic_with_error(Error::InvalidParticipant);
     }
     Escrow::require_migration_allowed(&env, contract.status);
     if Escrow::pending_migration_exists(&env, contract_id) {
-        env.panic_with_error(EscrowError::InvalidState);
+        env.panic_with_error(Error::InvalidState);
     }
 
     let requested_at = env.ledger().sequence();
@@ -101,13 +101,13 @@ pub fn accept_client_migration_impl(env: &Env, contract_id: u32, new_client: Add
 
     let key = Escrow::pending_migration_key(contract_id);
     let pending: PendingClientMigration =
-        read_if_live(&env, &key).unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidState));
+        read_if_live(&env, &key).unwrap_or_else(|| env.panic_with_error(Error::InvalidState));
 
     if pending.proposed_client != new_client {
-        env.panic_with_error(EscrowError::UnauthorizedRole);
+        env.panic_with_error(Error::UnauthorizedRole);
     }
     if pending.current_client != contract.client {
-        env.panic_with_error(EscrowError::InvalidState);
+        env.panic_with_error(Error::InvalidState);
     }
 
     contract.client = new_client.clone();
@@ -131,5 +131,5 @@ pub fn has_pending_client_migration_impl(env: &Env, contract_id: u32) -> bool {
 /// Return the live pending client migration record.
 pub fn get_pending_client_migration_impl(env: &Env, contract_id: u32) -> PendingClientMigration {
     read_if_live(&env, &Escrow::pending_migration_key(contract_id))
-        .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidState))
+        .unwrap_or_else(|| env.panic_with_error(Error::InvalidState))
 }

--- a/contracts/escrow/src/proptest.rs
+++ b/contracts/escrow/src/proptest.rs
@@ -33,9 +33,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::vec::Vec as StdVec;
 
 use proptest::prelude::*;
-use soroban_sdk::{
-    testutils::Address as _, Address, Env, Vec as SorobanVec,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec as SorobanVec};
 
 use crate::{Contract, ContractStatus, Escrow, EscrowClient, ReleaseAuthorization};
 

--- a/contracts/escrow/src/refund.rs
+++ b/contracts/escrow/src/refund.rs
@@ -1,6 +1,4 @@
-use crate::{
-    ttl, Contract, ContractStatus, DataKey, Error, Escrow, Milestone,
-};
+use crate::{ttl, Contract, ContractStatus, DataKey, Error, Escrow, Milestone};
 use soroban_sdk::{contractimpl, Env, Symbol, Vec};
 
 #[contractimpl]

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -1,7 +1,4 @@
-use crate::{
-    approvals, ttl, Contract, ContractStatus, DataKey, Error, Escrow, Milestone,
-    ReleaseAuthorization,
-};
+use crate::{approvals, ttl, Contract, ContractStatus, DataKey, Error, Escrow, Milestone, ReleaseAuthorization};
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
 impl Escrow {

--- a/contracts/escrow/src/simple_amount_test.rs
+++ b/contracts/escrow/src/simple_amount_test.rs
@@ -5,11 +5,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::amount_validation::{
-        safe_add_amounts, safe_subtract_amounts, validate_contract_total, validate_deposit_amount,
-        validate_milestone_amounts, validate_single_amount, EscrowError,
-        MAX_SINGLE_AMOUNT_STROOPS, MIN_POSITIVE_AMOUNT,
-    };
+    use crate::amount_validation::{safe_add_amounts, safe_subtract_amounts, validate_contract_total, validate_deposit_amount, validate_milestone_amounts, validate_single_amount, Error, MAX_SINGLE_AMOUNT_STROOPS, MIN_POSITIVE_AMOUNT};
     use crate::MAX_TOTAL_ESCROW_STROOPS;
 
     #[test]
@@ -22,15 +18,15 @@ mod tests {
         // Test invalid amounts
         assert_eq!(
             validate_single_amount(0),
-            Err(EscrowError::AmountMustBePositive)
+            Err(Error::AmountMustBePositive)
         );
         assert_eq!(
             validate_single_amount(-1),
-            Err(EscrowError::AmountMustBePositive)
+            Err(Error::AmountMustBePositive)
         );
         assert_eq!(
             validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS + 1),
-            Err(EscrowError::InvalidMilestoneAmount)
+            Err(Error::InvalidMilestoneAmount)
         );
     }
 
@@ -52,19 +48,19 @@ mod tests {
         let milestones3 = [100_0000000, 0, 300_0000000]; // Contains zero
         assert_eq!(
             validate_milestone_amounts(&milestones3, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::AmountMustBePositive)
+            Err(Error::AmountMustBePositive)
         );
 
         let milestones4 = [100_0000000, -50_0000000, 300_0000000]; // Contains negative
         assert_eq!(
             validate_milestone_amounts(&milestones4, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::AmountMustBePositive)
+            Err(Error::AmountMustBePositive)
         );
 
         let milestones5 = [600_000_0000000, 500_000_0000000]; // Exceeds contract max
         assert_eq!(
             validate_milestone_amounts(&milestones5, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::InvalidMilestoneAmount)
+            Err(Error::InvalidMilestoneAmount)
         );
     }
 
@@ -82,17 +78,17 @@ mod tests {
         // Test invalid deposits
         assert_eq!(
             validate_deposit_amount(0, 0, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::AmountMustBePositive)
+            Err(Error::AmountMustBePositive)
         );
         assert_eq!(
             validate_deposit_amount(-1, 0, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::AmountMustBePositive)
+            Err(Error::AmountMustBePositive)
         );
 
         // Test would exceed maximum
         assert_eq!(
             validate_deposit_amount(600_000_0000000, 500_000_0000000, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::InvalidMilestoneAmount)
+            Err(Error::InvalidMilestoneAmount)
         );
     }
 
@@ -107,7 +103,7 @@ mod tests {
         // Test invalid totals
         assert_eq!(
             validate_contract_total(MAX_TOTAL_ESCROW_STROOPS + 1, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::InvalidMilestoneAmount)
+            Err(Error::InvalidMilestoneAmount)
         );
     }
 
@@ -137,7 +133,7 @@ mod tests {
         assert!(validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS).is_ok());
         assert_eq!(
             validate_single_amount(MAX_SINGLE_AMOUNT_STROOPS + 1),
-            Err(EscrowError::InvalidMilestoneAmount)
+            Err(Error::InvalidMilestoneAmount)
         );
 
         // Test contract boundary
@@ -147,7 +143,7 @@ mod tests {
         let over_boundary_milestones = [MAX_TOTAL_ESCROW_STROOPS + 1];
         assert_eq!(
             validate_milestone_amounts(&over_boundary_milestones, MAX_TOTAL_ESCROW_STROOPS),
-            Err(EscrowError::InvalidMilestoneAmount)
+            Err(Error::InvalidMilestoneAmount)
         );
     }
 

--- a/contracts/escrow/src/test/admin_auth_helper.rs
+++ b/contracts/escrow/src/test/admin_auth_helper.rs
@@ -7,7 +7,7 @@
 //! 2. Calling any entrypoint before `initialize` panics with `NotInitialized`.
 //! 3. A non-admin caller cannot authenticate (Soroban auth failure = panic).
 
-use crate::{Escrow, EscrowClient, EscrowError};
+use crate::{Escrow, EscrowClient, Error};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -36,14 +36,14 @@ fn setup_uninitialized(env: &Env) -> EscrowClient<'_> {
 fn pause_before_initialize_panics_not_initialized() {
     let env = Env::default();
     let client = setup_uninitialized(&env);
-    super::assert_contract_error(client.try_pause(), EscrowError::NotInitialized);
+    super::assert_contract_error(client.try_pause(), Error::NotInitialized);
 }
 
 #[test]
 fn unpause_before_initialize_panics_not_initialized() {
     let env = Env::default();
     let client = setup_uninitialized(&env);
-    super::assert_contract_error(client.try_unpause(), EscrowError::NotInitialized);
+    super::assert_contract_error(client.try_unpause(), Error::NotInitialized);
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn activate_emergency_pause_before_initialize_panics_not_initialized() {
     let client = setup_uninitialized(&env);
     super::assert_contract_error(
         client.try_activate_emergency_pause(),
-        EscrowError::NotInitialized,
+        Error::NotInitialized,
     );
 }
 
@@ -60,7 +60,7 @@ fn activate_emergency_pause_before_initialize_panics_not_initialized() {
 fn resolve_emergency_before_initialize_panics_not_initialized() {
     let env = Env::default();
     let client = setup_uninitialized(&env);
-    super::assert_contract_error(client.try_resolve_emergency(), EscrowError::NotInitialized);
+    super::assert_contract_error(client.try_resolve_emergency(), Error::NotInitialized);
 }
 
 // ─── Correct admin loaded and authenticated ───────────────────────────────────

--- a/contracts/escrow/src/test/authorization_matrix_validation.rs
+++ b/contracts/escrow/src/test/authorization_matrix_validation.rs
@@ -13,7 +13,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
-use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, Error, ReleaseAuthorization};
 
 use super::assert_contract_error;
 
@@ -67,11 +67,11 @@ fn clientonly_matrix_allowed_approvers() {
 
     // Freelancer cannot approve
     let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 
     // Arbiter cannot approve
     let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn clientonly_matrix_required_approvals() {
 
     // Without approvals, release fails
     let result = client.try_release_milestone(&id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::InsufficientApprovals);
+    assert_contract_error(result, Error::InsufficientApprovals);
 
     // With client approval, release succeeds
     assert!(client.approve_milestone_release(&id, &client_addr, &0));
@@ -122,11 +122,11 @@ fn clientonly_matrix_allowed_release_callers() {
 
     // Freelancer cannot release
     let result = client.try_release_milestone(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 
     // Arbiter cannot release
     let result = client.try_release_milestone(&id, &arbiter_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 // ===========================================================================
@@ -154,11 +154,11 @@ fn arbiteronly_matrix_allowed_approvers() {
 
     // Client cannot approve
     let result = client.try_approve_milestone_release(&id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 
     // Freelancer cannot approve
     let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn arbiteronly_matrix_required_approvals() {
 
     // Without approvals, release fails
     let result = client.try_release_milestone(&id, &arbiter_addr, &0);
-    assert_contract_error(result, EscrowError::InsufficientApprovals);
+    assert_contract_error(result, Error::InsufficientApprovals);
 
     // With arbiter approval, release succeeds
     assert!(client.approve_milestone_release(&id, &arbiter_addr, &0));
@@ -209,11 +209,11 @@ fn arbiteronly_matrix_allowed_release_callers() {
 
     // Client cannot release
     let result = client.try_release_milestone(&id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 
     // Freelancer cannot release
     let result = client.try_release_milestone(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 // ===========================================================================
@@ -245,7 +245,7 @@ fn clientandarbiter_matrix_allowed_approvers() {
 
     // Freelancer cannot approve
     let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 #[test]
@@ -317,7 +317,7 @@ fn clientandarbiter_matrix_allowed_release_callers() {
 
     // Freelancer cannot release
     let result = client.try_release_milestone(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 // ===========================================================================
@@ -349,7 +349,7 @@ fn multisig_matrix_allowed_approvers() {
 
     // Arbiter cannot approve
     let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 #[test]
@@ -370,7 +370,7 @@ fn multisig_matrix_required_approvals_and_logic() {
     // With only client approval, release fails
     assert!(client.approve_milestone_release(&id, &client_addr, &0));
     let result = client.try_release_milestone(&id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::InsufficientApprovals);
+    assert_contract_error(result, Error::InsufficientApprovals);
 
     // With both approvals, release succeeds
     assert!(client.approve_milestone_release(&id, &freelancer_addr, &0));
@@ -416,7 +416,7 @@ fn multisig_matrix_allowed_release_callers() {
 
     // Arbiter cannot release
     let result = client.try_release_milestone(&id, &arbiter_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 // ===========================================================================
@@ -439,7 +439,7 @@ fn matrix_error_codes_unauthorized_role() {
         &ReleaseAuthorization::ClientOnly,
     );
     let result = client.try_approve_milestone_release(&id, &freelancer_addr, &0);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 #[test]
@@ -462,7 +462,7 @@ fn matrix_error_codes_already_approved() {
 
     // Duplicate approval fails
     let result = client.try_approve_milestone_release(&id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::AlreadyApproved);
+    assert_contract_error(result, Error::AlreadyApproved);
 }
 
 #[test]
@@ -482,7 +482,7 @@ fn matrix_error_codes_insufficient_approvals() {
 
     // Release without approval fails
     let result = client.try_release_milestone(&id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::InsufficientApprovals);
+    assert_contract_error(result, Error::InsufficientApprovals);
 }
 
 #[test]

--- a/contracts/escrow/src/test/client_migration.rs
+++ b/contracts/escrow/src/test/client_migration.rs
@@ -4,12 +4,9 @@ use crate::migration::PendingClientMigration;
 use crate::ttl::PENDING_MIGRATION_TTL_LEDGERS;
 use crate::{
     types::{ContractStatus, DataKey},
-    Contract, Escrow, EscrowClient, EscrowError,
+    Contract, Escrow, EscrowClient, Error,
 };
-use soroban_sdk::{
-    testutils::Address as _, testutils::Events, testutils::Ledger as _, testutils::LedgerInfo,
-    Address, Env, IntoVal, Symbol, TryFromVal, Val,
-};
+use soroban_sdk::{testutils::Address as _, testutils::Events, testutils::Ledger as _, testutils::LedgerInfo, Address, Env, IntoVal, Symbol, TryFromVal, Val};
 
 use super::{assert_contract_error, create_contract, register_client, total_milestone_amount};
 
@@ -148,19 +145,19 @@ fn non_proposed_address_cannot_accept_migration() {
     // Random attacker is rejected
     assert_contract_error(
         client.try_accept_client_migration(&id, &attacker),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 
     // The original client is also rejected (only proposed address may accept)
     assert_contract_error(
         client.try_accept_client_migration(&id, &client_addr),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 
     // Freelancer is rejected
     assert_contract_error(
         client.try_accept_client_migration(&id, &freelancer_addr),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 }
 
@@ -221,7 +218,7 @@ fn expired_proposal_cannot_be_accepted() {
     // accept panics with InvalidState because no live record exists
     assert_contract_error(
         client.try_accept_client_migration(&id, &new_client),
-        EscrowError::InvalidState,
+        Error::InvalidState,
     );
 }
 
@@ -313,7 +310,7 @@ fn migration_blocked_on_completed_contract() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &new_client),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
 }
 
@@ -332,7 +329,7 @@ fn migration_blocked_on_cancelled_contract() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &new_client),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
 }
 
@@ -353,7 +350,7 @@ fn migration_blocked_on_refunded_contract() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &new_client),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
 }
 
@@ -373,7 +370,7 @@ fn migration_blocked_on_disputed_contract() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &new_client),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
 }
 
@@ -393,7 +390,7 @@ fn cannot_propose_freelancer_as_new_client() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &freelancer_addr),
-        EscrowError::InvalidParticipant,
+        Error::InvalidParticipant,
     );
 }
 
@@ -409,7 +406,7 @@ fn cannot_propose_current_client_as_new_client() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &client_addr),
-        EscrowError::InvalidParticipant,
+        Error::InvalidParticipant,
     );
 }
 
@@ -432,13 +429,13 @@ fn only_current_client_may_propose_migration() {
     // Freelancer as proposer is rejected
     assert_contract_error(
         client.try_propose_client_migration(&id, &freelancer_addr, &new_client),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 
     // Random attacker as proposer is rejected
     assert_contract_error(
         client.try_propose_client_migration(&id, &attacker, &new_client),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 }
 
@@ -462,7 +459,7 @@ fn duplicate_proposal_while_pending_is_rejected() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &new_client2),
-        EscrowError::InvalidState,
+        Error::InvalidState,
     );
 }
 
@@ -487,7 +484,7 @@ fn double_accept_after_migration_accepted_fails() {
     // Pending record is gone — second accept must fail
     assert_contract_error(
         client.try_accept_client_migration(&id, &new_client),
-        EscrowError::InvalidState,
+        Error::InvalidState,
     );
 }
 

--- a/contracts/escrow/src/test/create_contract_bounds.rs
+++ b/contracts/escrow/src/test/create_contract_bounds.rs
@@ -11,9 +11,7 @@
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
 
-use crate::{
-    Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS,
-};
+use crate::{Escrow, EscrowClient, Error, ReleaseAuthorization, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS};
 
 // Returns (env, contract_address). Each test creates EscrowClient locally so
 // the borrow of `env` stays in the same scope — same pattern as pause_controls.
@@ -29,7 +27,7 @@ fn assert_err(
         Result<u32, soroban_sdk::ConversionError>,
         Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
     >,
-    expected: EscrowError,
+    expected: Error,
 ) {
     match result {
         Err(Ok(e)) => {
@@ -49,7 +47,7 @@ fn rejects_same_client_and_freelancer() {
     let same = Address::generate(&env);
     assert_err(
         client.try_create_contract(&same, &same, &None, &vec![&env, 100_i128], &ReleaseAuthorization::ClientOnly),
-        EscrowError::InvalidParticipant,
+        Error::InvalidParticipant,
     );
 }
 
@@ -63,7 +61,7 @@ fn rejects_empty_milestones() {
     let f = Address::generate(&env);
     assert_err(
         client.try_create_contract(&c, &f, &None, &Vec::new(&env), &ReleaseAuthorization::ClientOnly),
-        EscrowError::EmptyMilestones,
+        Error::EmptyMilestones,
     );
 }
 
@@ -82,7 +80,7 @@ fn rejects_one_over_max_milestones() {
     assert_eq!(amounts.len(), MAX_MILESTONES + 1);
     assert_err(
         client.try_create_contract(&c, &f, &None, &amounts, &ReleaseAuthorization::ClientOnly),
-        EscrowError::TooManyMilestones,
+        Error::TooManyMilestones,
     );
 }
 
@@ -112,7 +110,7 @@ fn rejects_zero_milestone_amount() {
     let f = Address::generate(&env);
     assert_err(
         client.try_create_contract(&c, &f, &None, &vec![&env, 0_i128], &ReleaseAuthorization::ClientOnly),
-        EscrowError::InvalidMilestoneAmount,
+        Error::InvalidMilestoneAmount,
     );
 }
 
@@ -124,7 +122,7 @@ fn rejects_negative_milestone_amount() {
     let f = Address::generate(&env);
     assert_err(
         client.try_create_contract(&c, &f, &None, &vec![&env, -1_i128], &ReleaseAuthorization::ClientOnly),
-        EscrowError::InvalidMilestoneAmount,
+        Error::InvalidMilestoneAmount,
     );
 }
 
@@ -140,7 +138,7 @@ fn rejects_amounts_that_would_overflow_i128() {
     let large = i128::MAX / 2 + 2;
     assert_err(
         client.try_create_contract(&c, &f, &None, &vec![&env, large, large], &ReleaseAuthorization::ClientOnly),
-        EscrowError::PotentialOverflow,
+        Error::PotentialOverflow,
     );
 }
 
@@ -175,7 +173,7 @@ fn rejects_total_one_over_cap() {
             &vec![&env, MAX_TOTAL_ESCROW_STROOPS + 1],
             &ReleaseAuthorization::ClientOnly,
         ),
-        EscrowError::InvalidMilestoneAmount,
+        Error::InvalidMilestoneAmount,
     );
 }
 
@@ -188,7 +186,7 @@ fn rejects_multi_milestone_total_over_cap() {
     let half = MAX_TOTAL_ESCROW_STROOPS / 2 + 1;
     assert_err(
         client.try_create_contract(&c, &f, &None, &vec![&env, half, half], &ReleaseAuthorization::ClientOnly),
-        EscrowError::InvalidMilestoneAmount,
+        Error::InvalidMilestoneAmount,
     );
 }
 
@@ -208,6 +206,6 @@ fn count_guard_fires_before_amount_guard() {
     }
     assert_err(
         client.try_create_contract(&c, &f, &None, &amounts, &ReleaseAuthorization::ClientOnly),
-        EscrowError::TooManyMilestones,
+        Error::TooManyMilestones,
     );
 }

--- a/contracts/escrow/src/test/deposit.rs
+++ b/contracts/escrow/src/test/deposit.rs
@@ -1,6 +1,4 @@
-use super::{
-    assert_contract_error, assert_contract_state, create_client, create_default_contract, setup,
-};
+use super::{assert_contract_error, assert_contract_state, create_client, create_default_contract, setup};
 use crate::{types::Error, ContractStatus};
 use soroban_sdk::{testutils::Address as _, Address};
 
@@ -150,7 +148,7 @@ fn test_deposit_unauthorized_role() {
     // Attempt deposit from wrong caller (freelancer instead of client)
     let wrong_caller = Address::generate(&env);
     let result = client.try_deposit_funds(&contract_id, &wrong_caller, &100_0000000_i128);
-    assert_contract_error(result, EscrowError::UnauthorizedRole);
+    assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 /// Tests that deposit_funds panics with InvalidState when contract is not in Created state.
@@ -172,7 +170,7 @@ fn test_deposit_invalid_state() {
 
     // Try to deposit again (contract is now Funded, not Created)
     let result = client.try_deposit_funds(&contract_id, &client_addr, &100_0000000_i128);
-    assert_contract_error(result, EscrowError::InvalidState);
+    assert_contract_error(result, Error::InvalidState);
 }
 
 /// Tests that deposit_funds panics with InsufficientFunds when caller token balance is too low.

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -1,8 +1,6 @@
 #![cfg(test)]
 
-use crate::{
-    ContractStatus, DisputeResolution, Escrow, EscrowClient, EscrowError, ReleaseAuthorization,
-};
+use crate::{ContractStatus, DisputeResolution, Escrow, EscrowClient, Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 fn setup_initialized() -> (Env, EscrowClient<'static>) {
@@ -254,7 +252,7 @@ fn raise_dispute_requires_contract_party() {
     let outsider = Address::generate(&env);
     super::assert_contract_error(
         client.try_raise_dispute(&escrow_id, &outsider),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 }
 
@@ -279,7 +277,7 @@ fn raise_dispute_requires_assigned_arbiter() {
 
     super::assert_contract_error(
         client.try_raise_dispute(&escrow_id, &client_addr),
-        EscrowError::ArbiterRequired,
+        Error::ArbiterRequired,
     );
 }
 
@@ -295,7 +293,7 @@ fn raise_dispute_rejects_completed_contract() {
 
     super::assert_contract_error(
         client.try_raise_dispute(&escrow_id, &client_addr),
-        EscrowError::InvalidState,
+        Error::InvalidState,
     );
 }
 
@@ -414,7 +412,7 @@ fn resolve_split_rejects_invalid_totals() {
     // Split doesn't match available balance
     super::assert_contract_error(
         client.try_resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::Split(30, 50)),
-        EscrowError::InvalidDisputeSplit,
+        Error::InvalidDisputeSplit,
     );
 }
 
@@ -432,7 +430,7 @@ fn resolve_split_rejects_negative_amounts() {
             &arbiter_addr,
             &DisputeResolution::Split(-10, 110),
         ),
-        EscrowError::InvalidDisputeSplit,
+        Error::InvalidDisputeSplit,
     );
 }
 
@@ -447,7 +445,7 @@ fn resolve_dispute_requires_assigned_arbiter() {
     let outsider = Address::generate(&env);
     super::assert_contract_error(
         client.try_resolve_dispute(&escrow_id, &outsider, &DisputeResolution::FullPayout),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 }
 
@@ -460,7 +458,7 @@ fn resolve_dispute_rejects_non_disputed_contract() {
     // Try to resolve without raising dispute first
     super::assert_contract_error(
         client.try_resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::FullRefund),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
 }
 
@@ -476,7 +474,7 @@ fn resolve_dispute_cannot_be_called_twice() {
     // Try to resolve again
     super::assert_contract_error(
         client.try_resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::FullPayout),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
 }
 
@@ -490,7 +488,7 @@ fn pause_blocks_raise_dispute() {
 
     super::assert_contract_error(
         client.try_raise_dispute(&escrow_id, &client_addr),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -505,7 +503,7 @@ fn pause_blocks_resolve_dispute() {
 
     super::assert_contract_error(
         client.try_resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::FullRefund),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -519,7 +517,7 @@ fn emergency_blocks_raise_and_resolve_dispute() {
 
     super::assert_contract_error(
         client.try_raise_dispute(&escrow_id, &client_addr),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 
     // Resolve emergency, raise dispute, then emergency again
@@ -529,7 +527,7 @@ fn emergency_blocks_raise_and_resolve_dispute() {
 
     super::assert_contract_error(
         client.try_resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::FullRefund),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 }
 

--- a/contracts/escrow/src/test/emergency_controls.rs
+++ b/contracts/escrow/src/test/emergency_controls.rs
@@ -1,4 +1,4 @@
-use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 fn setup_initialized() -> (Env, Address, Address) {
@@ -54,7 +54,7 @@ fn unpause_fails_while_emergency_active() {
     let (env, contract_id, _admin) = setup_initialized();
     let client = EscrowClient::new(&env, &contract_id);
     client.activate_emergency_pause();
-    super::assert_contract_error(client.try_unpause(), EscrowError::EmergencyActive);
+    super::assert_contract_error(client.try_unpause(), Error::EmergencyActive);
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn emergency_blocks_create_contract() {
             &vec![&env, 50_i128],
             &ReleaseAuthorization::ClientOnly,
         ),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -100,7 +100,7 @@ fn emergency_blocks_deposit_funds() {
 
     super::assert_contract_error(
         client.try_deposit_funds(&id, &client_addr, &50_i128),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -115,7 +115,7 @@ fn emergency_blocks_release_milestone() {
 
     super::assert_contract_error(
         client.try_release_milestone(&id, &client_addr, &0),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -136,7 +136,7 @@ fn emergency_blocks_issue_reputation() {
             &5_u32,
             &soroban_sdk::String::from_str(&env, "Great"),
         ),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -151,7 +151,7 @@ fn emergency_blocks_cancel_contract() {
 
     super::assert_contract_error(
         client.try_cancel_contract(&id, &client_addr),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 

--- a/contracts/escrow/src/test/flows.rs
+++ b/contracts/escrow/src/test/flows.rs
@@ -1,5 +1,5 @@
 use super::{complete_contract, create_contract, default_milestones, register_client, total_milestone_amount};
-use crate::{EscrowError, ReleaseAuthorization, types::DataKey};
+use crate::{Error, ReleaseAuthorization, types::DataKey};
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
 
 #[test]
@@ -41,7 +41,7 @@ fn scenario_reputation_invalid_rating_zero_fails() {
     let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::InvalidRating);
+    super::assert_contract_error(result, Error::InvalidRating);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn scenario_reputation_invalid_rating_six_fails() {
     let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::InvalidRating);
+    super::assert_contract_error(result, Error::InvalidRating);
 }
 
 #[test]

--- a/contracts/escrow/src/test/input_sanitization_amounts.rs
+++ b/contracts/escrow/src/test/input_sanitization_amounts.rs
@@ -4,11 +4,7 @@
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
-use crate::{
-    safe_add_amounts, safe_subtract_amounts, validate_deposit_amount, validate_milestone_amounts,
-    validate_single_amount, Escrow, EscrowClient, EscrowError, ReleaseAuthorization,
-    MAX_TOTAL_ESCROW_STROOPS,
-};
+use crate::{safe_add_amounts, safe_subtract_amounts, validate_deposit_amount, validate_milestone_amounts, validate_single_amount, Escrow, EscrowClient, Error, ReleaseAuthorization, MAX_TOTAL_ESCROW_STROOPS};
 
 fn setup() -> (Env, EscrowClient, Address, Address) {
     let env = Env::default();
@@ -163,19 +159,19 @@ fn test_single_amount_validation() {
     // Invalid amounts
     assert_eq!(
         validate_single_amount(0),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
     assert_eq!(
         validate_single_amount(-1),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
     assert_eq!(
         validate_single_amount(-100_0000000),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
     assert_eq!(
         validate_single_amount(1_000_000_0000001),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 }
 
@@ -203,19 +199,19 @@ fn test_milestone_amounts_validation() {
     let milestones4 = vec![100_0000000, 0, 300_0000000]; // Contains zero
     assert_eq!(
         validate_milestone_amounts(&milestones4, max_total),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
 
     let milestones5 = vec![100_0000000, -50_0000000, 300_0000000]; // Contains negative
     assert_eq!(
         validate_milestone_amounts(&milestones5, max_total),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
 
     let milestones6 = vec![600_000_0000000, 500_000_0000000]; // Exceeds contract max
     assert_eq!(
         validate_milestone_amounts(&milestones6, max_total),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 }
 
@@ -231,23 +227,23 @@ fn test_deposit_amount_validation() {
     // Invalid deposits
     assert_eq!(
         validate_deposit_amount(0, 0, max_total),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
     assert_eq!(
         validate_deposit_amount(-1, 0, max_total),
-        Err(EscrowError::AmountMustBePositive)
+        Err(Error::AmountMustBePositive)
     );
 
     // Would exceed maximum
     assert_eq!(
         validate_deposit_amount(600_000_0000000, 500_000_0000000, max_total),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 
     // Single amount exceeds maximum
     assert_eq!(
         validate_deposit_amount(1_000_000_0000001, 0, max_total),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 }
 
@@ -279,7 +275,7 @@ fn test_edge_cases() {
     assert!(validate_single_amount(1_000_000_0000000).is_ok()); // Max single amount
     assert_eq!(
         validate_single_amount(1_000_000_0000001),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 
     // Test contract boundary
@@ -289,7 +285,7 @@ fn test_edge_cases() {
     let over_boundary_milestones = vec![MAX_TOTAL_ESCROW_STROOPS + 1];
     assert_eq!(
         validate_milestone_amounts(&over_boundary_milestones, max_total),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 }
 
@@ -327,7 +323,7 @@ fn test_large_amount_arrays() {
     }
     assert_eq!(
         validate_milestone_amounts(&overflow_milestones, max_total),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 }
 
@@ -343,7 +339,7 @@ fn test_cumulative_deposit_validation() {
     // Should fail when cumulative exceeds maximum
     assert_eq!(
         validate_deposit_amount(800_000_0000000, 300_000_0000000, max_total),
-        Err(EscrowError::InvalidMilestoneAmount)
+        Err(Error::InvalidMilestoneAmount)
     );
 }
 

--- a/contracts/escrow/src/test/lifecycle.rs
+++ b/contracts/escrow/src/test/lifecycle.rs
@@ -1,4 +1,4 @@
-use crate::{ContractStatus, DepositMode, DisputeResolution, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{ContractStatus, DepositMode, DisputeResolution, Escrow, EscrowClient, Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, vec, Address, Env};
 
 fn setup() -> (Env, Address) {
@@ -115,7 +115,7 @@ fn finalize_rejects_unauthorized_finalizer() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &outsider),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -136,7 +136,7 @@ fn finalize_rejects_non_terminal_contract() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -150,7 +150,7 @@ fn finalize_is_idempotent_guarded() {
     assert!(client.finalize_contract(&contract_id, &client_addr));
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -164,19 +164,19 @@ fn finalized_contract_rejects_subsequent_mutations() {
 
     super::assert_contract_error(
         client.try_deposit_funds(&contract_id, &client_addr, &1_i128),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
     super::assert_contract_error(
         client.try_release_milestone(&contract_id, &client_addr, &0),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
     super::assert_contract_error(
         client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great")),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
     super::assert_contract_error(
         client.try_cancel_contract(&contract_id, &client_addr),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -190,11 +190,11 @@ fn finalized_dispute_rejects_resolution() {
 
     super::assert_contract_error(
         client.try_resolve_dispute(&contract_id, &arbiter, &DisputeResolution::FullRefund),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
     super::assert_contract_error(
         client.try_raise_dispute(&contract_id, &client_addr),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -209,7 +209,7 @@ fn pause_blocks_finalization() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }

--- a/contracts/escrow/src/test/mainnet_readiness.rs
+++ b/contracts/escrow/src/test/mainnet_readiness.rs
@@ -2,7 +2,7 @@ extern crate std;
 
 use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env};
 
-use crate::{Escrow, EscrowClient, EscrowError};
+use crate::{Escrow, EscrowClient, Error};
 
 /// Returns a fresh (Env, contract Address) pair with all auths mocked.
 fn setup() -> (Env, Address) {
@@ -87,7 +87,7 @@ fn unauthorized_set_governed_params_does_not_set_flag() {
     client.initialize(&admin);
 
     let result = client.try_set_governed_params(&fake_admin, &1000_u32, &500_000_000_000_i128);
-    super::assert_contract_error(result, EscrowError::UnauthorizedRole);
+    super::assert_contract_error(result, Error::UnauthorizedRole);
 
     let info = client.get_mainnet_readiness_info();
     assert!(
@@ -105,7 +105,7 @@ fn invalid_set_governed_params_does_not_set_flag() {
     client.initialize(&admin);
 
     let result = client.try_set_governed_params(&admin, &20_000_u32, &500_000_000_000_i128);
-    super::assert_contract_error(result, EscrowError::InvalidProtocolParameters);
+    super::assert_contract_error(result, Error::InvalidProtocolParameters);
 
     let info = client.get_mainnet_readiness_info();
     assert!(

--- a/contracts/escrow/src/test/milestone_schedule.rs
+++ b/contracts/escrow/src/test/milestone_schedule.rs
@@ -19,10 +19,7 @@
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String, Vec};
 
-use crate::{
-    Escrow, EscrowClient, MilestoneSchedule, ReleaseAuthorization,
-    MAX_SCHEDULE_DESCRIPTION_LEN, MAX_SCHEDULE_TITLE_LEN,
-};
+use crate::{Escrow, EscrowClient, MilestoneSchedule, ReleaseAuthorization, MAX_SCHEDULE_DESCRIPTION_LEN, MAX_SCHEDULE_TITLE_LEN};
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -3,7 +3,7 @@
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
 
-use crate::{Contract, ContractStatus, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{Contract, ContractStatus, Escrow, EscrowClient, Error, ReleaseAuthorization};
 
 // --- Submodules ---
 
@@ -104,7 +104,7 @@ pub fn complete_contract(env: &Env, client: &EscrowClient) -> (Address, Address,
 ///   `Result<Result<T, ConversionError>, Result<soroban_sdk::Error, InvokeError>>`
 /// A contract-level `panic_with_error` surfaces as `Err(Ok(soroban_sdk::Error))`.
 /// The `expected` argument can be any type convertible to `soroban_sdk::Error`,
-/// including both `EscrowError` and the canonical `Error` from `types.rs`.
+/// including both `Error` and the canonical `Error` from `types.rs`.
 pub fn assert_contract_error<
     T: core::fmt::Debug,
     E: Into<soroban_sdk::Error> + core::fmt::Debug,

--- a/contracts/escrow/src/test/pause_controls.rs
+++ b/contracts/escrow/src/test/pause_controls.rs
@@ -14,7 +14,7 @@
 //!
 //! Run locally with `cargo test -p escrow --lib pause_controls`.
 
-use crate::{Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -105,7 +105,7 @@ fn initialize_only_once_fails() {
     let (_env, client, admin) = setup_initialized();
     super::assert_contract_error(
         client.try_initialize(&admin),
-        EscrowError::AlreadyInitialized,
+        Error::AlreadyInitialized,
     );
 }
 
@@ -128,7 +128,7 @@ fn pause_requires_initialization() {
     env.mock_all_auths();
     let contract_id = env.register(Escrow, ());
     let client = EscrowClient::new(&env, &contract_id);
-    super::assert_contract_error(client.try_pause(), EscrowError::NotInitialized);
+    super::assert_contract_error(client.try_pause(), Error::NotInitialized);
 }
 
 // ─── create_contract blocked ─────────────────────────────────────────────────
@@ -149,7 +149,7 @@ fn pause_blocks_create_contract() {
             &vec![&env, 50_i128],
             &ReleaseAuthorization::ClientOnly,
         ),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -169,7 +169,7 @@ fn emergency_blocks_create_contract() {
             &vec![&env, 50_i128],
             &ReleaseAuthorization::ClientOnly,
         ),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 }
 
@@ -224,7 +224,7 @@ fn pause_blocks_deposit_funds() {
 
     super::assert_contract_error(
         client.try_deposit_funds(&contract_id, &client_addr, &50_i128),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -237,7 +237,7 @@ fn emergency_blocks_deposit_funds() {
 
     super::assert_contract_error(
         client.try_deposit_funds(&contract_id, &client_addr, &50_i128),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 }
 
@@ -272,7 +272,7 @@ fn pause_blocks_release_milestone() {
 
     super::assert_contract_error(
         client.try_release_milestone(&contract_id, &client_addr, &0),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -285,7 +285,7 @@ fn emergency_blocks_release_milestone() {
 
     super::assert_contract_error(
         client.try_release_milestone(&contract_id, &client_addr, &0),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 }
 
@@ -321,7 +321,7 @@ fn pause_blocks_refund_unreleased_milestones() {
     client.pause();
 
     match client.try_refund_unreleased_milestones(&contract_id, &vec![&env, 1_u32]) {
-        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(EscrowError::ContractPaused)),
+        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(Error::ContractPaused)),
         other => panic!("expected ContractPaused error, got {:?}", other),
     }
 }
@@ -334,7 +334,7 @@ fn emergency_blocks_refund_unreleased_milestones() {
     set_emergency_only(&env, &client);
 
     match client.try_refund_unreleased_milestones(&contract_id, &vec![&env, 1_u32]) {
-        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(EscrowError::EmergencyActive)),
+        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(Error::EmergencyActive)),
         other => panic!("expected EmergencyActive error, got {:?}", other),
     }
 }
@@ -377,7 +377,7 @@ fn pause_blocks_issue_reputation() {
             &5_u32,
             &soroban_sdk::String::from_str(&env, "Great"),
         ),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -395,7 +395,7 @@ fn emergency_blocks_issue_reputation() {
             &5_u32,
             &soroban_sdk::String::from_str(&env, "Great"),
         ),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 }
 
@@ -440,7 +440,7 @@ fn pause_blocks_cancel_contract() {
 
     super::assert_contract_error(
         client.try_cancel_contract(&contract_id, &client_addr),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -453,7 +453,7 @@ fn emergency_blocks_cancel_contract() {
 
     super::assert_contract_error(
         client.try_cancel_contract(&contract_id, &client_addr),
-        EscrowError::EmergencyActive,
+        Error::EmergencyActive,
     );
 }
 
@@ -529,7 +529,7 @@ fn pause_gate_runs_before_auth_on_create_contract() {
             &milestones,
             &ReleaseAuthorization::ClientOnly,
         ),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -543,6 +543,6 @@ fn pause_gate_runs_before_auth_on_deposit_funds() {
     let outsider = Address::generate(&env);
     super::assert_contract_error(
         client.try_deposit_funds(&contract_id, &outsider, &50_i128),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -1,5 +1,5 @@
 use super::{create_contract, register_client};
-use crate::{ContractStatus, EscrowError, ReleaseAuthorization};
+use crate::{ContractStatus, Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Symbol};
 
 /// Finalization succeeds from Completed status; record snapshot matches contract state.
@@ -100,7 +100,7 @@ fn try_get_contract_reports_missing_state_without_mutating_storage() {
     env.mock_all_auths();
     let client = register_client(&env);
 
-    super::assert_contract_error(client.try_get_contract(&777), EscrowError::ContractNotFound);
+    super::assert_contract_error(client.try_get_contract(&777), Error::ContractNotFound);
     let client_addr = Address::generate(&env);
     let freelancer_addr = Address::generate(&env);
     let milestones = vec![&env, 10_i128];
@@ -140,7 +140,7 @@ fn finalize_rejects_unauthorized_finalizer() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &outsider),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -155,7 +155,7 @@ fn finalize_rejects_created_contract() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -175,7 +175,7 @@ fn finalize_rejects_funded_contract() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::InvalidStatusTransition,
+        Error::InvalidStatusTransition,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -191,7 +191,7 @@ fn finalize_is_idempotent_guarded() {
     assert!(client.finalize_contract(&contract_id, &client_addr));
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -207,7 +207,7 @@ fn release_milestone_rejects_after_finalization() {
 
     super::assert_contract_error(
         client.try_release_milestone(&contract_id, &client_addr, &0),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -224,7 +224,7 @@ fn refund_unreleased_milestones_rejects_after_finalization() {
     let res = client.try_refund_unreleased_milestones(&contract_id, &vec![&env, 0u32]);
     match res {
         Err(Ok(e)) => {
-            assert_eq!(e, soroban_sdk::Error::from(EscrowError::AlreadyFinalized));
+            assert_eq!(e, soroban_sdk::Error::from(Error::AlreadyFinalized));
         }
         _ => panic!("expected contract error AlreadyFinalized"),
     }
@@ -242,7 +242,7 @@ fn deposit_funds_rejects_after_finalization() {
 
     super::assert_contract_error(
         client.try_deposit_funds(&contract_id, &client_addr, &1_i128),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -258,7 +258,7 @@ fn approve_milestone_release_rejects_after_finalization() {
 
     super::assert_contract_error(
         client.try_approve_milestone_release(&contract_id, &client_addr, &0),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );
 }
 
@@ -294,7 +294,7 @@ fn pause_blocks_finalization() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &client_addr),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -355,7 +355,7 @@ fn get_contract_panics_for_unknown_id() {
     env.mock_all_auths();
     let client = register_client(&env);
 
-    assert_contract_error(client.try_get_contract(&999), EscrowError::ContractNotFound);
+    assert_contract_error(client.try_get_contract(&999), Error::ContractNotFound);
 }
 
 /// `get_contract` panics with `ContractNotFound` even when probed with id zero
@@ -366,7 +366,7 @@ fn get_contract_panics_for_zero_id_when_no_zero_contract() {
     env.mock_all_auths();
     let client = register_client(&env);
 
-    assert_contract_error(client.try_get_contract(&0), EscrowError::ContractNotFound);
+    assert_contract_error(client.try_get_contract(&0), Error::ContractNotFound);
 }
 
 // ── get_contract: success ─────────────────────────────────────────────────────
@@ -461,7 +461,7 @@ fn get_milestones_panics_for_unknown_id() {
 
     assert_contract_error(
         client.try_get_milestones(&999),
-        EscrowError::ContractNotFound,
+        Error::ContractNotFound,
     );
 }
 
@@ -473,7 +473,7 @@ fn get_milestones_panics_for_zero_id_when_no_zero_contract() {
     env.mock_all_auths();
     let client = register_client(&env);
 
-    assert_contract_error(client.try_get_milestones(&0), EscrowError::ContractNotFound);
+    assert_contract_error(client.try_get_milestones(&0), Error::ContractNotFound);
 }
 
 // ── get_milestones: success ───────────────────────────────────────────────────
@@ -532,7 +532,7 @@ fn get_refundable_balance_panics_for_unknown_id() {
     let client = register_client(&env);
 
     match client.try_get_refundable_balance(&999) {
-        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(EscrowError::ContractNotFound)),
+        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(Error::ContractNotFound)),
         other => panic!("expected ContractNotFound, got {:?}", other),
     }
 }
@@ -545,7 +545,7 @@ fn get_refundable_balance_panics_for_zero_id() {
     let client = register_client(&env);
 
     match client.try_get_refundable_balance(&0) {
-        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(EscrowError::ContractNotFound)),
+        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(Error::ContractNotFound)),
         other => panic!("expected ContractNotFound, got {:?}", other),
     }
 }
@@ -916,14 +916,14 @@ fn read_getters_fail_for_arbitrary_unknown_id() {
         // Invalid id 4_242 — no getter may mutate stored state.
         assert_contract_error(
             client.try_get_contract(&4_242),
-            EscrowError::ContractNotFound,
+            Error::ContractNotFound,
         );
         assert_contract_error(
             client.try_get_milestones(&4_242),
-            EscrowError::ContractNotFound,
+            Error::ContractNotFound,
         );
         match client.try_get_refundable_balance(&4_242) {
-            Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(EscrowError::ContractNotFound)),
+            Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(Error::ContractNotFound)),
             other => panic!("expected ContractNotFound, got {:?}", other),
         };
 
@@ -961,11 +961,11 @@ fn read_getters_succeed_after_creating_contract_at_zero_index() {
     // First contract allocated by `create_contract` is at slot 1 (DataKey::NextContractId
     // starts at 1 — see create_contract.rs). Probe the zero slot to confirm
     // it remains not-found, then exercise slot 1.
-    assert_contract_error(client.try_get_contract(&0), EscrowError::ContractNotFound);
-    assert_contract_error(client.try_get_milestones(&0), EscrowError::ContractNotFound);
+    assert_contract_error(client.try_get_contract(&0), Error::ContractNotFound);
+    assert_contract_error(client.try_get_milestones(&0), Error::ContractNotFound);
     assert_contract_error(
         client.try_get_refundable_balance(&0),
-        EscrowError::ContractNotFound,
+        Error::ContractNotFound,
     );
 
     let (c, f) = generated_participants(&env);
@@ -1022,14 +1022,14 @@ fn read_getters_unchanged_after_pause() {
     // Not-found assertions still hold while paused.
     assert_contract_error(
         client.try_get_contract(&9999),
-        EscrowError::ContractNotFound,
+        Error::ContractNotFound,
     );
     assert_contract_error(
         client.try_get_milestones(&9999),
-        EscrowError::ContractNotFound,
+        Error::ContractNotFound,
     );
     match client.try_get_refundable_balance(&9999) {
-        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(EscrowError::ContractNotFound)),
+        Err(Ok(e)) => assert_eq!(e, soroban_sdk::Error::from(Error::ContractNotFound)),
         other => panic!("expected ContractNotFound, got {:?}", other),
     };
 }

--- a/contracts/escrow/src/test/refund.rs
+++ b/contracts/escrow/src/test/refund.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::vec;
 
 use super::{assert_contract_error, complete_contract, create_contract, register_client};
-use crate::{ContractStatus, Error, EscrowError};
+use crate::{ContractStatus, Error};
 #[test]
 fn refund_succeeds_on_funded_contract() {
     let env = soroban_sdk::Env::default();
@@ -61,5 +61,5 @@ fn rejects_refund_on_finalized_contract() {
     let refund_ids = vec![&env, 0_u32];
     assert_contract_error(
         client.try_refund_unreleased_milestones(&contract_id, &refund_ids),
-        EscrowError::AlreadyFinalized,
+        Error::AlreadyFinalized,
     );

--- a/contracts/escrow/src/test/release.rs
+++ b/contracts/escrow/src/test/release.rs
@@ -1,12 +1,7 @@
-use soroban_sdk::{
-    symbol_short, testutils::Address as _, testutils::Events, vec, Address, Env, String, Symbol,
-    TryFromVal, Val,
-};
+use soroban_sdk::{symbol_short, testutils::Address as _, testutils::Events, vec, Address, Env, String, Symbol, TryFromVal, Val};
 
-use super::{
-    assert_contract_error, create_contract, register_client, total_milestone_amount, MILESTONE_ONE,
-};
-use crate::{ContractStatus, Error, EscrowError, ReleaseAuthorization};
+use super::{assert_contract_error, create_contract, register_client, total_milestone_amount, MILESTONE_ONE};
+use crate::{ContractStatus, Error, ReleaseAuthorization};
 
 fn evidence(env: &Env, s: &str) -> String {
     String::from_str(env, s)
@@ -53,7 +48,7 @@ fn rejects_release_without_sufficient_balance() {
     assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
     let result = client.try_release_milestone(&contract_id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::InsufficientFunds);
+    assert_contract_error(result, Error::InsufficientFunds);
 }
 
 #[test]
@@ -65,7 +60,7 @@ fn rejects_release_of_invalid_milestone_index() {
 
     assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestone_amount()));
     let result = client.try_release_milestone(&contract_id, &client_addr, &99);
-    assert_contract_error(result, EscrowError::InvalidMilestone);
+    assert_contract_error(result, Error::InvalidMilestone);
 }
 
 #[test]
@@ -80,7 +75,7 @@ fn rejects_releasing_refunded_milestone() {
 
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
     let result = client.try_release_milestone(&contract_id, &client_addr, &1);
-    assert_contract_error(result, EscrowError::AlreadyRefunded);
+    assert_contract_error(result, Error::AlreadyRefunded);
 }
 
 #[test]
@@ -96,7 +91,7 @@ fn rejects_releasing_same_milestone_twice() {
 
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
     let result = client.try_release_milestone(&contract_id, &client_addr, &0);
-    assert_contract_error(result, EscrowError::AlreadyReleased);
+    assert_contract_error(result, Error::AlreadyReleased);
 }
 
 // ---------------------------------------------------------------------------
@@ -266,7 +261,7 @@ fn work_evidence_rejects_oversized_string() {
     // 257 chars > 256-byte limit
     let ev = String::from_str(&env, &"a".repeat(257));
     let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
-    assert_contract_error(result, EscrowError::EvidenceTooLong);
+    assert_contract_error(result, Error::EvidenceTooLong);
 }
 
 #[test]
@@ -296,7 +291,7 @@ fn work_evidence_rejects_paused_contract() {
 
     let ev = evidence(&env, "ipfs://QmTest");
     let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
-    assert_contract_error(result, EscrowError::ContractPaused);
+    assert_contract_error(result, Error::ContractPaused);
 }
 
 #[test]
@@ -318,7 +313,7 @@ fn work_evidence_rejects_finalized_contract() {
 
     let ev = evidence(&env, "ipfs://QmAfterFinalize");
     let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev);
-    assert_contract_error(result, EscrowError::AlreadyFinalized);
+    assert_contract_error(result, Error::AlreadyFinalized);
 }
 
 #[test]

--- a/contracts/escrow/src/test/release_authorization.rs
+++ b/contracts/escrow/src/test/release_authorization.rs
@@ -18,9 +18,7 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{
-    testutils::Address as _, testutils::Events, vec, Address, Env, IntoVal, Symbol, TryFromVal,
-};
+use soroban_sdk::{testutils::Address as _, testutils::Events, vec, Address, Env, IntoVal, Symbol, TryFromVal};
 
 use super::register_client;
 use crate::{ContractStatus, Error, Escrow, EscrowClient, ReleaseAuthorization};

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -1,5 +1,5 @@
 use super::{complete_contract, create_contract, register_client};
-use crate::{Contract, DataKey, EscrowError};
+use crate::{Contract, DataKey, Error};
 use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 fn valid_comment(env: &Env) -> String {
@@ -15,7 +15,7 @@ fn issue_reputation_rejects_unauthorized_caller() {
     let unauthorized = Address::generate(&env);
 
     let result = client.try_issue_reputation(&contract_id, &unauthorized, &5, &valid_comment(&env));
-    super::assert_contract_error(result, EscrowError::UnauthorizedRole);
+    super::assert_contract_error(result, Error::UnauthorizedRole);
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn issue_reputation_rejects_non_completed_contract() {
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env));
-    super::assert_contract_error(result, EscrowError::NotCompleted);
+    super::assert_contract_error(result, Error::NotCompleted);
 }
 
 #[test]
@@ -37,10 +37,10 @@ fn issue_reputation_rejects_invalid_rating_bounds() {
     let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
 
     let result_low = client.try_issue_reputation(&contract_id, &client_addr, &0, &valid_comment(&env));
-    super::assert_contract_error(result_low, EscrowError::InvalidRating);
+    super::assert_contract_error(result_low, Error::InvalidRating);
 
     let result_high = client.try_issue_reputation(&contract_id, &client_addr, &6, &valid_comment(&env));
-    super::assert_contract_error(result_high, EscrowError::InvalidRating);
+    super::assert_contract_error(result_high, Error::InvalidRating);
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn issue_reputation_rejects_empty_comment() {
 
     let empty_comment = String::from_str(&env, "");
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::EmptyComment);
+    super::assert_contract_error(result, Error::EmptyComment);
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn issue_reputation_rejects_comment_too_long() {
     let long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let long_comment = String::from_str(&env, long_str);
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::CommentTooLong);
+    super::assert_contract_error(result, Error::CommentTooLong);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn issue_reputation_rejects_duplicate_issuance() {
 
     assert!(client.issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env)));
     let result = client.try_issue_reputation(&contract_id, &client_addr, &4, &valid_comment(&env));
-    super::assert_contract_error(result, EscrowError::ReputationAlreadyIssued);
+    super::assert_contract_error(result, Error::ReputationAlreadyIssued);
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn issue_reputation_rejects_self_rating_when_client_equals_freelancer() {
     });
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env));
-    super::assert_contract_error(result, EscrowError::SelfRating);
+    super::assert_contract_error(result, Error::SelfRating);
 }
 
 #[test]

--- a/contracts/escrow/src/test/sac_custody.rs
+++ b/contracts/escrow/src/test/sac_custody.rs
@@ -26,11 +26,8 @@ use soroban_sdk::{
     Address, Env, Symbol, Vec as SorobanVec,
 };
 
-use super::{
-    assert_contract_error, create_contract, register_client, total_milestone_amount,
-    MILESTONE_ONE, MILESTONE_TWO, MILESTONE_THREE,
-};
-use crate::{ContractStatus, EscrowError, ReleaseAuthorization};
+use super::{assert_contract_error, create_contract, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_TWO, MILESTONE_THREE};
+use crate::{ContractStatus, Error, ReleaseAuthorization};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -141,7 +138,7 @@ fn bind_settlement_token_rejects_double_bind() {
 
     assert_contract_error(
         client.try_bind_settlement_token(&sac2),
-        EscrowError::SettlementTokenAlreadyBound,
+        Error::SettlementTokenAlreadyBound,
     );
 }
 
@@ -153,7 +150,7 @@ fn bind_settlement_token_rejects_uninit() {
     let sac = env.register_stellar_asset_contract(Address::generate(&env));
     assert_contract_error(
         client.try_bind_settlement_token(&sac),
-        EscrowError::NotInitialized,
+        Error::NotInitialized,
     );
 }
 
@@ -225,7 +222,7 @@ fn deposit_funds_rejects_when_token_unbound() {
 
     assert_contract_error(
         client.try_deposit_funds(&id, &client_addr, &100_i128),
-        EscrowError::SettlementTokenNotConfigured,
+        Error::SettlementTokenNotConfigured,
     );
 
     // State must be unchanged: no funded_amount bump, no status transition.
@@ -246,7 +243,7 @@ fn deposit_funds_rejects_overfunding_even_with_sac_balance() {
 
     assert_contract_error(
         client.try_deposit_funds(&id, &client_addr, &overpay),
-        EscrowError::InvalidDepositAmount,
+        Error::InvalidDepositAmount,
     );
 
     // State unchanged.
@@ -266,7 +263,7 @@ fn deposit_funds_paused_blocks_sac_transfer() {
 
     assert_contract_error(
         client.try_deposit_funds(&id, &client_addr, &total_milestone_amount()),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
     let contract = client.get_contract(&id);
     assert_eq!(contract.funded_amount, 0);
@@ -386,7 +383,7 @@ fn release_milestone_rejects_when_token_unbound() {
 
     assert_contract_error(
         client.try_release_milestone(&id, &client_addr, &0),
-        EscrowError::SettlementTokenNotConfigured,
+        Error::SettlementTokenNotConfigured,
     );
 }
 

--- a/contracts/escrow/src/test/security.rs
+++ b/contracts/escrow/src/test/security.rs
@@ -1,5 +1,5 @@
 use super::{create_contract, default_milestones, generated_participants, register_client, total_milestone_amount};
-use crate::{EscrowError, ReleaseAuthorization};
+use crate::{Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Env, Vec};
 
 #[test]
@@ -11,7 +11,7 @@ fn create_rejects_same_participants() {
 
     let result =
         client.try_create_contract(&addr, &addr, &None, &default_milestones(&env), &ReleaseAuthorization::ClientOnly);
-    super::assert_contract_error(result, EscrowError::InvalidParticipant);
+    super::assert_contract_error(result, Error::InvalidParticipant);
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn create_rejects_empty_milestone_list() {
 
     let result =
         client.try_create_contract(&client_addr, &freelancer_addr, &None, &empty, &ReleaseAuthorization::ClientOnly);
-    super::assert_contract_error(result, EscrowError::EmptyMilestones);
+    super::assert_contract_error(result, Error::EmptyMilestones);
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn create_rejects_non_positive_milestone_amount() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    super::assert_contract_error(result, EscrowError::InvalidMilestoneAmount);
+    super::assert_contract_error(result, Error::InvalidMilestoneAmount);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn deposit_rejects_non_positive_amount() {
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
     let result = client.try_deposit_funds(&contract_id, &client_addr, &0);
-    super::assert_contract_error(result, EscrowError::InvalidDepositAmount);
+    super::assert_contract_error(result, Error::InvalidDepositAmount);
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn release_rejects_when_contract_not_funded() {
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
     let result = client.try_release_milestone(&contract_id, &client_addr, &0);
-    super::assert_contract_error(result, EscrowError::InsufficientFunds);
+    super::assert_contract_error(result, Error::InsufficientFunds);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn release_rejects_invalid_milestone_id() {
 
     assert!(client.deposit_funds(&contract_id, &client_addr, &super::total_milestone_amount()));
     let result = client.try_release_milestone(&contract_id, &client_addr, &99);
-    super::assert_contract_error(result, EscrowError::InvalidMilestone);
+    super::assert_contract_error(result, Error::InvalidMilestone);
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn release_rejects_double_release() {
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
 
     let result = client.try_release_milestone(&contract_id, &client_addr, &0);
-    super::assert_contract_error(result, EscrowError::AlreadyReleased);
+    super::assert_contract_error(result, Error::AlreadyReleased);
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn issue_reputation_rejects_unfinished_contract() {
     let (client_addr, freelancer_addr, contract_id) = create_contract(&env, &client);
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::NotCompleted);
+    super::assert_contract_error(result, Error::NotCompleted);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn issue_reputation_rejects_invalid_rating() {
     let (client_addr, freelancer_addr, contract_id) = super::complete_contract(&env, &client);
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::InvalidRating);
+    super::assert_contract_error(result, Error::InvalidRating);
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn issue_reputation_once_per_contract() {
 
     assert!(client.issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great")));
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::ReputationAlreadyIssued);
+    super::assert_contract_error(result, Error::ReputationAlreadyIssued);
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn issue_reputation_rejects_freelancer_mismatch() {
     let wrong_freelancer = soroban_sdk::Address::generate(&env);
 
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::FreelancerMismatch);
+    super::assert_contract_error(result, Error::FreelancerMismatch);
 }
 
 #[test]
@@ -164,5 +164,36 @@ fn issue_reputation_rejects_unauthorized_caller() {
     let unauthorized = soroban_sdk::Address::generate(&env);
 
     let result = client.try_issue_reputation(&contract_id, &unauthorized, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
-    super::assert_contract_error(result, EscrowError::UnauthorizedRole);
+    super::assert_contract_error(result, Error::UnauthorizedRole);
 }
+
+#[test]
+fn test_error_code_stability() {
+    assert_eq!(Error::IndexOutOfBounds as u32, 3);
+    assert_eq!(Error::AlreadyReleased as u32, 4);
+    assert_eq!(Error::EmptyRefundRequest as u32, 6);
+    assert_eq!(Error::DuplicateMilestoneInRefund as u32, 7);
+    assert_eq!(Error::AlreadyRefunded as u32, 8);
+    assert_eq!(Error::InsufficientFunds as u32, 9);
+    assert_eq!(Error::ContractNotFound as u32, 10);
+    assert_eq!(Error::UnauthorizedRole as u32, 11);
+    assert_eq!(Error::InvalidParticipants as u32, 14);
+    assert_eq!(Error::AmountMustBePositive as u32, 15);
+    assert_eq!(Error::InvalidState as u32, 16);
+    assert_eq!(Error::EmptyMilestones as u32, 25);
+    assert_eq!(Error::InvalidMilestoneAmount as u32, 26);
+    assert_eq!(Error::CommentTooLong as u32, 30);
+    assert_eq!(Error::InvalidParticipant as u32, 31);
+    assert_eq!(Error::InvalidDepositAmount as u32, 32);
+    assert_eq!(Error::AlreadyInitialized as u32, 34);
+    assert_eq!(Error::NotInitialized as u32, 36);
+    assert_eq!(Error::ContractPaused as u32, 37);
+    assert_eq!(Error::EmergencyActive as u32, 38);
+    assert_eq!(Error::InvalidStatusTransition as u32, 41);
+    assert_eq!(Error::AccountingInvariantViolated as u32, 44);
+    assert_eq!(Error::AlreadyFinalized as u32, 46);
+    assert_eq!(Error::EvidenceTooLong as u32, 47);
+    assert_eq!(Error::TimelockNotElapsed as u32, 48);
+    assert_eq!(Error::InvalidProtocolParameters as u32, 49);
+}
+

--- a/contracts/escrow/src/test/storage.rs
+++ b/contracts/escrow/src/test/storage.rs
@@ -1,8 +1,5 @@
-use super::{
-    assert_contract_error, complete_contract, create_contract, default_milestones,
-    generated_participants, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_TWO,
-};
-use crate::{ContractStatus, DataKey, EscrowError, ReadinessChecklist, ReleaseAuthorization};
+use super::{assert_contract_error, complete_contract, create_contract, default_milestones, generated_participants, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_TWO};
+use crate::{ContractStatus, DataKey, Error, ReadinessChecklist, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 // ─── Initialized / Admin ──────────────────────────────────────────────────────
@@ -51,7 +48,7 @@ fn double_initialize_fails() {
     client.initialize(&admin);
     assert_contract_error(
         client.try_initialize(&admin),
-        EscrowError::AlreadyInitialized,
+        Error::AlreadyInitialized,
     );
 }
 
@@ -104,7 +101,7 @@ fn paused_blocks_create_contract() {
             &default_milestones(&env),
             &ReleaseAuthorization::ClientOnly,
         ),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -121,7 +118,7 @@ fn paused_blocks_deposit_funds() {
 
     assert_contract_error(
         client.try_deposit_funds(&id, &client_addr, &total_milestone_amount()),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -139,7 +136,7 @@ fn paused_blocks_release_milestone() {
 
     assert_contract_error(
         client.try_release_milestone(&id, &client_addr, &0),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -156,7 +153,7 @@ fn paused_blocks_cancel_contract() {
 
     assert_contract_error(
         client.try_cancel_contract(&id, &client_addr),
-        EscrowError::ContractPaused,
+        Error::ContractPaused,
     );
 }
 
@@ -216,7 +213,7 @@ fn unpause_blocked_while_emergency_active() {
     client.initialize(&admin);
 
     client.activate_emergency_pause();
-    assert_contract_error(client.try_unpause(), EscrowError::EmergencyActive);
+    assert_contract_error(client.try_unpause(), Error::EmergencyActive);
 }
 
 // ─── Contract / NextContractId ────────────────────────────────────────────────
@@ -261,7 +258,7 @@ fn get_contract_fails_for_unknown_id() {
 
     assert_contract_error(
         client.try_get_contract(&9999),
-        EscrowError::ContractNotFound,
+        Error::ContractNotFound,
     );
 }
 
@@ -299,7 +296,7 @@ fn double_release_same_milestone_fails() {
 
     assert_contract_error(
         client.try_release_milestone(&id, &client_addr, &0),
-        EscrowError::AlreadyReleased,
+        Error::AlreadyReleased,
     );
 }
 
@@ -314,7 +311,7 @@ fn release_out_of_bounds_milestone_fails() {
 
     assert_contract_error(
         client.try_release_milestone(&id, &client_addr, &99),
-        EscrowError::InvalidMilestone,
+        Error::InvalidMilestone,
     );
 }
 
@@ -355,7 +352,7 @@ fn double_issue_reputation_fails() {
 
     assert_contract_error(
         client.try_issue_reputation(&id, &c, &5_u32, &soroban_sdk::String::from_str(&env, "Great")),
-        EscrowError::ReputationAlreadyIssued,
+        Error::ReputationAlreadyIssued,
     );
 }
 
@@ -399,7 +396,7 @@ fn reputation_not_issuable_before_completion() {
 
     assert_contract_error(
         client.try_issue_reputation(&id, &c, &5_u32, &soroban_sdk::String::from_str(&env, "Great")),
-        EscrowError::NotCompleted,
+        Error::NotCompleted,
     );
 }
 
@@ -414,7 +411,7 @@ fn reputation_requires_client_caller() {
 
     assert_contract_error(
         client.try_issue_reputation(&id, &stranger, &5_u32, &soroban_sdk::String::from_str(&env, "Great")),
-        EscrowError::UnauthorizedRole,
+        Error::UnauthorizedRole,
     );
 }
 
@@ -494,6 +491,6 @@ fn deposit_exceeding_total_fails() {
     let (client_addr, _, id) = create_contract(&env, &client);
     assert_contract_error(
         client.try_deposit_funds(&id, &client_addr, &(total_milestone_amount() + 1)),
-        EscrowError::ExactDepositRequired,
+        Error::ExactDepositRequired,
     );
 }

--- a/contracts/escrow/src/test/timeout_tests.rs
+++ b/contracts/escrow/src/test/timeout_tests.rs
@@ -3,9 +3,7 @@ use soroban_sdk::{
     vec, Address, Env, Vec,
 };
 
-use crate::{
-    ContractStatus, Escrow, EscrowClient, MilestoneSchedule, ReleaseAuthorization,
-};
+use crate::{ContractStatus, Escrow, EscrowClient, MilestoneSchedule, ReleaseAuthorization};
 
 fn register_client(env: &Env) -> EscrowClient<'_> {
     let contract_id = env.register(Escrow, ());

--- a/contracts/escrow/src/test/treasury_rotation_timelock.rs
+++ b/contracts/escrow/src/test/treasury_rotation_timelock.rs
@@ -6,7 +6,7 @@
 //! `ADMIN_ROTATION_MIN_DELAY_LEDGERS` have elapsed since the matching
 //! `propose_governance_admin` call.
 
-use crate::{EscrowError, ADMIN_ROTATION_MIN_DELAY_LEDGERS};
+use crate::{Error, ADMIN_ROTATION_MIN_DELAY_LEDGERS};
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _, LedgerInfo},
     Address, Env,
@@ -79,7 +79,7 @@ fn accept_rejected_immediately_after_proposal() {
     // No ledger advancement — timelock has not elapsed.
     super::assert_contract_error(
         client.try_accept_governance_admin(),
-        EscrowError::TimelockNotElapsed,
+        Error::TimelockNotElapsed,
     );
 }
 
@@ -102,6 +102,6 @@ fn accept_rejected_one_ledger_before_min_delay() {
 
     super::assert_contract_error(
         client.try_accept_governance_admin(),
-        EscrowError::TimelockNotElapsed,
+        Error::TimelockNotElapsed,
     );
 }

--- a/contracts/escrow/src/test_approval_expiry.rs
+++ b/contracts/escrow/src/test_approval_expiry.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{testutils::Ledger as _, testutils::LedgerInfo, vec, Address, Env};
 
-use crate::{Escrow, EscrowClient, EscrowError};
+use crate::{Escrow, EscrowClient, Error};
 
 fn setup<'a>(env: &'a Env) -> (EscrowClient<'a>, Address, Address) {
     let contract_id = env.register(Escrow, ());

--- a/contracts/escrow/src/test_bounds.rs
+++ b/contracts/escrow/src/test_bounds.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
-use crate::{Escrow, EscrowClient, EscrowError, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS};
+use crate::{Escrow, EscrowClient, Error, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS};
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -67,7 +67,7 @@ fn create_contract_rejects_count_one_above_max_with_error_code() {
     }
     let result = client.try_create_contract(&client_addr, &freelancer_addr, &milestones);
     match result {
-        Err(Ok(EscrowError::TooManyMilestones)) => {}
+        Err(Ok(Error::TooManyMilestones)) => {}
         other => panic!("expected TooManyMilestones, got {:?}", other),
     }
 }
@@ -101,7 +101,7 @@ fn create_contract_rejects_total_one_above_cap() {
     let milestones = vec![&env, MAX_TOTAL_ESCROW_STROOPS + 1];
     let result = client.try_create_contract(&client_addr, &freelancer_addr, &milestones);
     match result {
-        Err(Ok(EscrowError::TotalCapExceeded)) => {}
+        Err(Ok(Error::TotalCapExceeded)) => {}
         other => panic!("expected TotalCapExceeded, got {:?}", other),
     }
 }
@@ -115,7 +115,7 @@ fn create_contract_rejects_total_above_cap_across_milestones() {
     let milestones = vec![&env, half, half];
     let result = client.try_create_contract(&client_addr, &freelancer_addr, &milestones);
     match result {
-        Err(Ok(EscrowError::TotalCapExceeded)) => {}
+        Err(Ok(Error::TotalCapExceeded)) => {}
         other => panic!("expected TotalCapExceeded, got {:?}", other),
     }
 }
@@ -131,7 +131,7 @@ fn create_contract_rejects_i128_max_single_milestone() {
     let milestones = vec![&env, i128::MAX];
     let result = client.try_create_contract(&client_addr, &freelancer_addr, &milestones);
     match result {
-        Err(Ok(EscrowError::TotalCapExceeded)) => {}
+        Err(Ok(Error::TotalCapExceeded)) => {}
         other => panic!("expected TotalCapExceeded for i128::MAX milestone, got {:?}", other),
     }
 }
@@ -146,7 +146,7 @@ fn create_contract_rejects_two_large_milestones_that_would_overflow_i128() {
     let milestones = vec![&env, large, large];
     let result = client.try_create_contract(&client_addr, &freelancer_addr, &milestones);
     match result {
-        Err(Ok(EscrowError::TotalCapExceeded)) => {}
+        Err(Ok(Error::TotalCapExceeded)) => {}
         other => panic!("expected TotalCapExceeded for overflow pair, got {:?}", other),
     }
 }
@@ -166,7 +166,7 @@ fn count_check_fires_before_amount_check() {
     }
     let result = client.try_create_contract(&client_addr, &freelancer_addr, &milestones);
     match result {
-        Err(Ok(EscrowError::TooManyMilestones)) => {}
+        Err(Ok(Error::TooManyMilestones)) => {}
         other => panic!("expected TooManyMilestones (count check first), got {:?}", other),
     }
 }

--- a/contracts/escrow/src/test_deposit_strictness.rs
+++ b/contracts/escrow/src/test_deposit_strictness.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     types::{ContractStatus, DepositMode},
-    EscrowClient, EscrowError,
+    EscrowClient, Error,
 };
 use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
 

--- a/contracts/escrow/src/test_read_notfound.rs
+++ b/contracts/escrow/src/test_read_notfound.rs
@@ -1,9 +1,9 @@
 //! Tests for read API NotFound behavior.
 //!
 //! `get_contract`, `get_milestones`, and `get_checklist` panic with
-//! `EscrowError::ContractNotFound` (error code 9) when the requested data is
+//! `Error::ContractNotFound` (error code 9) when the requested data is
 //! absent.  The Soroban SDK auto-generates `try_*` client wrappers for every
-//! contract function; those wrappers return `Err(Ok(EscrowError::...))` instead
+//! contract function; those wrappers return `Err(Ok(Error::...))` instead
 //! of propagating the panic, which is what indexers and off-chain callers should
 //! use.
 
@@ -13,7 +13,7 @@ extern crate std;
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
-use crate::{Escrow, EscrowClient, EscrowError};
+use crate::{Escrow, EscrowClient, Error};
 
 fn setup() -> (Env, EscrowClient) {
     let env = Env::default();
@@ -30,7 +30,7 @@ fn get_contract_missing_id_returns_not_found() {
     let (_env, client) = setup();
     assert_eq!(
         client.try_get_contract(&999),
-        Err(Ok(EscrowError::ContractNotFound))
+        Err(Ok(Error::ContractNotFound))
     );
 }
 
@@ -54,7 +54,7 @@ fn get_milestones_missing_id_returns_not_found() {
     let (_env, client) = setup();
     assert_eq!(
         client.try_get_milestones(&999),
-        Err(Ok(EscrowError::ContractNotFound))
+        Err(Ok(Error::ContractNotFound))
     );
 }
 
@@ -80,6 +80,6 @@ fn get_checklist_absent_returns_not_found() {
     let (_env, client) = setup();
     assert_eq!(
         client.try_get_checklist(),
-        Err(Ok(EscrowError::ContractNotFound))
+        Err(Ok(Error::ContractNotFound))
     );
 }

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -74,32 +74,96 @@ pub enum DataKey {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
+    /// The specified milestone index is out of bounds.
     IndexOutOfBounds = 3,
+    /// The milestone has already been released.
     AlreadyReleased = 4,
+    /// The refund request is empty.
     EmptyRefundRequest = 6,
+    /// Duplicate milestone indices specified in the refund request.
     DuplicateMilestoneInRefund = 7,
+    /// The milestone has already been refunded.
     AlreadyRefunded = 8,
+    /// Insufficient funds available to perform the operation.
     InsufficientFunds = 9,
+    /// The requested contract was not found.
     ContractNotFound = 10,
+    /// The caller is not authorized for this operation.
     UnauthorizedRole = 11,
+    /// The contract requires an arbiter address but none was provided.
     MissingArbiter = 12,
+    /// The provided arbiter address is invalid (e.g. same as client or freelancer).
     InvalidArbiter = 13,
+    /// The client and freelancer addresses are identical or invalid.
     InvalidParticipants = 14,
+    /// The amount must be strictly greater than zero.
     AmountMustBePositive = 15,
+    /// The contract is in an invalid state for this operation.
     InvalidState = 16,
+    /// The milestone has already been released.
     MilestoneAlreadyReleased = 17,
+    /// The milestone has already been approved.
     AlreadyApproved = 18,
+    /// The milestone has not received sufficient approvals to release.
     InsufficientApprovals = 20,
+    /// The freelancer address does not match the stored freelancer.
     FreelancerMismatch = 21,
+    /// The rating value is outside the allowed range (1 to 5).
     InvalidRating = 22,
+    /// Reputation has already been issued for this contract.
     ReputationAlreadyIssued = 23,
+    /// The milestone list cannot be empty.
     EmptyMilestones = 25,
+    /// The milestone amount is invalid.
     InvalidMilestoneAmount = 26,
+    /// A contract with the specified ID already exists.
     ContractIdCollision = 27,
+    /// The contract ID has overflowed the maximum limit.
     ContractIdOverflow = 28,
+    /// The comment string is empty.
     EmptyComment = 29,
+    /// The comment string exceeds the maximum length limit.
     CommentTooLong = 30,
+    /// The participant address is invalid.
+    InvalidParticipant = 31,
+    /// The deposit amount is invalid.
+    InvalidDepositAmount = 32,
+    /// The milestone configuration is invalid.
+    InvalidMilestone = 33,
+    /// The contract has already been initialized.
+    AlreadyInitialized = 34,
+    /// Insufficient accumulated fees available for extraction.
+    InsufficientAccumulatedFees = 35,
+    /// The contract has not been initialized.
+    NotInitialized = 36,
+    /// The contract is currently paused.
+    ContractPaused = 37,
+    /// Emergency mode is currently active.
+    EmergencyActive = 38,
+    /// Self-rating is not allowed.
+    SelfRating = 39,
+    /// The contract has not been completed.
+    NotCompleted = 40,
+    /// The requested contract status transition is invalid.
+    InvalidStatusTransition = 41,
+    /// An arbiter is required for this operation.
+    ArbiterRequired = 42,
+    /// The dispute split percentage is invalid.
+    InvalidDisputeSplit = 43,
+    /// The operation would violate the core accounting invariant.
+    AccountingInvariantViolated = 44,
+    /// Checked arithmetic operation resulted in an overflow.
+    PotentialOverflow = 45,
+    /// The contract has already been finalized.
+    AlreadyFinalized = 46,
+    /// The work evidence string exceeds the maximum length limit.
+    EvidenceTooLong = 47,
+    /// The governance admin rotation timelock has not elapsed.
+    TimelockNotElapsed = 48,
+    /// The provided protocol parameters are invalid.
+    InvalidProtocolParameters = 49,
 }
+
 
 /// Contract lifecycle states
 #[contracttype]

--- a/docs/escrow/SECURITY.md
+++ b/docs/escrow/SECURITY.md
@@ -64,3 +64,54 @@ This document reflects the escrow API currently implemented in `contracts/escrow
 
 This prevents a client from requesting refunds against a cancelled, completed,
 or already-finalized contract.
+
+## Canonical Error Codes
+
+The following table documents the authoritative, consolidated contract error codes (`Error` enum in `types.rs`) and their trigger conditions. To ensure client SDK stability, all error codes are treated as append-only.
+
+| Error Code | Variant Name | Trigger Condition |
+| :--- | :--- | :--- |
+| 3 | `IndexOutOfBounds` | The specified milestone index is out of bounds. |
+| 4 | `AlreadyReleased` | The milestone has already been released. |
+| 6 | `EmptyRefundRequest` | The refund request contains no milestones. |
+| 7 | `DuplicateMilestoneInRefund` | Duplicate milestone indices specified in the refund request. |
+| 8 | `AlreadyRefunded` | The milestone has already been refunded. |
+| 9 | `InsufficientFunds` | Insufficient funds available to perform the operation. |
+| 10 | `ContractNotFound` | The requested contract ID was never allocated or does not exist. |
+| 11 | `UnauthorizedRole` | The caller's authorization check failed for this operation. |
+| 12 | `MissingArbiter` | The contract requires an arbiter address but none was provided. |
+| 13 | `InvalidArbiter` | The provided arbiter address is same as client or freelancer. |
+| 14 | `InvalidParticipants` | The client and freelancer addresses are identical or invalid. |
+| 15 | `AmountMustBePositive` | The amount or milestone amount must be strictly greater than zero. |
+| 16 | `InvalidState` | The contract is in an invalid lifecycle state for this operation. |
+| 17 | `MilestoneAlreadyReleased` | The milestone is already released and cannot be released/refunded. |
+| 18 | `AlreadyApproved` | The milestone has already been approved. |
+| 20 | `InsufficientApprovals` | The milestone has not received sufficient approvals to release. |
+| 21 | `FreelancerMismatch` | The freelancer address does not match the stored freelancer. |
+| 22 | `InvalidRating` | The rating value is outside the allowed range (1 to 5). |
+| 23 | `ReputationAlreadyIssued` | Reputation has already been issued for this contract. |
+| 25 | `EmptyMilestones` | The milestone list cannot be empty when creating a contract. |
+| 26 | `InvalidMilestoneAmount` | The milestone amount violates validity limits (e.g. non-positive). |
+| 27 | `ContractIdCollision` | A contract with the specified ID already exists. |
+| 28 | `ContractIdOverflow` | The contract ID has overflowed the maximum limit. |
+| 29 | `EmptyComment` | The comment string is empty. |
+| 30 | `CommentTooLong` | The comment string exceeds the maximum length limit. |
+| 31 | `InvalidParticipant` | The participant address is invalid (e.g. self-matching). |
+| 32 | `InvalidDepositAmount` | The deposit amount is invalid. |
+| 33 | `InvalidMilestone` | The milestone configuration or index is invalid. |
+| 34 | `AlreadyInitialized` | The contract has already been initialized. |
+| 35 | `InsufficientAccumulatedFees` | Insufficient accumulated fees available for extraction. |
+| 36 | `NotInitialized` | The contract has not been initialized. |
+| 37 | `ContractPaused` | The contract is currently paused. |
+| 38 | `EmergencyActive` | Emergency mode is currently active. |
+| 39 | `SelfRating` | Self-rating is not allowed (client and freelancer addresses collapse). |
+| 40 | `NotCompleted` | The contract has not been completed. |
+| 41 | `InvalidStatusTransition` | The requested contract status transition is invalid. |
+| 42 | `ArbiterRequired` | An arbiter is required for this operation. |
+| 43 | `InvalidDisputeSplit` | The dispute split percentage is invalid. |
+| 44 | `AccountingInvariantViolated` | The operation would violate the core accounting invariant. |
+| 45 | `PotentialOverflow` | Checked arithmetic operation resulted in an overflow. |
+| 46 | `AlreadyFinalized` | The contract has already been finalized. |
+| 47 | `EvidenceTooLong` | The work evidence string exceeds the maximum length limit. |
+| 48 | `TimelockNotElapsed` | The governance admin rotation timelock has not elapsed. |
+| 49 | `InvalidProtocolParameters` | The provided protocol parameters are invalid. |


### PR DESCRIPTION
Closes #403

## PR Description

This pull request resolves the duplicate and divergent error definitions in the escrow contract by establishing the `Error` enum in `types.rs` as the single source of truth. Previously, the contract maintained two separate enums: `EscrowError` in `lib.rs` and `Error` in `types.rs`. These enums had overlapping variants with conflicting numeric codes, creating decoding failures and stability hazards for client SDKs.

This change deletes the duplicate `EscrowError` enum in `lib.rs` and redirects the entire codebase to import and use the canonical `Error` enum from `types.rs`. The variants from both enums have been merged into `Error`, maintaining the original numeric codes to preserve client-SDK decoding stability. 

Additionally, we added NatSpec-style doc comments to all variants in the unified enum, documented the entire consolidated error catalog in the security notes, and added an error-code stability test to prevent future regressions.

## Changed
- Removed the duplicated `EscrowError` enum from `contracts/escrow/src/lib.rs`.
- Consolidated all unique error variants (such as lifecycle, pause/emergency, reputation, and governance errors) into `Error` in `contracts/escrow/src/types.rs`.
- Updated all occurrences of `EscrowError` to `Error` in core contract logic files (`lib.rs`, `governance.rs`, `migration.rs`, `finalize.rs`).
- Updated all test files to use `Error` instead of `EscrowError` for error assertions.
- Added a `test_error_code_stability` unit test in `contracts/escrow/src/test/security.rs` to assert the stability of representative error codes.
- Added an error-code catalog mapping error codes to their trigger conditions in `docs/escrow/SECURITY.md`.