### PR TITLE
feat: add get_milestone single-index reader returning Option<Milestone>

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1055,6 +1055,41 @@ impl Escrow {
         milestones
     }
 
+    /// Retrieves a single milestone by index for a contract.
+    ///
+    /// This is the bounds-checked single-item counterpart to
+    /// [`get_milestones`]. Off-chain callers that only need one milestone's
+    /// state (amount, funded/released/refunded flags, deadline, work evidence)
+    /// can avoid fetching and decoding the full `Vec<Milestone>`.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    /// * `milestone_index` - The zero-based index of the milestone to read
+    ///
+    /// # Returns
+    /// * `Some(Milestone)` if `milestone_index` is in bounds
+    /// * `None` if `milestone_index` is out of bounds
+    ///
+    /// # Panics
+    /// Panics with `ContractNotFound` if the contract's milestones were never
+    /// allocated (i.e. the contract id is unknown), matching
+    /// [`get_milestones`].
+    ///
+    /// # Side effects
+    /// Extends the milestones vector TTL on a successful read, consistent with
+    /// [`get_milestones`]. Auth-free and otherwise non-mutating.
+    pub fn get_milestone(env: Env, contract_id: u32, milestone_index: u32) -> Option<Milestone> {
+        let milestone_key = Symbol::new(&env, "milestones");
+        let milestones: Vec<Milestone> = env
+            .storage()
+            .persistent()
+            .get(&(DataKey::Contract(contract_id), milestone_key))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+        ttl::extend_milestone_ttl(&env, contract_id);
+        milestones.get(milestone_index)
+    }
+
     /// Returns funded minus released minus refunded for `contract_id`.
     pub fn get_refundable_balance(env: Env, contract_id: u32) -> i128 {
         let contract: Contract = env

--- a/contracts/escrow/src/test/storage.rs
+++ b/contracts/escrow/src/test/storage.rs
@@ -1,6 +1,7 @@
 use super::{
     assert_contract_error, complete_contract, create_contract, default_milestones,
-    generated_participants, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_TWO,
+    generated_participants, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_THREE,
+    MILESTONE_TWO,
 };
 use crate::{ContractStatus, DataKey, EscrowError, ReadinessChecklist, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, Address, Env};
@@ -483,6 +484,66 @@ fn released_amount_tracks_milestone_amounts() {
     let r = client.get_contract(&id);
     assert_eq!(r.released_amount, total_milestone_amount());
     assert_eq!(r.status, ContractStatus::Completed);
+}
+
+// ─── get_milestone single-index reader (issue #649) ───────────────────────────
+
+#[test]
+fn get_milestone_index_zero_returns_first_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    // Default contract has three milestones: ONE, TWO, THREE.
+    let (_client_addr, _, id) = create_contract(&env, &client);
+
+    let m = client
+        .get_milestone(&id, &0u32)
+        .expect("index 0 is in bounds");
+    assert_eq!(m.amount, MILESTONE_ONE);
+    // It must match the entry returned by the full-vector reader.
+    assert_eq!(m, client.get_milestones(&id).get(0).unwrap());
+}
+
+#[test]
+fn get_milestone_last_valid_index_returns_last_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_client_addr, _, id) = create_contract(&env, &client);
+
+    let milestones = client.get_milestones(&id);
+    let last = milestones.len() - 1;
+    let m = client
+        .get_milestone(&id, &last)
+        .expect("last index is in bounds");
+    assert_eq!(m.amount, MILESTONE_THREE);
+    assert_eq!(m, milestones.get(last).unwrap());
+}
+
+#[test]
+fn get_milestone_out_of_bounds_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let (_client_addr, _, id) = create_contract(&env, &client);
+
+    let len = client.get_milestones(&id).len();
+    // One past the last valid index must return None, not panic.
+    assert!(client.get_milestone(&id, &len).is_none());
+    assert!(client.get_milestone(&id, &(len + 5)).is_none());
+}
+
+#[test]
+fn get_milestone_unknown_contract_panics_contract_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    // No contract has been created; id 999 was never allocated.
+    assert_contract_error(
+        client.try_get_milestone(&999u32, &0u32),
+        EscrowError::ContractNotFound,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds `get_milestone(env, contract_id, milestone_index) -> Option<Milestone>` alongside `get_milestones`. Returns `Some(milestone)` for an in-bounds index, `None` for an out-of-bounds index, and panics with `ContractNotFound` when the contract's milestones were never allocated. Extends the milestones-vector TTL on read, matching `get_milestones`; auth-free and otherwise non-mutating.

Adds tests in `contracts/escrow/src/test/storage.rs` covering index 0, last valid index, out-of-bounds (None), and unknown contract id (ContractNotFound).

Closes #649