### PR TITLE
refactor: de-duplicate amount_validation module and safe_add_amounts

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -54,15 +54,6 @@ pub type EscrowError = Error;
 #[contract]
 pub struct Escrow;
 
-
-
-
-
-/// Returns `Some(a + b)`, or `None` on overflow.
-pub fn safe_add_amounts(a: i128, b: i128) -> Option<i128> {
-    a.checked_add(b)
-}
-
 #[contractimpl]
 impl Escrow {
     // ── Hello / CI ───────────────────────────────────────────────────────────

--- a/contracts/escrow/src/test/security.rs
+++ b/contracts/escrow/src/test/security.rs
@@ -1,5 +1,5 @@
 use super::{create_contract, default_milestones, generated_participants, register_client, total_milestone_amount};
-use crate::{Error, ReleaseAuthorization};
+use crate::{safe_add_amounts, safe_subtract_amounts, Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Env, Vec};
 
 #[test]
@@ -168,6 +168,77 @@ fn issue_reputation_rejects_unauthorized_caller() {
 
     let result = client.try_issue_reputation(&contract_id, &unauthorized, &5_u32, &soroban_sdk::String::from_str(&env, "Great"));
     super::assert_contract_error(result, Error::UnauthorizedRole);
+}
+
+// ── Safe arithmetic helpers (overflow / underflow) ──────────────────────
+
+#[test]
+fn safe_add_overflow_returns_none() {
+    assert_eq!(safe_add_amounts(i128::MAX, 1), None);
+    assert_eq!(safe_add_amounts(i128::MAX, 1_000), None);
+    assert_eq!(safe_add_amounts(1, i128::MAX), None);
+}
+
+#[test]
+fn safe_add_underflow_returns_none() {
+    assert_eq!(safe_add_amounts(i128::MIN, -1), None);
+    assert_eq!(safe_add_amounts(i128::MIN, -1_000), None);
+    assert_eq!(safe_add_amounts(-1, i128::MIN), None);
+}
+
+#[test]
+fn safe_add_normal_values() {
+    assert_eq!(safe_add_amounts(100, 200), Some(300));
+    assert_eq!(safe_add_amounts(0, 0), Some(0));
+    assert_eq!(safe_add_amounts(-50, 50), Some(0));
+    assert_eq!(safe_add_amounts(i128::MAX, 0), Some(i128::MAX));
+    assert_eq!(safe_add_amounts(i128::MIN, 0), Some(i128::MIN));
+}
+
+#[test]
+fn safe_subtract_underflow_returns_none() {
+    assert_eq!(safe_subtract_amounts(i128::MIN, 1), None);
+    assert_eq!(safe_subtract_amounts(i128::MIN, 10), None);
+}
+
+#[test]
+fn safe_subtract_normal_values() {
+    assert_eq!(safe_subtract_amounts(300, 100), Some(200));
+    assert_eq!(safe_subtract_amounts(100, 100), Some(0));
+    assert_eq!(safe_subtract_amounts(0, 0), Some(0));
+    assert_eq!(safe_subtract_amounts(50, 100), Some(-50));
+    assert_eq!(safe_subtract_amounts(i128::MAX, 0), Some(i128::MAX));
+    assert_eq!(safe_subtract_amounts(i128::MIN, 0), Some(i128::MIN));
+}
+
+#[test]
+fn safe_arithmetic_round_trip() {
+    let vals = [0_i128, 1, 100, 1_000_000, i128::MAX / 2, -1, -100];
+    for &a in &vals {
+        for &b in &vals {
+            if let Some(sum) = safe_add_amounts(a, b) {
+                if let Some(diff) = safe_subtract_amounts(sum, b) {
+                    assert_eq!(diff, a, "round-trip failed: {} + {} - {} != {}", a, b, b, a);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn safe_add_subtract_edge_cases() {
+    // Adding zero never overflows
+    assert_eq!(safe_add_amounts(i128::MAX, 0), Some(i128::MAX));
+    assert_eq!(safe_add_amounts(i128::MIN, 0), Some(i128::MIN));
+    // Subtracting zero never underflows
+    assert_eq!(safe_subtract_amounts(i128::MAX, 0), Some(i128::MAX));
+    assert_eq!(safe_subtract_amounts(i128::MIN, 0), Some(i128::MIN));
+    // MAX overflow boundary
+    assert_eq!(safe_add_amounts(i128::MAX - 1, 1), Some(i128::MAX));
+    assert_eq!(safe_add_amounts(i128::MAX - 1, 2), None);
+    // MIN underflow boundary
+    assert_eq!(safe_subtract_amounts(i128::MIN + 1, 1), Some(i128::MIN));
+    assert_eq!(safe_subtract_amounts(i128::MIN + 1, 2), None);
 }
 
 #[test]


### PR DESCRIPTION
- Keep a single canonical safe_add_amounts and remove the duplicate free-function copies in lib.rs.
- Collapse the redundant pub use / pub(crate) use lines for safe_add_amounts/safe_subtract_amounts.

closes #554 