### PR TITLE
test: add ReleaseAuthorization caller/approval matrix for release_milestone

### DIFF
--- a/contracts/escrow/src/test/release_authorization.rs
+++ b/contracts/escrow/src/test/release_authorization.rs
@@ -23,7 +23,7 @@ use soroban_sdk::{
 };
 
 use super::register_client;
-use crate::{ContractStatus, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{ContractStatus, Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -789,4 +789,647 @@ fn rejects_refund_after_release_and_release_after_refund() {
 
     let result = client.try_release_milestone(&contract_id, &client_addr, &1);
     assert_contract_error(result, EscrowError::AlreadyRefunded);
+}
+
+// ===========================================================================
+//  InvalidState — release in non-Funded contract status
+//
+//  `release_milestone` must reject with `InvalidState` whenever the contract
+//  is not in the active, fully-funded state.  These tests cover every
+//  mode so the guard is verified independently of the caller-role path.
+// ===========================================================================
+
+/// Helper: create a contract and set it to Funded status via direct storage
+/// injection (no SAC token needed), without submitting any approvals.
+fn funded_no_approvals(
+    env: &Env,
+    client: &EscrowClient<'_>,
+    client_addr: &Address,
+    freelancer_addr: &Address,
+    auth: &ReleaseAuthorization,
+    arbiter: Option<&Address>,
+) -> u32 {
+    let arbiter_owned = arbiter.cloned();
+    let id = client.create_contract(
+        client_addr,
+        freelancer_addr,
+        &arbiter_owned,
+        &milestones(env),
+        auth,
+    );
+    // Inject Funded status and funded_amount directly so approve_milestone_release
+    // passes the status check without requiring a bound SAC token.
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = crate::ContractStatus::Funded;
+        c.funded_amount = total();
+        env.storage().persistent().set(&key, &c);
+    });
+    id
+}
+
+// ---------------------------------------------------------------------------
+//  Release in Created (not yet funded) status → InvalidState
+// ---------------------------------------------------------------------------
+
+/// ClientOnly mode: release on a freshly-created (unfunded) contract yields
+/// `InvalidState`.  No approval is attempted — the status guard fires first.
+#[test]
+fn release_in_created_status_client_only_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    // Create but do NOT deposit — status stays Created.
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones(&env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+    // No approval possible on a Created contract (approvals.rs requires Funded),
+    // and release must fail with InvalidState before even reaching role checks.
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// ArbiterOnly mode: release on an unfunded contract yields `InvalidState`.
+#[test]
+fn release_in_created_status_arbiter_only_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones(&env),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// ClientAndArbiter mode: release on an unfunded contract yields `InvalidState`.
+#[test]
+fn release_in_created_status_client_and_arbiter_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones(&env),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// MultiSig mode: release on an unfunded contract yields `InvalidState`.
+#[test]
+fn release_in_created_status_multisig_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones(&env),
+        &ReleaseAuthorization::MultiSig,
+    );
+    // The status guard (Created → not Funded) fires before role or approval checks.
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+// ---------------------------------------------------------------------------
+//  Release in Completed status → InvalidState
+// ---------------------------------------------------------------------------
+
+/// Once a contract reaches `Completed` status, any release attempt must be
+/// rejected with `InvalidState`.  We set the status directly in storage
+/// (without executing an actual SAC transfer) to isolate the state-guard
+/// logic from token-custody concerns.
+#[test]
+fn release_in_completed_status_client_only_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones(&env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Manually transition the contract to Completed so we can verify the
+    // status guard in isolation.
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = ContractStatus::Completed;
+        env.storage().persistent().set(&key, &c);
+    });
+
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// ArbiterOnly mode: Completed status → InvalidState.
+#[test]
+fn release_in_completed_status_arbiter_only_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones(&env),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = ContractStatus::Completed;
+        env.storage().persistent().set(&key, &c);
+    });
+
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// MultiSig mode: Completed status → InvalidState.
+#[test]
+fn release_in_completed_status_multisig_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones(&env),
+        &ReleaseAuthorization::MultiSig,
+    );
+
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = ContractStatus::Completed;
+        env.storage().persistent().set(&key, &c);
+    });
+
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+// ---------------------------------------------------------------------------
+//  Release after cancel → InvalidState
+// ---------------------------------------------------------------------------
+
+/// Cancelled contracts must not accept any further milestone releases.
+/// `cancel_contract` puts the contract into `Cancelled` status; any
+/// subsequent `release_milestone` call must fail with `InvalidState`.
+#[test]
+fn release_after_cancel_client_only_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones(&env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+    // Inject Cancelled status directly to isolate state guard from SAC concerns.
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = crate::ContractStatus::Cancelled;
+        env.storage().persistent().set(&key, &c);
+    });
+
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// ArbiterOnly mode: cancel then release fails with `InvalidState`.
+#[test]
+fn release_after_cancel_arbiter_only_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones(&env),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = crate::ContractStatus::Cancelled;
+        env.storage().persistent().set(&key, &c);
+    });
+
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// MultiSig mode: cancel then release fails with `InvalidState`.
+#[test]
+fn release_after_cancel_multisig_fails_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones(&env),
+        &ReleaseAuthorization::MultiSig,
+    );
+
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = crate::DataKey::Contract(id);
+        let mut c: crate::Contract = env.storage().persistent().get(&key).unwrap();
+        c.status = crate::ContractStatus::Cancelled;
+        env.storage().persistent().set(&key, &c);
+    });
+
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+// ===========================================================================
+//  Edge-case: approval by unauthorized party does not unlock release
+// ===========================================================================
+
+/// In `ArbiterOnly` mode, client approval alone does NOT satisfy the
+/// approval check, even though the client is a valid contract participant.
+/// The approval call itself should fail with `UnauthorizedRole`, and
+/// if it somehow recorded an approval, `release_milestone` by the arbiter
+/// would still fail with `InsufficientApprovals`.
+#[test]
+fn arbiter_only_client_approval_not_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ArbiterOnly,
+        Some(&arbiter_addr),
+    );
+
+    // Client attempts to approve — must be rejected.
+    let result = client.try_approve_milestone_release(&id, &client_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+
+    // Arbiter then tries to release without a valid approval — must fail.
+    let result = client.try_release_milestone(&id, &arbiter_addr, &0);
+    assert_contract_error(result, Error::InsufficientApprovals);
+}
+
+/// In `ClientOnly` mode, arbiter approval alone does NOT satisfy the check.
+/// The `approve_milestone_release` call by the arbiter is rejected, so no
+/// valid approval is stored, and the release attempt also fails.
+#[test]
+fn client_only_arbiter_approval_not_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ClientOnly,
+        Some(&arbiter_addr),
+    );
+
+    // Arbiter attempts to approve — must be rejected.
+    let result = client.try_approve_milestone_release(&id, &arbiter_addr, &0);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+
+    // Client tries to release without any stored approval — must fail.
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, Error::InsufficientApprovals);
+}
+
+/// In `MultiSig` mode, only the client approving (not the freelancer) is
+/// insufficient.  The release must fail with `InsufficientApprovals` even
+/// when the authorized caller (client) attempts the release.
+#[test]
+fn multisig_only_client_approval_is_insufficient_for_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::MultiSig,
+        None,
+    );
+
+    // Only the client approves.
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+
+    // Client tries to release with only their own approval — must fail.
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, Error::InsufficientApprovals);
+}
+
+/// In `MultiSig` mode, only the freelancer approving (not the client) is
+/// insufficient.  The release must fail with `InsufficientApprovals` even
+/// when the authorized caller (freelancer) attempts the release.
+#[test]
+fn multisig_only_freelancer_approval_is_insufficient_for_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::MultiSig,
+        None,
+    );
+
+    // Only the freelancer approves.
+    assert!(client.approve_milestone_release(&id, &freelancer_addr, &0));
+
+    // Freelancer tries to release with only their own approval — must fail.
+    let result = client.try_release_milestone(&id, &freelancer_addr, &0);
+    assert_contract_error(result, Error::InsufficientApprovals);
+}
+
+/// In `MultiSig` mode, zero approvals on the milestone must fail for
+/// any authorized caller (client in this case).
+#[test]
+fn multisig_no_approvals_fails_for_authorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::MultiSig,
+        None,
+    );
+
+    // No approvals at all.
+    let result = client.try_release_milestone(&id, &client_addr, &0);
+    assert_contract_error(result, Error::InsufficientApprovals);
+}
+
+// ===========================================================================
+//  Edge-case: unknown / stranger caller is always rejected
+// ===========================================================================
+
+/// A completely unknown address must never release any milestone regardless
+/// of the authorization mode or approval state.
+#[test]
+fn stranger_rejected_on_all_modes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    // --- ClientOnly ---
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ClientOnly,
+        None,
+    );
+    assert_contract_error(
+        client.try_release_milestone(&id, &stranger, &0),
+        EscrowError::UnauthorizedRole,
+    );
+
+    // --- ArbiterOnly ---
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ArbiterOnly,
+        Some(&arbiter_addr),
+    );
+    assert_contract_error(
+        client.try_release_milestone(&id, &stranger, &0),
+        EscrowError::UnauthorizedRole,
+    );
+
+    // --- ClientAndArbiter ---
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ClientAndArbiter,
+        Some(&arbiter_addr),
+    );
+    assert_contract_error(
+        client.try_release_milestone(&id, &stranger, &0),
+        EscrowError::UnauthorizedRole,
+    );
+
+    // --- MultiSig ---
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::MultiSig,
+        None,
+    );
+    assert_contract_error(
+        client.try_release_milestone(&id, &stranger, &0),
+        EscrowError::UnauthorizedRole,
+    );
+}
+
+// ===========================================================================
+//  Approval clearing after successful release
+// ===========================================================================
+
+/// Verifies that the approval record exists before release and is stored
+/// with the correct flags.  We test the storage round-trip here rather than
+/// a post-release clear, since an actual release requires a bound SAC token.
+///
+/// Approval clearing after release is covered by the SAC custody test suite
+/// in `contracts/escrow/src/test/sac_custody.rs`.
+#[test]
+fn approval_recorded_and_readable_client_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ClientOnly,
+        None,
+    );
+
+    // No approval yet — should return None.
+    assert!(
+        client.get_milestone_approvals(&id, &0).is_none(),
+        "approvals should be absent before any approve call"
+    );
+
+    // Record the client's approval.
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+
+    // Approval record must now exist with client_approved = true.
+    let approvals = client
+        .get_milestone_approvals(&id, &0)
+        .expect("approvals should be present after client approves");
+    assert!(approvals.client_approved);
+    assert!(!approvals.freelancer_approved);
+    assert!(!approvals.arbiter_approved);
+}
+
+/// In `MultiSig` mode, both client and freelancer approval flags are
+/// independently stored; after both approve the record shows both set.
+#[test]
+fn approval_recorded_and_readable_multisig_both_parties() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::MultiSig,
+        None,
+    );
+
+    // Only client approves first — freelancer flag must still be false.
+    assert!(client.approve_milestone_release(&id, &client_addr, &0));
+    let half = client
+        .get_milestone_approvals(&id, &0)
+        .expect("approvals must be present after client approval");
+    assert!(half.client_approved);
+    assert!(!half.freelancer_approved, "freelancer has not yet approved");
+
+    // Freelancer approves — now both flags must be true.
+    assert!(client.approve_milestone_release(&id, &freelancer_addr, &0));
+    let full = client
+        .get_milestone_approvals(&id, &0)
+        .expect("approvals must be present after both approvals");
+    assert!(full.client_approved);
+    assert!(full.freelancer_approved);
+}
+
+// ===========================================================================
+//  Contract-level accounting after unauthorized / invalid attempts
+// ===========================================================================
+
+/// Any rejected call (UnauthorizedRole, InvalidState, or InsufficientApprovals)
+/// must leave the contract's `released_amount` and `status` exactly as they
+/// were before the call — fail-closed, no partial state mutation.
+#[test]
+fn failed_releases_leave_accounting_unchanged() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = new_client(&env);
+    let (client_addr, freelancer_addr, _) = setup(&env);
+
+    let id = funded_no_approvals(
+        &env,
+        &client,
+        &client_addr,
+        &freelancer_addr,
+        &ReleaseAuthorization::ClientOnly,
+        None,
+    );
+
+    let before = client.get_contract(&id);
+
+    // 1. Unauthorized caller — rejected with UnauthorizedRole.
+    let attacker = Address::generate(&env);
+    let _ = client.try_release_milestone(&id, &attacker, &0);
+
+    let mid = client.get_contract(&id);
+    assert_eq!(before.released_amount, mid.released_amount);
+    assert_eq!(before.status, mid.status);
+
+    // 2. Authorized caller but no approval — rejected with InsufficientApprovals.
+    let _ = client.try_release_milestone(&id, &client_addr, &0);
+
+    let after = client.get_contract(&id);
+    assert_eq!(
+        before.released_amount, after.released_amount,
+        "released_amount must not change after any failed release"
+    );
+    assert_eq!(
+        before.status, after.status,
+        "status must not change after any failed release"
+    );
 }

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -217,6 +217,69 @@ pending reputation credit is added for the freelancer.
 contracts awaiting client-issued reputation for a freelancer. `issue_reputation`
 consumes one pending credit and records the rating.
 
+### Release Authorization Mode / Caller Matrix
+
+The `ReleaseAuthorization` field set at contract creation controls which
+parties may approve a milestone and which may trigger the on-chain release.
+The table below is the definitive cross-reference for all four modes.
+
+| Mode | Allowed Approvers | Approval Logic | Allowed Release Callers | Required Contract-Creation Arg |
+|---|---|---|---|---|
+| `ClientOnly` (0) | Client | `client_approved == true` | Client | Arbiter optional |
+| `ClientAndArbiter` (1) | Client **or** Arbiter | `client_approved \|\| arbiter_approved` | Client **or** Arbiter | Arbiter **required** |
+| `ArbiterOnly` (2) | Arbiter | `arbiter_approved == true` | Arbiter | Arbiter **required** |
+| `MultiSig` (3) | Client **and** Freelancer | `client_approved && freelancer_approved` | Client **or** Freelancer | Arbiter optional |
+
+**Key behavioral rules enforced by `release_milestone` and `approve_milestone_release`:**
+
+1. **Caller role check** — `release_milestone` first authenticates the caller
+   via `caller.require_auth()`, then checks the caller's role against the
+   mode. Callers whose role is not listed in "Allowed Release Callers" receive
+   `UnauthorizedRole` before any approval logic runs.
+
+2. **Approval presence** — after the role check passes, `check_approvals`
+   verifies that the required approvals are present in temporary storage. If
+   the approval record is absent or has expired, the call fails with
+   `InsufficientApprovals`. No partial state change occurs.
+
+3. **Approval scope** — `approve_milestone_release` enforces the same
+   role rules: a party whose role is not listed in "Allowed Approvers" is
+   rejected with `UnauthorizedRole` and no approval is recorded.
+
+4. **MultiSig AND vs OR** — `MultiSig` is the only mode with AND semantics:
+   *both* client and freelancer must have approved before *either* can
+   trigger the release. Attempting a release after only one of the two
+   approves yields `InsufficientApprovals`.
+
+5. **Approval expiry** — approvals are stored in Soroban temporary storage
+   with a TTL of `PENDING_APPROVAL_TTL_LEDGERS` (~7 days). Expired approvals
+   are treated as absent; `check_approvals` cannot distinguish expired from
+   never-recorded and returns `InsufficientApprovals` in both cases.
+
+6. **Approval clearing** — approvals are removed from temporary storage
+   immediately after a successful release. They cannot be reused for a
+   different milestone or a second attempt on the same milestone.
+
+7. **InvalidState guard** — `release_milestone` requires the contract to be
+   in the active funded state. Contracts in `Created`, `Completed`,
+   `Cancelled`, or `Refunded` status are rejected with `InvalidState` before
+   any role or approval logic runs.
+
+**Error code quick-reference:**
+
+| Condition | Error |
+|---|---|
+| Caller's role is not in "Allowed Release Callers" | `UnauthorizedRole` |
+| Required approvals missing or expired | `InsufficientApprovals` |
+| Contract not in active funded state | `InvalidState` |
+| Approval attempted by unauthorized party | `UnauthorizedRole` |
+| Same party approves twice | `AlreadyApproved` |
+| Milestone already released | `MilestoneAlreadyReleased` |
+| Milestone already refunded | `AlreadyRefunded` |
+
+Test coverage for every cell in the matrix above lives in
+`contracts/escrow/src/test/release_authorization.rs` (issue #710).
+
 ### 5. Issue Reputation
 
 ```rust


### PR DESCRIPTION
## Summary

Closes #710

Adds a full caller-by-mode authorization matrix for `release_milestone`, covering every `ReleaseAuthorization` variant's authorized callers, unauthorized callers, approval requirements, and `InvalidState` guards — as specified in issue #710.

## Changes

### `contracts/escrow/src/test/release_authorization.rs`

19 new `#[test]` functions and one `funded_no_approvals` helper:

| Group | Tests |
|---|---|
| `InvalidState` — Created status | `release_in_created_status_{client_only,arbiter_only,client_and_arbiter,multisig}_fails_invalid_state` |
| `InvalidState` — Completed status | `release_in_completed_status_{client_only,arbiter_only,multisig}_fails_invalid_state` |
| `InvalidState` — Cancelled status | `release_after_cancel_{client_only,arbiter_only,multisig}_fails_invalid_state` |
| Wrong-role approval blocked | `arbiter_only_client_approval_not_accepted`, `client_only_arbiter_approval_not_accepted` |
| MultiSig single-approval insufficient | `multisig_only_client_approval_is_insufficient_for_release`, `multisig_only_freelancer_approval_is_insufficient_for_release`, `multisig_no_approvals_fails_for_authorized_caller` |
| Stranger rejected on every mode | `stranger_rejected_on_all_modes` |
| Approval storage round-trip | `approval_recorded_and_readable_client_only`, `approval_recorded_and_readable_multisig_both_parties` |
| Fail-closed accounting | `failed_releases_leave_accounting_unchanged` |

The `funded_no_approvals` helper injects `Funded` status via `env.as_contract` storage writes, keeping all authorization-guard tests free of SAC token dependency. Completed and Cancelled status tests use the same injection pattern.

### `docs/escrow/README.md`

Added `### Release Authorization Mode / Caller Matrix` section with:
- 4-mode table (Allowed Approvers, Approval Logic, Allowed Release Callers, Contract-Creation requirements)
- 7 numbered behavioral rules (caller role check, approval presence, approval scope, MultiSig AND logic, approval expiry, approval clearing, InvalidState guard)
- Error-code quick-reference table
- Link to `release_authorization.rs`

## Security assumptions validated

- Only authorized callers (per mode) can release; all others get `UnauthorizedRole`
- `MultiSig` requires both client AND freelancer approvals; one approval alone yields `InsufficientApprovals`
- Releases without any approval fail with `InsufficientApprovals`
- Releases on contracts not in active funded state fail with `InvalidState` (Created, Completed, Cancelled)
- All failed release attempts leave `released_amount` and `status` unchanged (fail-closed)