### PR TITLE
close #726:  Assert on-chain token balances for the cancel_contract client refund transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The escrow implementation follows a fail-closed state machine:
 - a Stellar Asset Contract (SAC) settlement token is admin-bound exactly once via `bind_settlement_token`; each subsequent `deposit_funds` and `release_milestone` calls `token::Client::transfer` and updates accounting atomically
 - deposits pull SAC tokens from the client BEFORE `funded_amount` is updated, so a failed transfer leaves accounting untouched
 - deposits cannot exceed the required escrow total
+- cancellation returns the full refundable SAC balance to the client while preserving funds held for other active contracts
 - releases pay the freelancer (less protocol fee) via SAC transfer BEFORE milestone state is updated, so a failed payout leaves state untouched
 - releases require a valid unreleased milestone, caller authorization via `caller.require_auth()`, and valid non-expired approvals matching the contract's `ReleaseAuthorization` mode
 - reputation is gated behind contract completion and is issued once per contract

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1430,7 +1430,9 @@ impl Escrow {
     /// The caller must be the stored client and must authorize the call. The
     /// contract must be in `Created` or `Funded` state, with no released
     /// balance, and the full remaining refundable balance is sent back to the
-    /// client before the contract is marked `Cancelled`.
+    /// client via the configured Stellar Asset Contract before the contract is
+    /// marked `Cancelled`. A zero-funded cancellation does not invoke a token
+    /// transfer and leaves unrelated contracts' escrowed token balances intact.
     ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode.

--- a/contracts/escrow/src/test/cancel_contract.rs
+++ b/contracts/escrow/src/test/cancel_contract.rs
@@ -1,6 +1,10 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env,
+};
 
 use crate::{
     ContractStatus, Error, Escrow, EscrowClient, ReleaseAuthorization,
@@ -26,7 +30,7 @@ fn setup_cancel_context(env: &Env) -> (EscrowClient<'_>, Address, Address, u32) 
     let token_address = env.register_stellar_asset_contract(token_admin);
     client.set_settlement_token(&token_address);
 
-    let token_client = soroban_sdk::token::StellarAssetClient::new(env, &token_address);
+    let token_client = StellarAssetClient::new(env, &token_address);
     token_client.mint(&client_addr, &10_000_0000000_i128);
 
     let milestones = vec![env, 100_i128, 200_i128, 300_i128];
@@ -41,18 +45,32 @@ fn setup_cancel_context(env: &Env) -> (EscrowClient<'_>, Address, Address, u32) 
     (client, client_addr, freelancer_addr, contract_id)
 }
 
+/// Returns the address that owns settlement-token custody for this escrow.
+fn escrow_address(env: &Env, client: &EscrowClient<'_>) -> Address {
+    env.as_contract(&client.address, || env.current_contract_address())
+}
+
 #[test]
 fn cancel_created_contract_marks_it_cancelled_without_refund() {
     let env = Env::default();
     let (client, client_addr, _, contract_id) = setup_cancel_context(&env);
+    let token_address = client.get_settlement_token();
+    let token_client = TokenClient::new(&env, &token_address);
+    let escrow_addr = escrow_address(&env, &client);
+    let client_balance_before = token_client.balance(&client_addr);
+    let escrow_balance_before = token_client.balance(&escrow_addr);
 
     assert!(client.cancel_contract(&contract_id, &client_addr));
 
     let contract = client.get_contract(&contract_id);
     assert_eq!(contract.status, ContractStatus::Cancelled);
     assert_eq!(contract.refunded_amount, 0);
+    assert_eq!(token_client.balance(&client_addr), client_balance_before);
+    assert_eq!(token_client.balance(&escrow_addr), escrow_balance_before);
 }
 
+/// Cancelling a funded contract transfers its full remaining SAC balance to the
+/// client and removes only that contract's funds from escrow custody.
 #[test]
 fn cancel_funded_contract_refunds_the_remaining_balance_to_the_client() {
     let env = Env::default();
@@ -63,15 +81,52 @@ fn cancel_funded_contract_refunds_the_remaining_balance_to_the_client() {
     assert_eq!(contract.status, ContractStatus::Funded);
 
     let token_address = client.get_settlement_token();
-    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
-    let balance_before = token_client.balance(&client_addr);
+    let token_client = TokenClient::new(&env, &token_address);
+    let escrow_addr = escrow_address(&env, &client);
+    let client_balance_before = token_client.balance(&client_addr);
+    let escrow_balance_before = token_client.balance(&escrow_addr);
+    assert_eq!(escrow_balance_before, 600_i128);
 
     assert!(client.cancel_contract(&contract_id, &client_addr));
 
     let contract = client.get_contract(&contract_id);
     assert_eq!(contract.status, ContractStatus::Cancelled);
     assert_eq!(contract.refunded_amount, 600_i128);
-    assert_eq!(token_client.balance(&client_addr), balance_before + 600_i128);
+    assert_eq!(token_client.balance(&client_addr), client_balance_before + 600_i128);
+    assert_eq!(token_client.balance(&escrow_addr), escrow_balance_before - 600_i128);
+}
+
+/// Cancelling one funded contract preserves SAC custody for other active
+/// contracts sharing the same escrow contract address.
+#[test]
+fn cancel_refund_leaves_other_contract_funds_in_escrow() {
+    let env = Env::default();
+    let (client, client_addr, freelancer_addr, first_contract_id) = setup_cancel_context(&env);
+    let second_contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 400_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    let token_address = client.get_settlement_token();
+    let token_client = TokenClient::new(&env, &token_address);
+    let escrow_addr = escrow_address(&env, &client);
+
+    assert!(client.deposit_funds(&first_contract_id, &client_addr, &600_i128));
+    assert!(client.deposit_funds(&second_contract_id, &client_addr, &400_i128));
+    let client_balance_before = token_client.balance(&client_addr);
+    assert_eq!(token_client.balance(&escrow_addr), 1_000_i128);
+
+    assert!(client.cancel_contract(&first_contract_id, &client_addr));
+
+    assert_eq!(token_client.balance(&client_addr), client_balance_before + 600_i128);
+    assert_eq!(
+        token_client.balance(&escrow_addr),
+        client.get_refundable_balance(&second_contract_id),
+        "escrow balance must contain only the remaining active contract funds"
+    );
+    assert_eq!(client.get_refundable_balance(&first_contract_id), 0);
 }
 
 #[test]

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -7,6 +7,7 @@ use crate::{Contract, ContractStatus, Escrow, EscrowClient, EscrowError, Release
 
 // --- Submodules ---
 mod approval_expiry;
+mod cancel_contract;
 mod client_migration;
 mod dispute;
 mod emergency_controls;

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -12,6 +12,7 @@ issues so integrators can distinguish live API from roadmap.
 - `contracts/escrow/src/release_milestone.rs`: inlined in `lib.rs`; transfers tokens from escrow to freelancer net of protocol fee.
 - `contracts/escrow/src/refund.rs`: `refund_unreleased_milestones` lifecycle entrypoint.
 - `contracts/escrow/src/test/sac_custody.rs`: SAC custody tests for `bind_settlement_token`, `deposit_funds` (SAC path), and `release_milestone` (SAC path).
+- `contracts/escrow/src/test/cancel_contract.rs`: cancellation tests, including SAC client-refund and shared-escrow balance assertions.
 
 ## Implemented API Surface
 

--- a/docs/escrow/sac-custody.md
+++ b/docs/escrow/sac-custody.md
@@ -111,6 +111,11 @@ Escrow contract address ──[SAC transfer, all unreleased]──► Client wal
 
 Transitions status to `Cancelled`.
 
+Cancellation tests assert the actual SAC balances before and after the transfer:
+the client receives the full refundable amount, and the shared escrow address
+retains exactly the funds that remain escrowed for other active contracts. A
+zero-funded cancellation performs no token transfer.
+
 ---
 
 ## Protocol-Fee Withdrawal (`withdraw_protocol_fees`)


### PR DESCRIPTION
close #726 

I added direct SAC balance assertions around cancellation, including a multi-contract residual-balance case and an unfunded no-transfer case. I inspect the existing cancel flow and token test conventions, then branch, implement, validate what this environment supports, commit, and push.