### PR TITLE
feat: emit settlement_token_bound event for indexer observability

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -147,6 +147,18 @@ impl Escrow {
     /// * `NotInitialized` if `initialize` has not been called
     /// * `UnauthorizedRole` if `admin` is not the stored admin
     /// * `SettlementTokenAlreadyBound` if a token is already bound
+    ///
+    /// # Events
+    /// On a successful, authorized bind this publishes a `settlement_token_bound`
+    /// event so off-chain indexers and monitoring dashboards can observe which
+    /// asset an escrow settles in, and when the binding happened.
+    ///
+    /// * Topics: `(Symbol "settlement_token_bound",)`
+    /// * Data: `(admin: Address, token: Address, timestamp: u64)`
+    ///
+    /// The event only fires after the write succeeds. Rejected binds
+    /// (uninitialized or unauthorized) panic before this point and therefore
+    /// publish nothing. All payload fields are public configuration.
     pub fn bind_settlement_token(env: Env, admin: Address, token: Address) -> bool {
         Self::require_initialized(&env);
         let stored_admin: Address = env
@@ -161,6 +173,13 @@ impl Escrow {
         admin.require_auth();
 
         Self::write_settlement_token(&env, &token);
+
+        // Emit after the binding write succeeds so indexers can track the bound
+        // asset. Consistent topic naming with `init` / `protocol_fee_bps` events.
+        env.events().publish(
+            (Symbol::new(&env, "settlement_token_bound"),),
+            (admin, token, env.ledger().timestamp()),
+        );
         true
     }
 

--- a/contracts/escrow/src/test/sac_custody.rs
+++ b/contracts/escrow/src/test/sac_custody.rs
@@ -157,6 +157,78 @@ fn bind_settlement_token_rejects_uninit() {
     );
 }
 
+/// Returns `true` when at least one published event carries
+/// `settlement_token_bound` as its first topic.
+fn has_settlement_token_bound_event(env: &Env) -> bool {
+    use soroban_sdk::{testutils::Events, TryFromVal};
+    let topic = Symbol::new(env, "settlement_token_bound");
+    env.events().all().iter().any(|event| {
+        event.1.len() > 0
+            && Symbol::try_from_val(env, &event.1.get(0).unwrap())
+                .ok()
+                .as_ref()
+                == Some(&topic)
+    })
+}
+
+#[test]
+fn bind_settlement_token_emits_settlement_token_bound_event() {
+    use soroban_sdk::{testutils::Events, TryFromVal};
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let sac = env.register_stellar_asset_contract(admin.clone());
+    assert!(client.bind_settlement_token(&sac));
+
+    // Topic must be present on a successful, authorized bind.
+    assert!(
+        has_settlement_token_bound_event(&env),
+        "successful bind must publish settlement_token_bound"
+    );
+
+    // Payload must carry (admin, token, timestamp): assert the bound token
+    // address is the third element of the matching event's data tuple.
+    let topic = Symbol::new(&env, "settlement_token_bound");
+    let matching = env
+        .events()
+        .all()
+        .iter()
+        .find(|event| {
+            event.1.len() > 0
+                && Symbol::try_from_val(&env, &event.1.get(0).unwrap())
+                    .ok()
+                    .as_ref()
+                    == Some(&topic)
+        })
+        .expect("event present");
+    let data: SorobanVec<soroban_sdk::Val> =
+        SorobanVec::try_from_val(&env, &matching.2).expect("data is a tuple/vec");
+    let bound_token: Address =
+        Address::try_from_val(&env, &data.get(1).unwrap()).expect("token field");
+    assert_eq!(bound_token, sac);
+}
+
+#[test]
+fn rejected_bind_does_not_emit_settlement_token_bound_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let sac = env.register_stellar_asset_contract(Address::generate(&env));
+
+    // Uninitialized bind is rejected: no event must be published.
+    assert_contract_error(
+        client.try_bind_settlement_token(&sac),
+        EscrowError::NotInitialized,
+    );
+    assert!(
+        !has_settlement_token_bound_event(&env),
+        "rejected (uninitialized) bind must not publish settlement_token_bound"
+    );
+}
+
 // ─── deposit_funds (SAC path) ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Publishes a `settlement_token_bound` event from `bind_settlement_token` after the binding write succeeds, carrying `(admin, token, timestamp)`. Topic naming is consistent with the existing `init` / `protocol_fee_bps` events. The event only fires on a successful, authorized bind; rejected binds (uninitialized/unauthorized) panic before the publish and emit nothing.

Adds tests in `contracts/escrow/src/test/sac_custody.rs` asserting the topic and payload on a successful bind, and that a rejected (uninitialized) bind publishes no event.

Closes #648