### PR TITLE
close #724:  Add direct unit tests for the ttl helper functions against evicted entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Soroban smart contracts for the TalentTrust freelancer escrow protocol on Stella
 - **Escrow contract** (`contracts/escrow`): Holds funds in escrow, supports milestone-based payments and reputation credential issuance. **Token custody is on-chain** via a Stellar Asset Contract (SAC) bound at admin setup; `deposit_funds` and `release_milestone` perform real `token::Client::transfer` calls.
 - **Planned escrow fee model**: Configurable protocol fee is now wired into `release_milestone` (`set_protocol_fee_bps`); fee retention into `AccumulatedProtocolFees` is implemented. A separate `withdraw_protocol_fees` entrypoint remains tracked in [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314).
 
-Reviewer-oriented notes live in [docs/escrow/README.md](docs/escrow/README.md), with storage-key details in [docs/escrow/state-persistence.md](docs/escrow/state-persistence.md), threat analysis in [docs/escrow/SECURITY.md](docs/escrow/SECURITY.md), and release authorization modes in [docs/escrow/authorization.md](docs/escrow/authorization.md).
+Reviewer-oriented notes live in [docs/escrow/README.md](docs/escrow/README.md), with storage-key details in [docs/escrow/state-persistence.md](docs/escrow/state-persistence.md), transient-entry expiry and eviction behavior in [docs/escrow/storage-ttl.md](docs/escrow/storage-ttl.md), threat analysis in [docs/escrow/SECURITY.md](docs/escrow/SECURITY.md), and release authorization modes in [docs/escrow/authorization.md](docs/escrow/authorization.md).
 
 ---
 

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -15,6 +15,7 @@ mod pause_controls;
 mod persistence;
 mod release_authorization;
 mod security;
+mod ttl_tests;
 
 // --- Shared constants ---
 

--- a/contracts/escrow/src/test/ttl_tests.rs
+++ b/contracts/escrow/src/test/ttl_tests.rs
@@ -6,7 +6,11 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{symbol_short, testutils::Ledger as _, Env, Symbol};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{storage::Temporary as _, Ledger as _},
+    Env, Symbol,
+};
 
 use crate::{
     approvals,
@@ -107,11 +111,22 @@ fn approval_evicted_after_expiry() {
         store_with_ttl(&env, &approval_key(), &99u32, PENDING_APPROVAL_TTL_LEDGERS);
     });
 
-    advance(&env, &id, PENDING_APPROVAL_TTL_LEDGERS + 1);
+    let expiry =
+        env.as_contract(&id, || compute_expiry(&env, PENDING_APPROVAL_TTL_LEDGERS));
+    env.ledger().with_mut(|li| li.sequence_number = expiry.saturating_add(1));
+    env.as_contract(&id, || {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+    });
 
     env.as_contract(&id, || {
         let val: Option<u32> = read_if_live(&env, &approval_key());
         assert!(val.is_none(), "entry must be evicted after TTL elapses");
+        assert!(
+            !has_transient(&env, &approval_key()),
+            "evicted entries must not be reported as transient"
+        );
     });
 }
 
@@ -186,7 +201,7 @@ fn extend_returns_true_and_entry_survives_past_original_expiry() {
             PENDING_APPROVAL_BUMP_THRESHOLD,
             PENDING_APPROVAL_TTL_LEDGERS,
         );
-        assert!(bumped, "must return true for a live entry");
+        assert!(bumped, "must return true for a live entry that is bumped");
     });
 
     advance(&env, &id, PENDING_APPROVAL_BUMP_THRESHOLD + 1);
@@ -196,6 +211,39 @@ fn extend_returns_true_and_entry_survives_past_original_expiry() {
         assert!(
             val.is_some(),
             "entry must survive past original expiry after bump"
+        );
+    });
+}
+
+#[test]
+fn extend_is_a_no_op_when_remaining_ttl_is_at_threshold() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        store_with_ttl(&env, &approval_key(), &1u32, PENDING_APPROVAL_TTL_LEDGERS);
+    });
+
+    advance(
+        &env,
+        &id,
+        PENDING_APPROVAL_TTL_LEDGERS - PENDING_APPROVAL_BUMP_THRESHOLD,
+    );
+
+    env.as_contract(&id, || {
+        let ttl_before = env.storage().temporary().get_ttl(&approval_key());
+        assert_eq!(ttl_before, PENDING_APPROVAL_BUMP_THRESHOLD);
+        assert!(
+            extend_if_below_threshold(
+                &env,
+                &approval_key(),
+                PENDING_APPROVAL_BUMP_THRESHOLD,
+                PENDING_APPROVAL_TTL_LEDGERS,
+            ),
+            "the key remains live even though its TTL should not be bumped"
+        );
+        assert_eq!(
+            env.storage().temporary().get_ttl(&approval_key()),
+            ttl_before,
+            "a TTL at the threshold must not be extended"
         );
     });
 }
@@ -237,8 +285,7 @@ fn remove_transient_clears_entry_immediately() {
 fn remove_transient_is_idempotent() {
     let (env, id) = setup();
     env.as_contract(&id, || {
-        store_with_ttl(&env, &approval_key(), &5u32, PENDING_APPROVAL_TTL_LEDGERS);
-        remove_transient(&env, &approval_key());
+        assert!(!has_transient(&env, &approval_key()));
         remove_transient(&env, &approval_key());
         assert!(!has_transient(&env, &approval_key()));
     });

--- a/contracts/escrow/src/test/ttl_tests.rs
+++ b/contracts/escrow/src/test/ttl_tests.rs
@@ -6,7 +6,11 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{symbol_short, testutils::Ledger as _, Env, Symbol};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{storage::Temporary as _, Ledger as _},
+    Env, Symbol,
+};
 
 use crate::{
     approvals,
@@ -34,7 +38,7 @@ fn setup() -> (Env, soroban_sdk::Address) {
 
 fn advance(env: &Env, contract_id: &soroban_sdk::Address, by: u32) {
     env.ledger()
-        .with_mut(|li| li.sequence_number = li.sequence_number.saturating_add(by));
+        .set_sequence_number(env.ledger().sequence().saturating_add(by));
     env.as_contract(contract_id, || {
         env.storage()
             .instance()
@@ -107,11 +111,21 @@ fn approval_evicted_after_expiry() {
         store_with_ttl(&env, &approval_key(), &99u32, PENDING_APPROVAL_TTL_LEDGERS);
     });
 
-    advance(&env, &id, PENDING_APPROVAL_TTL_LEDGERS + 1);
+    let expiry = env.as_contract(&id, || compute_expiry(&env, PENDING_APPROVAL_TTL_LEDGERS));
+    env.ledger().set_sequence_number(expiry.saturating_add(1));
+    env.as_contract(&id, || {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+    });
 
     env.as_contract(&id, || {
         let val: Option<u32> = read_if_live(&env, &approval_key());
         assert!(val.is_none(), "entry must be evicted after TTL elapses");
+        assert!(
+            !has_transient(&env, &approval_key()),
+            "evicted entries must not be reported as transient"
+        );
     });
 }
 
@@ -186,7 +200,7 @@ fn extend_returns_true_and_entry_survives_past_original_expiry() {
             PENDING_APPROVAL_BUMP_THRESHOLD,
             PENDING_APPROVAL_TTL_LEDGERS,
         );
-        assert!(bumped, "must return true for a live entry");
+        assert!(bumped, "must return true for a live entry that is bumped");
     });
 
     advance(&env, &id, PENDING_APPROVAL_BUMP_THRESHOLD + 1);
@@ -196,6 +210,39 @@ fn extend_returns_true_and_entry_survives_past_original_expiry() {
         assert!(
             val.is_some(),
             "entry must survive past original expiry after bump"
+        );
+    });
+}
+
+#[test]
+fn extend_is_a_no_op_when_remaining_ttl_is_at_threshold() {
+    let (env, id) = setup();
+    env.as_contract(&id, || {
+        store_with_ttl(&env, &approval_key(), &1u32, PENDING_APPROVAL_TTL_LEDGERS);
+    });
+
+    advance(
+        &env,
+        &id,
+        PENDING_APPROVAL_TTL_LEDGERS - PENDING_APPROVAL_BUMP_THRESHOLD,
+    );
+
+    env.as_contract(&id, || {
+        let ttl_before = env.storage().temporary().get_ttl(&approval_key());
+        assert_eq!(ttl_before, PENDING_APPROVAL_BUMP_THRESHOLD);
+        assert!(
+            extend_if_below_threshold(
+                &env,
+                &approval_key(),
+                PENDING_APPROVAL_BUMP_THRESHOLD,
+                PENDING_APPROVAL_TTL_LEDGERS,
+            ),
+            "the key remains live even though its TTL should not be bumped"
+        );
+        assert_eq!(
+            env.storage().temporary().get_ttl(&approval_key()),
+            ttl_before,
+            "a TTL at the threshold must not be extended"
         );
     });
 }
@@ -237,8 +284,7 @@ fn remove_transient_clears_entry_immediately() {
 fn remove_transient_is_idempotent() {
     let (env, id) = setup();
     env.as_contract(&id, || {
-        store_with_ttl(&env, &approval_key(), &5u32, PENDING_APPROVAL_TTL_LEDGERS);
-        remove_transient(&env, &approval_key());
+        assert!(!has_transient(&env, &approval_key()));
         remove_transient(&env, &approval_key());
         assert!(!has_transient(&env, &approval_key()));
     });

--- a/contracts/escrow/src/ttl.rs
+++ b/contracts/escrow/src/ttl.rs
@@ -79,6 +79,15 @@ where
     env.storage().temporary().get(key)
 }
 
+/// Extends a live transient entry only when its remaining TTL is below `threshold`.
+///
+/// Returns `false` when `key` is absent or has already been evicted. Returns
+/// `true` when the key is live; in that case Soroban performs the extension only
+/// when the remaining TTL is below `threshold` and otherwise leaves the TTL
+/// unchanged.
+///
+/// The boolean reports liveness, not whether Soroban changed the TTL. The host
+/// intentionally does not expose a production API for observing an entry's TTL.
 #[allow(dead_code)]
 pub fn extend_if_below_threshold<K>(env: &Env, key: &K, threshold: u32, extend_to: u32) -> bool
 where
@@ -92,6 +101,9 @@ where
     true
 }
 
+/// Removes a transient entry if it exists.
+///
+/// This operation is idempotent: removing an absent or evicted key is a no-op.
 #[allow(dead_code)]
 pub fn remove_transient<K>(env: &Env, key: &K)
 where
@@ -100,6 +112,10 @@ where
     env.storage().temporary().remove(key);
 }
 
+/// Returns whether a transient key is currently live in contract storage.
+///
+/// Expired temporary entries are auto-evicted by Soroban and therefore return
+/// `false`, just like keys that were never stored.
 #[allow(dead_code)]
 pub fn has_transient<K>(env: &Env, key: &K) -> bool
 where

--- a/docs/escrow/storage-ttl.md
+++ b/docs/escrow/storage-ttl.md
@@ -52,7 +52,7 @@ All transient reads and writes go through the helpers in `contracts/escrow/src/t
 | `compute_expiry(env, ttl)` | Returns `sequence + ttl` (saturating). |
 | `store_with_ttl(env, key, value, ttl)` | Writes to temporary storage and sets TTL. |
 | `read_if_live(env, key)` | Returns `Some(v)` if live, `None` if absent or evicted. |
-| `extend_if_below_threshold(env, key, threshold, extend_to)` | Bumps TTL; returns `false` if key absent. |
+| `extend_if_below_threshold(env, key, threshold, extend_to)` | Bumps TTL only below the threshold; returns `false` if key is absent or evicted. |
 | `remove_transient(env, key)` | Explicit removal before auto-eviction. |
 | `has_transient(env, key)` | Returns `true` if the key is currently live. |
 
@@ -84,8 +84,11 @@ environments produce identical expiry values. This is verified by
 
 - If remaining TTL is **below** the bump threshold, the entry's TTL is
   extended to the full policy value.
-- If the entry is already fresh, the call is a no-op (Soroban only extends,
-  never shrinks).
+- If the entry is already fresh, including when its remaining TTL equals the
+  threshold, the call is a no-op (Soroban only extends, never shrinks).
+- The helper's boolean reports whether the key was live. Soroban does not expose
+  the resulting TTL to production contracts, so the test suite uses the
+  test-only `get_ttl` API to verify whether an extension occurred.
 - If the entry is absent or already evicted, the helper returns `false` and
   performs no write.
 
@@ -118,6 +121,7 @@ auto-eviction.
 | `migration_evicted_after_expiry` | `read_if_live` returns `None` one ledger after migration TTL |
 | `extend_returns_false_for_absent_key` | `extend_if_below_threshold` returns `false` when key absent |
 | `extend_returns_true_and_entry_survives_past_original_expiry` | Bump keeps entry live past original expiry |
+| `extend_is_a_no_op_when_remaining_ttl_is_at_threshold` | Exact threshold does not extend a fresh entry |
 | `extend_migration_returns_false_for_absent_key` | Same absent-key check for migration threshold |
 | `remove_transient_clears_entry_immediately` | Entry absent after `remove_transient` |
 | `remove_transient_is_idempotent` | Second `remove_transient` does not panic |


### PR DESCRIPTION
close #724 



Changes include:
Enabled the direct TTL test module.
Added explicit eviction assertions for read_if_live and has_transient.
Verified exact-threshold TTL extension is a no-op using test-only TTL inspection.
Covered removal of an already-absent key.
Added /// helper documentation and updated README/TTL docs.