### PR TITLE
Add tests asserting submit_work_evidence overwrite and 256-byte length bound

### DIFF
--- a/contracts/escrow/src/test/lifecycle.rs
+++ b/contracts/escrow/src/test/lifecycle.rs
@@ -1,5 +1,5 @@
-use crate::{ContractStatus, DepositMode, DisputeResolution, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, vec, Address, Env};
+use crate::{ContractStatus, DepositMode, DisputeResolution, Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, vec, Address, Env, String};
 
 fn setup() -> (Env, Address) {
     let env = Env::default();
@@ -212,4 +212,157 @@ fn pause_blocks_finalization() {
         EscrowError::ContractPaused,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// submit_work_evidence: overwrite and 256-byte length bound
+// ---------------------------------------------------------------------------
+
+/// Helper that produces a Soroban `String` from a plain `&str`.
+fn ev(env: &Env, s: &str) -> String {
+    String::from_str(env, s)
+}
+
+/// Helper that builds a funded contract and returns (client_addr, freelancer_addr, contract_id).
+fn funded_contract(env: &Env, client: &EscrowClient<'_>) -> (Address, Address, u32) {
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![env, 100_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
+    (client_addr, freelancer_addr, contract_id)
+}
+
+/// A successful `submit_work_evidence` call is round-tripped by `get_work_evidence`.
+#[test]
+fn submit_work_evidence_round_trips_via_get() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (_, freelancer_addr, contract_id) = funded_contract(&env, &client);
+
+    let evidence = ev(&env, "ipfs://QmRoundTrip");
+    assert!(client.submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence));
+
+    let stored = client.get_work_evidence(&contract_id, &0);
+    assert_eq!(stored, Some(evidence));
+}
+
+/// Overwriting evidence before release replaces the prior value,
+/// confirmed by `get_work_evidence`.
+#[test]
+fn submit_work_evidence_overwrite_replaces_prior_value() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (_, freelancer_addr, contract_id) = funded_contract(&env, &client);
+
+    let first = ev(&env, "ipfs://first-version");
+    let second = ev(&env, "ipfs://second-version");
+    assert!(client.submit_work_evidence(&contract_id, &freelancer_addr, &0, &first));
+    assert!(client.submit_work_evidence(&contract_id, &freelancer_addr, &0, &second));
+
+    // Only the latest value must be visible.
+    let stored = client.get_work_evidence(&contract_id, &0);
+    assert_eq!(stored, Some(second));
+}
+
+/// Exactly 256 bytes of evidence must be accepted.
+#[test]
+fn submit_work_evidence_accepts_exactly_256_bytes() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (_, freelancer_addr, contract_id) = funded_contract(&env, &client);
+
+    let boundary = String::from_str(&env, &"x".repeat(256));
+    assert!(client.submit_work_evidence(&contract_id, &freelancer_addr, &0, &boundary));
+
+    let stored = client.get_work_evidence(&contract_id, &0);
+    assert_eq!(stored.map(|s| s.len()), Some(256));
+}
+
+/// 257 bytes must be rejected with `EvidenceTooLong`.
+#[test]
+fn submit_work_evidence_rejects_257_bytes() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (_, freelancer_addr, contract_id) = funded_contract(&env, &client);
+
+    let too_long = String::from_str(&env, &"x".repeat(257));
+    let result = client.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &too_long);
+    super::assert_contract_error(result, EscrowError::EvidenceTooLong);
+}
+
+/// Only the freelancer may submit evidence; any other caller gets `UnauthorizedRole`.
+#[test]
+fn submit_work_evidence_rejects_non_freelancer() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (client_addr, _, contract_id) = funded_contract(&env, &client);
+
+    let evidence = ev(&env, "ipfs://QmUnauth");
+    let result = client.try_submit_work_evidence(&contract_id, &client_addr, &0, &evidence);
+    super::assert_contract_error(result, Error::UnauthorizedRole);
+}
+
+/// Submitting to an unfunded (Created) contract must fail with `InvalidState`.
+#[test]
+fn submit_work_evidence_rejects_unfunded_contract() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    // Create without depositing — remains in Created status.
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 100_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    let evidence = ev(&env, "ipfs://QmNoFunds");
+    let result = client.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    super::assert_contract_error(result, Error::InvalidState);
+}
+
+/// `get_work_evidence` returns `None` for an out-of-bounds milestone index.
+#[test]
+fn get_work_evidence_returns_none_for_out_of_bounds_index() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (_, _, contract_id) = funded_contract(&env, &client);
+
+    // milestone index 99 does not exist.
+    let stored = client.get_work_evidence(&contract_id, &99);
+    assert!(stored.is_none());
+}
+
+/// `get_work_evidence` returns `None` when no evidence has been submitted yet.
+#[test]
+fn get_work_evidence_returns_none_before_submission() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let (_, _, contract_id) = funded_contract(&env, &client);
+
+    assert!(client.get_work_evidence(&contract_id, &0).is_none());
+}
+
+/// A paused contract blocks `submit_work_evidence` with `ContractPaused`.
+#[test]
+fn submit_work_evidence_rejects_paused_contract() {
+    let (env, contract_addr) = setup();
+    let client = escrow_client(&env, &contract_addr);
+    let admin = Address::generate(&env);
+    assert!(client.initialize(&admin));
+
+    let (_, freelancer_addr, contract_id) = funded_contract(&env, &client);
+    assert!(client.pause());
+
+    let evidence = ev(&env, "ipfs://QmPaused");
+    let result = client.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    super::assert_contract_error(result, EscrowError::ContractPaused);
 }


### PR DESCRIPTION
Closes #653

## Summary
- Add `submit_work_evidence_round_trips_via_get`: asserts a successful submission is retrievable via `get_work_evidence`
- Add `submit_work_evidence_overwrite_replaces_prior_value`: asserts that overwriting evidence before release replaces the prior value, confirmed by `get_work_evidence`
- Add `submit_work_evidence_accepts_exactly_256_bytes`: asserts the exact 256-byte boundary is accepted
- Add `submit_work_evidence_rejects_257_bytes`: asserts `EvidenceTooLong` is returned for 257-byte evidence
- Add `submit_work_evidence_rejects_non_freelancer`: asserts `UnauthorizedRole` for non-freelancer callers
- Add `submit_work_evidence_rejects_unfunded_contract`: asserts `InvalidState` for non-Funded contracts
- Add `get_work_evidence_returns_none_for_out_of_bounds_index`: asserts `None` for out-of-bounds milestone index
- Add `get_work_evidence_returns_none_before_submission`: asserts `None` before any evidence is submitted
- Add `submit_work_evidence_rejects_paused_contract`: asserts `ContractPaused` when contract is paused

All tests are in `contracts/escrow/src/test/lifecycle.rs` as specified by the issue.

🤖 Generated with Claude Code