### PR TITLE
Document the SAC custody and settlement-token lifecycle for the escrow contract

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -133,10 +133,17 @@ impl Escrow {
 
 #[contractimpl]
 impl Escrow {
-    /// Set the settlement token for the escrow contract.
+    /// Bind the single Stellar Asset Contract (SAC) token this escrow instance will custody.
     ///
-    /// Writes the canonical [`DataKey::SettlementToken`] binding used by escrow
-    /// funding, releases, refunds, and protocol-fee withdrawal paths.
+    /// This is a **write-once** step: once a token is recorded under
+    /// [`DataKey::SettlementToken`] all subsequent money-flow entrypoints
+    /// (`deposit_funds`, `release_milestone`, `refund_unreleased_milestones`,
+    /// `cancel_contract`, `withdraw_protocol_fees`) read that address to execute SAC
+    /// `transfer` calls.  A second call with any token address is rejected with
+    /// `SettlementTokenAlreadyBound`.
+    ///
+    /// See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
+    /// full custody model, accounting invariant, and lifecycle sequence diagram.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
@@ -312,7 +319,15 @@ impl Escrow {
         )
     }
 
-    /// Deposits funds into the contract. Transitions to Funded status when fully funded.
+    /// Pull the settlement-token deposit from the client into the escrow contract address.
+    ///
+    /// Executes `SAC::transfer(from: client, to: escrow_address, amount)` and advances
+    /// status from `Created` to `Funded` once the full milestone sum has been deposited.
+    /// Requires `bind_settlement_token` to have been called first; panics with
+    /// `SettlementTokenNotConfigured` otherwise.
+    ///
+    /// See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
+    /// full custody model and accounting invariant.
     ///
     /// # Arguments
     /// * `env` - The contract environment
@@ -324,6 +339,7 @@ impl Escrow {
     /// `true` if deposit was successful
     ///
     /// # Errors
+    /// * `SettlementTokenNotConfigured` - If `bind_settlement_token` has not been called
     /// * `AmountMustBePositive` - If amount is <= 0
     /// * `ContractNotFound` - If contract doesn't exist
     /// * `InvalidState` - If contract is not in Created state
@@ -449,7 +465,15 @@ impl Escrow {
         env.storage().persistent().set(&pending_key, &(pending + 1));
     }
 
-    /// Releases a specific milestone, transferring funds to the freelancer.
+    /// Releases a specific milestone, transferring the net payout to the freelancer.
+    ///
+    /// Executes `SAC::transfer(from: escrow_address, to: freelancer, milestone.amount − fee)`.
+    /// The protocol fee is retained inside the contract under
+    /// `DataKey::AccumulatedProtocolFees` and stays commingled with the escrow balance
+    /// until `withdraw_protocol_fees` is called.
+    ///
+    /// See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
+    /// full custody model and accounting invariant.
     ///
     /// The target milestone must be fully funded through per-milestone deposit
     /// allocation before it can be released.
@@ -1655,7 +1679,15 @@ impl Escrow {
             .unwrap_or(0)
     }
 
-    /// Withdraws accumulated protocol fees.
+    /// Drains accrued protocol fees from the escrow contract to a treasury address.
+    ///
+    /// Executes `SAC::transfer(from: escrow_address, to: treasury, amount)`.  Protocol
+    /// fees accumulate in `DataKey::AccumulatedProtocolFees` as each milestone is
+    /// released; they remain commingled with the escrow's SAC balance until this
+    /// entrypoint is called.
+    ///
+    /// See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
+    /// full custody model, accounting invariant, and security notes on commingled fees.
     ///
     /// Requires the stored admin's authorization. Only an amount up to the
     /// currently accumulated fees can be withdrawn.

--- a/contracts/escrow/src/test/sac_custody.rs
+++ b/contracts/escrow/src/test/sac_custody.rs
@@ -390,6 +390,67 @@ fn release_milestone_rejects_when_token_unbound() {
     );
 }
 
+// ─── Accounting invariant ─────────────────────────────────────────────────────
+
+/// Verify the balance invariant documented in docs/escrow/sac-custody.md:
+///   escrow_sac_balance == funded_amount − released_amount − refunded_amount + accrued_fees
+///
+/// This test exercises bind → deposit → release (with fee) → verify invariant
+/// at each step.
+#[test]
+fn sac_custody_accounting_invariant_holds_after_deposit_and_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (escrow, sac, _admin, client_addr, freelancer_addr, id) = setup_and_funded_partial(&env, 0);
+    let total = total_milestone_amount();
+    mint_to(&env, &sac, &client_addr, total);
+
+    let token = TokenClient::new(&env, &sac);
+
+    // Before deposit: escrow holds nothing.
+    assert_eq!(token.balance(&escrow.address), 0_i128);
+
+    // Deposit: escrow balance == funded_amount, released == 0, refunded == 0, fees == 0.
+    escrow.deposit_funds(&id, &client_addr, &total);
+    let contract = escrow.get_contract(&id);
+    let escrow_bal: i128 = token.balance(&escrow.address);
+    // invariant: balance == funded - released - refunded + accrued_fees
+    // accrued_fees == 0 before any release.
+    assert_eq!(
+        escrow_bal,
+        contract.funded_amount - contract.released_amount - contract.refunded_amount,
+        "invariant violated after deposit"
+    );
+
+    // Release milestone 0 with a 500 bps (5 %) fee.
+    escrow.set_protocol_fee_bps(&500u32);
+    let fee_bps: i128 = 500;
+    let m0_amount = MILESTONE_ONE;
+    let m0_fee = m0_amount * fee_bps / 10_000;
+
+    escrow.approve_milestone_release(&id, &client_addr, &0);
+    escrow.release_milestone(&id, &client_addr, &0);
+
+    let contract = escrow.get_contract(&id);
+    let accrued: i128 = escrow.get_accumulated_protocol_fees();
+    let escrow_bal: i128 = token.balance(&escrow.address);
+
+    // invariant: balance == funded - released - refunded + accrued_fees
+    assert_eq!(
+        escrow_bal,
+        contract.funded_amount - contract.released_amount - contract.refunded_amount + accrued,
+        "invariant violated after milestone release"
+    );
+
+    // Fee was retained: freelancer received gross minus fee.
+    assert_eq!(token.balance(&freelancer_addr), m0_amount - m0_fee);
+
+    // Accrued fees == fee deducted.
+    assert_eq!(accrued, m0_fee);
+    let _ = (client_addr,);
+}
+
 // ─── Compound ⛓ end-to-end ────────────────────────────────────────────────────
 
 #[test]

--- a/docs/escrow/sac-custody.md
+++ b/docs/escrow/sac-custody.md
@@ -1,0 +1,217 @@
+# SAC Custody and Settlement-Token Lifecycle
+
+This document describes the custody model for the TalentTrust Escrow contract: which
+entrypoint moves funds in which direction, the one-token-per-escrow assumption, where
+accrued protocol fees reside until withdrawn, and the accounting invariant that
+integrators and auditors can rely on.
+
+Cross-check source: [`contracts/escrow/src/lib.rs`](../../contracts/escrow/src/lib.rs)
+
+---
+
+## One-Token-per-Escrow Assumption
+
+Each deployed escrow instance custodies **exactly one** Stellar Asset Contract (SAC)
+token.  The token address is stored under `DataKey::SettlementToken` and must be bound
+before any fund-moving entrypoint can execute.  There is no support for multi-token
+escrow; all milestone amounts are denominated in stroops of this single token.
+
+---
+
+## Entrypoint Fund-Flow Map
+
+| Entrypoint | Source | Destination | Amount |
+|---|---|---|---|
+| `bind_settlement_token` | — | — | No transfer; records the SAC address in persistent storage. |
+| `deposit_funds` | Client wallet | Escrow contract address | Exact `amount` argument (must equal total unfunded milestones). |
+| `release_milestone` | Escrow contract address | Freelancer wallet | `milestone.amount − protocol_fee`; fee is retained inside the escrow contract. |
+| `refund_unreleased_milestones` | Escrow contract address | Client wallet | Sum of milestone amounts for each requested unreleased index. |
+| `cancel_contract` | Escrow contract address | Client wallet | All funded-but-unreleased amounts returned. |
+| `withdraw_protocol_fees` | Escrow contract address | Protocol treasury | Accumulated fee balance (`DataKey::AccumulatedProtocolFees`). |
+
+---
+
+## Token-Binding Step (`bind_settlement_token`)
+
+`bind_settlement_token(admin, token)` is the **write-once** configuration step that
+records the SAC address under `DataKey::SettlementToken`.
+
+- Requires `initialize` to have been called (`NotInitialized` error otherwise).
+- Requires the caller to be the stored admin (`UnauthorizedRole` otherwise).
+- Rejects a second call when a token is already bound (`SettlementTokenAlreadyBound`).
+- `set_settlement_token` is a deprecated alias retained for backward compatibility;
+  new code must call `bind_settlement_token`.
+
+After binding, every fund-moving entrypoint reads this key via
+`Escrow::read_settlement_token`.  If the key is absent at call time the contract panics
+with `SettlementTokenNotConfigured`.
+
+---
+
+## Deposit (`deposit_funds`)
+
+```
+Client wallet ──[SAC transfer]──► Escrow contract address
+```
+
+1. Validates `amount > 0`, contract exists, caller is the client, and contract is in
+   `Created` status.
+2. Calls `token::Client::transfer(from: client, to: escrow_address, amount)` — the SAC
+   deducts from the client's on-chain balance and credits the escrow contract address.
+3. Updates `contract.funded_amount += amount` and `contract.total_deposited += amount`.
+4. Transitions status to `Funded` once `funded_amount >= sum(milestones)`.
+
+The contract address itself holds the balance; there is no separate vault or sub-account.
+
+---
+
+## Milestone Release (`release_milestone`)
+
+```
+Escrow contract address ──[SAC transfer, net of fee]──► Freelancer wallet
+```
+
+1. Validates: contract is `Funded`, milestone not already released or refunded,
+   caller has the required `ReleaseAuthorization` role, approvals are satisfied.
+2. Computes `fee = milestone.amount × fee_bps / 10 000`.
+3. Transfers `milestone.amount − fee` from the escrow address to the freelancer.
+4. Adds `fee` to `DataKey::AccumulatedProtocolFees` (in-contract commingled balance).
+5. Updates `contract.released_amount += milestone.amount`.
+6. If all milestones are released or refunded, transitions status to `Completed`.
+
+Protocol fees are **not** moved out of the contract immediately; they remain commingled
+with the escrow balance until `withdraw_protocol_fees` is called.
+
+---
+
+## Refund (`refund_unreleased_milestones`)
+
+```
+Escrow contract address ──[SAC transfer]──► Client wallet
+```
+
+1. Requires client auth and a non-empty, deduplicated list of milestone indices.
+2. Rejects any index that is already released or refunded.
+3. Checks `available_balance >= total_refund_amount` where
+   `available_balance = funded_amount − released_amount − refunded_amount`.
+4. Transfers the summed refund amount from the escrow address to the client.
+5. Updates `contract.refunded_amount += total_refund_amount`.
+6. Transitions to `Refunded` (all milestones refunded) or `Completed` (mix of released
+   and refunded) when no unreleased milestone remains.
+
+---
+
+## Cancel Contract (`cancel_contract`)
+
+Behaves like a bulk refund of all unfunded or unreleased milestones.
+
+```
+Escrow contract address ──[SAC transfer, all unreleased]──► Client wallet
+```
+
+Transitions status to `Cancelled`.
+
+---
+
+## Protocol-Fee Withdrawal (`withdraw_protocol_fees`)
+
+```
+Escrow contract address ──[SAC transfer, accumulated fees]──► Treasury address
+```
+
+Only the protocol admin may call this entrypoint.  It reads
+`DataKey::AccumulatedProtocolFees`, transfers that amount from the escrow address to the
+configured treasury, and resets the counter to zero.
+
+---
+
+## Balance / Accounting Invariant
+
+At any point in a contract's lifetime the following invariant must hold:
+
+```
+escrow_sac_balance == funded_amount − released_amount − refunded_amount + accrued_fees
+```
+
+where:
+- `funded_amount` = total deposited by the client (sum of all `deposit_funds` calls).
+- `released_amount` = gross milestone amounts passed to the freelancer (before fee
+  deduction); fees remain in the contract and are counted in `accrued_fees`.
+- `refunded_amount` = sum of all milestone amounts returned to the client.
+- `accrued_fees` = `DataKey::AccumulatedProtocolFees` — protocol fees retained in-contract
+  from prior milestone releases but not yet withdrawn.
+
+This invariant is enforced by `AccountingInvariantViolated` checks throughout the
+codebase.  Auditors should verify it holds after every state-mutating transaction.
+
+---
+
+## Full Lifecycle Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Admin
+    actor Client
+    actor Freelancer
+    actor Treasury
+    participant Escrow
+    participant SAC
+
+    Admin->>Escrow: initialize(admin)
+    Note over Escrow: DataKey::Initialized = true
+
+    Admin->>Escrow: bind_settlement_token(admin, sac_address)
+    Note over Escrow: DataKey::SettlementToken = sac_address (write-once)
+
+    Client->>Escrow: create_contract(client, freelancer, milestones, ...)
+    Note over Escrow: status = Created, funded_amount = 0
+
+    Client->>Escrow: deposit_funds(id, client, total)
+    Escrow->>SAC: transfer(from: client, to: escrow, total)
+    Note over Escrow: funded_amount = total, status = Funded
+
+    Client->>Escrow: approve_milestone_release(id, client, milestone_index)
+    Client->>Escrow: release_milestone(id, client, milestone_index)
+    Escrow->>SAC: transfer(from: escrow, to: freelancer, amount − fee)
+    Note over Escrow: AccumulatedProtocolFees += fee, released_amount += amount
+
+    Admin->>Escrow: withdraw_protocol_fees(admin, treasury)
+    Escrow->>SAC: transfer(from: escrow, to: treasury, accrued_fees)
+    Note over Escrow: AccumulatedProtocolFees = 0
+```
+
+---
+
+## Failure Modes
+
+| Scenario | Error |
+|---|---|
+| `deposit_funds` / `release_milestone` called before `bind_settlement_token` | `SettlementTokenNotConfigured` |
+| `bind_settlement_token` called a second time | `SettlementTokenAlreadyBound` |
+| Any fund-moving call before `initialize` | `NotInitialized` |
+| Caller not the expected role (client / admin) | `UnauthorizedRole` |
+| Contract is paused | `ContractPaused` |
+| Deposit while status is not `Created` | `InvalidState` |
+| Release while status is not `Funded` | `InvalidState` |
+| Available balance less than requested amount | `InsufficientFunds` |
+
+---
+
+## Security Notes for Integrators
+
+1. **Single-token deployment**: Deploy one escrow contract per currency.  Binding a
+   different SAC after the first binding is rejected; migration requires deploying a new
+   contract.
+2. **Commingled protocol fees**: Accrued fees sit in the escrow contract's own SAC
+   balance.  The balance invariant above accounts for them.  Draining `withdraw_protocol_fees`
+   regularly avoids confusion when auditing the contract balance.
+3. **Client auth on deposit**: The SAC `transfer` in `deposit_funds` requires the
+   client's signature (`require_auth`).  An escrow contract cannot pull funds without
+   explicit client authorisation per transaction.
+4. **Atomicity**: State updates and SAC transfers occur in the same Soroban transaction.
+   A failed SAC transfer (e.g., insufficient client balance) leaves contract state
+   unchanged.
+5. **Overflow protection**: All arithmetic uses `safe_add_amounts` /
+   `safe_subtract_amounts` wrappers; overflow panics with `PotentialOverflow` before any
+   state or balance is modified.


### PR DESCRIPTION
Closes #657

## Summary
- Add `docs/escrow/sac-custody.md` with the full one-token-per-escrow custody model: fund-flow map for every entrypoint, accounting invariant (`balance == funded − released − refunded + accrued_fees`), failure modes, security notes, and a Mermaid lifecycle sequence diagram.
- Extend `///` doc comments on `bind_settlement_token`, `deposit_funds`, `release_milestone`, and `withdraw_protocol_fees` in `lib.rs` to cross-reference the new document.
- Add `sac_custody_accounting_invariant_holds_after_deposit_and_release` test that exercises bind → deposit → release with a 5% fee and verifies the documented invariant holds at each step.

🤖 Generated with Claude Code