### PR TITLE
feat: persist reputation_issued in finalization ContractSummary snaps…

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -111,7 +111,7 @@ impl Escrow {
             freelancer: contract.freelancer.clone(),
             arbiter: contract.arbiter.clone(),
             status: contract.status,
-            reputation_issued: false,
+            reputation_issued: contract.reputation_issued,
             total_amount,
             funded_amount: contract.funded_amount,
             released_amount: contract.released_amount,


### PR DESCRIPTION
# Description
This PR ensures that `reputation_issued` is correctly persisted in the finalization `ContractSummary` snapshot instead of being hardcoded to `false`.

Closes #451 