### PR TITLE
fix: validate deposit inputs before token transfer

### DIFF
--- a/contracts/escrow/src/deposit.rs
+++ b/contracts/escrow/src/deposit.rs
@@ -1,6 +1,66 @@
 use crate::{ttl, Contract, ContractStatus, DataKey, Error, Milestone};
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
+/// Validated deposit data that is safe to use before any token transfer.
+pub struct ValidatedDeposit {
+    pub contract: Contract,
+    pub total_amount: i128,
+}
+
+/// Validate a deposit without mutating state or moving tokens.
+///
+/// This preflight must run before the SAC transfer in `deposit_funds` so an
+/// invalid deposit cannot debit the client and then fail during escrow state
+/// validation.
+pub fn validate_deposit(
+    env: &Env,
+    contract_id: u32,
+    caller: &Address,
+    amount: i128,
+) -> ValidatedDeposit {
+    if amount <= 0 {
+        env.panic_with_error(Error::AmountMustBePositive);
+    }
+
+    let contract: Contract = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Contract(contract_id))
+        .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+    if caller != &contract.client {
+        env.panic_with_error(Error::UnauthorizedRole);
+    }
+
+    if contract.status != ContractStatus::Created
+        && contract.status != ContractStatus::PartiallyFunded
+    {
+        env.panic_with_error(Error::InvalidState);
+    }
+
+    let milestone_key = Symbol::new(env, "milestones");
+    let milestones: Vec<Milestone> = env
+        .storage()
+        .persistent()
+        .get(&(DataKey::Contract(contract_id), milestone_key))
+        .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+    let total_amount: i128 = milestones.iter().map(|m| m.amount).sum();
+    let new_funded_amount = contract
+        .funded_amount
+        .checked_add(amount)
+        .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+
+    if new_funded_amount > total_amount {
+        env.panic_with_error(Error::InvalidDepositAmount);
+    }
+
+    ValidatedDeposit {
+        contract,
+        total_amount,
+    }
+}
+
 /// Deposits funds into the contract. Transitions to Funded status when fully funded.
 ///
 /// # Arguments
@@ -18,43 +78,36 @@ use soroban_sdk::{Address, Env, Symbol, Vec};
 /// * `InvalidState` - If contract is not in Created state
 /// * `UnauthorizedRole` - If caller is not the client
 pub fn deposit_funds_impl(env: &Env, contract_id: u32, caller: Address, amount: i128) -> bool {
-    if amount <= 0 {
-        env.panic_with_error(Error::AmountMustBePositive);
-    }
+    let validated = validate_deposit(env, contract_id, &caller, amount);
+    apply_validated_deposit(env, contract_id, caller, amount, validated)
+}
 
-    let mut contract: Contract = env
-        .storage()
-        .persistent()
-        .get(&DataKey::Contract(contract_id))
-        .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+/// Apply a deposit after the caller has been validated and the token transfer succeeded.
+pub fn apply_validated_deposit(
+    env: &Env,
+    contract_id: u32,
+    caller: Address,
+    amount: i128,
+    validated: ValidatedDeposit,
+) -> bool {
+    let ValidatedDeposit {
+        mut contract,
+        total_amount,
+    } = validated;
 
     ttl::extend_contract_ttl(&env, contract_id);
 
-    if caller != contract.client {
-        env.panic_with_error(Error::UnauthorizedRole);
-    }
     caller.require_auth();
-
-    if contract.status != ContractStatus::Created {
-        env.panic_with_error(Error::InvalidState);
-    }
 
     contract.funded_amount += amount;
     contract.total_deposited += amount;
 
-    let milestone_key = Symbol::new(&env, "milestones");
-    let milestones: Vec<Milestone> = env
-        .storage()
-        .persistent()
-        .get(&(DataKey::Contract(contract_id), milestone_key))
-        .unwrap();
-
     ttl::extend_milestone_ttl(&env, contract_id);
 
-    let total_amount: i128 = milestones.iter().map(|m| m.amount).sum();
-
-    if contract.funded_amount >= total_amount && contract.status == ContractStatus::Created {
+    if contract.funded_amount == total_amount {
         contract.status = ContractStatus::Funded;
+    } else {
+        contract.status = ContractStatus::PartiallyFunded;
     }
 
     env.storage()

--- a/contracts/escrow/src/deposit.rs
+++ b/contracts/escrow/src/deposit.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{Address, Env, Symbol, Vec};
 /// Validated deposit data that is safe to use before any token transfer.
 pub struct ValidatedDeposit {
     pub contract: Contract,
+    pub new_funded_amount: i128,
+    pub new_total_deposited: i128,
     pub total_amount: i128,
 }
 
@@ -50,6 +52,10 @@ pub fn validate_deposit(
         .funded_amount
         .checked_add(amount)
         .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+    let new_total_deposited = contract
+        .total_deposited
+        .checked_add(amount)
+        .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
 
     if new_funded_amount > total_amount {
         env.panic_with_error(Error::InvalidDepositAmount);
@@ -57,6 +63,8 @@ pub fn validate_deposit(
 
     ValidatedDeposit {
         contract,
+        new_funded_amount,
+        new_total_deposited,
         total_amount,
     }
 }
@@ -79,7 +87,7 @@ pub fn validate_deposit(
 /// * `UnauthorizedRole` - If caller is not the client
 pub fn deposit_funds_impl(env: &Env, contract_id: u32, caller: Address, amount: i128) -> bool {
     let validated = validate_deposit(env, contract_id, &caller, amount);
-    apply_validated_deposit(env, contract_id, caller, amount, validated)
+    apply_validated_deposit(env, contract_id, caller, validated)
 }
 
 /// Apply a deposit after the caller has been validated and the token transfer succeeded.
@@ -87,11 +95,12 @@ pub fn apply_validated_deposit(
     env: &Env,
     contract_id: u32,
     caller: Address,
-    amount: i128,
     validated: ValidatedDeposit,
 ) -> bool {
     let ValidatedDeposit {
         mut contract,
+        new_funded_amount,
+        new_total_deposited,
         total_amount,
     } = validated;
 
@@ -99,8 +108,8 @@ pub fn apply_validated_deposit(
 
     caller.require_auth();
 
-    contract.funded_amount += amount;
-    contract.total_deposited += amount;
+    contract.funded_amount = new_funded_amount;
+    contract.total_deposited = new_total_deposited;
 
     ttl::extend_milestone_ttl(&env, contract_id);
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -401,7 +401,7 @@ impl Escrow {
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&caller, &env.current_contract_address(), &amount);
 
-        deposit::apply_validated_deposit(&env, contract_id, caller, amount, validated)
+        deposit::apply_validated_deposit(&env, contract_id, caller, validated)
     }
 
     /// Finalize an escrow contract by writing immutable close metadata.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -106,6 +106,10 @@ pub enum EscrowError {
     PotentialOverflow = 28,
     AlreadyFinalized = 29,
     AmountMustBePositive = 30,
+    /// No settlement token has been bound for custody transfers.
+    SettlementTokenNotConfigured = 31,
+    /// A settlement token has already been bound.
+    SettlementTokenAlreadyBound = 32,
 }
 
 #[contractimpl]
@@ -384,13 +388,20 @@ impl Escrow {
     /// * `InvalidState` - If contract is not in Created state
     /// * `UnauthorizedRole` - If caller is not the client
     pub fn deposit_funds(env: Env, contract_id: u32, caller: Address, amount: i128) -> bool {
-        // Transfer tokens from caller to contract
-        let token = Self::read_settlement_token(&env).expect("Settlement token not set");
+        Self::require_initialized(&env);
+        Self::require_not_paused(&env);
+
+        // Validate all contract-local preconditions before any SAC transfer so
+        // rejected deposits cannot debit the client and then fail state checks.
+        let validated = deposit::validate_deposit(&env, contract_id, &caller, amount);
+
+        let token = Self::read_settlement_token(&env)
+            .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
 
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&caller, &env.current_contract_address(), &amount);
 
-        deposit::deposit_funds_impl(&env, contract_id, caller, amount)
+        deposit::apply_validated_deposit(&env, contract_id, caller, amount, validated)
     }
 
     /// Finalize an escrow contract by writing immutable close metadata.

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -168,6 +168,8 @@ pub enum Error {
     InvalidProtocolParameters = 49,
     /// The escrow cap would be exceeded by this operation.
     EscrowCapExceeded = 51,
+    /// No settlement token has been bound for custody transfers.
+    SettlementTokenNotConfigured = 52,
 }
 
 
@@ -329,4 +331,3 @@ impl DisputeResolution {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- preflight `deposit_funds` contract-local validation before SAC token transfer
- reject invalid amount, caller, status, missing milestones, arithmetic overflow, and overfunding before debiting the client
- return a typed settlement-token configuration error instead of panicking with `expect`

## Threat mitigated
Previously `deposit_funds` performed the token transfer before validating escrow state. A rejected deposit could debit the client and then fail state validation, creating a transfer-then-revert custody/accounting risk.

Closes #643

## Validation
- `git diff --check HEAD~1..HEAD`
- Not run: `cargo test` because `cargo`/`rustc` are unavailable on this machine; Docker daemon is also unavailable.
