### PR TITLE
fix: bound set_protocol_fee_bps to 10_000 basis points

### DIFF
--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -3,6 +3,9 @@ use crate::{
 };
 use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol};
 
+/// Maximum protocol fee expressed in basis points.
+pub(crate) const MAX_PROTOCOL_FEE_BPS: u32 = 10_000;
+
 impl Escrow {
     // ── Two-step admin transfer ───────────────────────────────────────────────
 
@@ -109,9 +112,7 @@ impl Escrow {
         }
         admin.require_auth();
 
-        if protocol_fee_bps > 10_000 {
-            env.panic_with_error(Error::InvalidProtocolParameters);
-        }
+        Self::require_valid_protocol_fee_bps(env, protocol_fee_bps);
 
         let params = GovernedParameters {
             protocol_fee_bps,
@@ -137,5 +138,12 @@ impl Escrow {
     /// Retrieve the current governed parameters.
     pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
         env.storage().persistent().get(&DataKey::GovernedParameters)
+    }
+
+    /// Rejects protocol fees above 100% (10_000 basis points).
+    pub(crate) fn require_valid_protocol_fee_bps(env: &Env, protocol_fee_bps: u32) {
+        if protocol_fee_bps > MAX_PROTOCOL_FEE_BPS {
+            env.panic_with_error(Error::InvalidProtocolParameters);
+        }
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1696,6 +1696,8 @@ impl Escrow {
     }
 
     /// Sets the current protocol fee in basis points.
+    ///
+    /// `new_bps` must be less than or equal to `10_000`, which represents 100%.
     pub fn set_protocol_fee_bps(env: Env, new_bps: u32) -> bool {
         Self::require_initialized(&env);
 
@@ -1705,6 +1707,7 @@ impl Escrow {
             .get(&DataKey::Admin)
             .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
         admin.require_auth();
+        Self::require_valid_protocol_fee_bps(&env, new_bps);
 
         let old_bps = Self::read_protocol_fee_bps(&env);
         env.storage()

--- a/contracts/escrow/src/test/protocol_fees.rs
+++ b/contracts/escrow/src/test/protocol_fees.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, Address, Env, vec};
-use crate::{Escrow, EscrowClient, DataKey, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, DataKey, Error, ReleaseAuthorization};
 
 #[test]
 fn test_default_fees_are_zero() {
@@ -53,6 +53,43 @@ fn test_get_protocol_fee_bps_after_configuration() {
 
     client.set_protocol_fee_bps(&1000u32);
     assert_eq!(client.get_protocol_fee_bps(), 1000);
+}
+
+/// Test that protocol fee updates accept 0 and 10_000 basis points.
+#[test]
+fn test_set_protocol_fee_bps_accepts_boundary_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    assert!(client.set_protocol_fee_bps(&0u32));
+    assert_eq!(client.get_protocol_fee_bps(), 0);
+
+    assert!(client.set_protocol_fee_bps(&10_000u32));
+    assert_eq!(client.get_protocol_fee_bps(), 10_000);
+}
+
+/// Test that protocol fee updates reject values above 100%.
+#[test]
+fn test_set_protocol_fee_bps_rejects_values_above_100_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Escrow);
+    let client = EscrowClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    assert!(client.set_protocol_fee_bps(&0u32));
+
+    let result = client.try_set_protocol_fee_bps(&10_001u32);
+    super::assert_contract_error(result, Error::InvalidProtocolParameters);
+    assert_eq!(client.get_protocol_fee_bps(), 0);
 }
 
 /// Test that `get_accumulated_protocol_fees` reflects fees accumulated after milestone releases.

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -202,7 +202,8 @@ escrow.release_milestone(&contract_id, &client_addr, &0);
    `ReleaseAuthorization`, milestone state, balance) hold.
 2. The escrow reads the bound settlement token; if no token has been bound it
    panics with `SettlementTokenNotConfigured`.
-3. The escrow reads the protocol fee (set via `set_protocol_fee_bps`); the
+3. The escrow reads the protocol fee (set via `set_protocol_fee_bps`, capped at
+   `10_000` basis points / 100%); the
    payout to the freelancer is `milestone.amount - fee`, with `fee` retained
    inside the contract via `DataKey::AccumulatedProtocolFees`.
 4. `token::Client::transfer(escrow, freelancer, payout)` is invoked BEFORE

--- a/docs/escrow/abi-reference.md
+++ b/docs/escrow/abi-reference.md
@@ -333,7 +333,7 @@ The list intentionally omits planned or reserved entrypoints that are not implem
 - Signature: `set_protocol_fee_bps(env: Env, new_bps: u32) -> bool`
 - Kind: Mutating
 - Auth: stored admin
-- Semantics: Updates the configured protocol fee in basis points.
+- Semantics: Updates the configured protocol fee in basis points, capped at `10_000` (100%).
 - Events: `("protocol_fee_bps",)`
 - Errors: `NotInitialized`, `UnauthorizedRole`, `InvalidProtocolParameters`
 
@@ -396,7 +396,7 @@ The list intentionally omits planned or reserved entrypoints that are not implem
 - Signature: `set_governed_params(env: Env, admin: Address, protocol_fee_bps: u32, max_escrow_total_stroops: i128) -> bool`
 - Kind: Mutating
 - Auth: stored admin
-- Semantics: Stores the protocol fee and maximum escrow total and updates the readiness checklist.
+- Semantics: Stores the protocol fee (capped at `10_000`, or 100%) and maximum escrow total and updates the readiness checklist.
 - Events: None
 - Errors: `NotInitialized`, `UnauthorizedRole`, `InvalidProtocolParameters`
 


### PR DESCRIPTION
Closes #549

---

## Summary
- add the same <= 10_000 protocol fee bound to set_protocol_fee_bps that set_governed_params already enforces
- keep valid protocol fee updates and existing event emission behavior unchanged
- add boundary coverage for 