### PR TITLE
feat: add is_settlement_token_bound boolean readiness reader

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -177,6 +177,25 @@ impl Escrow {
         Self::read_settlement_token(&env)
     }
 
+    /// Returns `true` exactly when a settlement token is bound.
+    ///
+    /// This is the recommended cheap pre-flight readiness check before calling
+    /// [`deposit_funds`], which panics when no settlement token has been bound.
+    /// Integrators that only need to know *whether* the escrow can accept
+    /// deposits — without caring about the specific token address — should use
+    /// this instead of fetching and discarding the `Address` from
+    /// [`get_settlement_token`].
+    ///
+    /// Read-only and auth-free: it performs no state mutation (no TTL write is
+    /// needed for the simple binding key).
+    ///
+    /// # Returns
+    /// * `true` if a settlement token is bound
+    /// * `false` if no settlement token has been bound yet
+    pub fn is_settlement_token_bound(env: Env) -> bool {
+        Self::read_settlement_token(&env).is_some()
+    }
+
     /// Returns the stored governance admin address, or `None` if not set.
     pub fn get_governance_admin(env: Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Admin)

--- a/contracts/escrow/src/test/sac_custody.rs
+++ b/contracts/escrow/src/test/sac_custody.rs
@@ -128,6 +128,32 @@ fn bind_settlement_token_admin_can_bind_and_query_returns_some() {
 }
 
 #[test]
+fn is_settlement_token_bound_false_before_bind_true_after() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Pre-flight readiness probe must report false before any token is bound.
+    assert!(
+        !client.is_settlement_token_bound(),
+        "no token bound yet: readiness must be false"
+    );
+
+    let sac = env.register_stellar_asset_contract(admin.clone());
+    assert!(client.bind_settlement_token(&sac));
+
+    // After a successful bind the escrow is ready to accept deposits.
+    assert!(
+        client.is_settlement_token_bound(),
+        "token bound: readiness must be true"
+    );
+    // The boolean reader must agree with the Address-returning reader.
+    assert_eq!(client.get_settlement_token().is_some(), client.is_settlement_token_bound());
+}
+
+#[test]
 fn bind_settlement_token_rejects_double_bind() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Adds `is_settlement_token_bound(env) -> bool`, implemented as `Self::read_settlement_token(&env).is_some()`, next to `get_settlement_token`. It is the recommended cheap pre-flight check before `deposit_funds` (which panics when no token is bound) for integrators that only need readiness, not the token address. Read-only, auth-free, no state mutation. `get_settlement_token` and the binding write path are unchanged.

Adds tests in `contracts/escrow/src/test/sac_custody.rs` asserting it returns false before binding and true after.

Closes #650