### PR TITLE
close #727: Cover pending reputation credit accrual and drain across multiple completed contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The escrow implementation follows a fail-closed state machine:
 - a Stellar Asset Contract (SAC) settlement token is admin-bound exactly once via `bind_settlement_token`; each subsequent `deposit_funds` and `release_milestone` calls `token::Client::transfer` and updates accounting atomically
 - deposits pull SAC tokens from the client BEFORE `funded_amount` is updated, so a failed transfer leaves accounting untouched
 - deposits cannot exceed the required escrow total
+- cancellation returns the full refundable SAC balance to the client while preserving funds held for other active contracts
 - releases pay the freelancer (less protocol fee) via SAC transfer BEFORE milestone state is updated, so a failed payout leaves state untouched
 - releases require a valid unreleased milestone, caller authorization via `caller.require_auth()`, and valid non-expired approvals matching the contract's `ReleaseAuthorization` mode
 - reputation is gated behind contract completion and is issued once per contract

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The escrow implementation follows a fail-closed state machine:
 - cancellation returns the full refundable SAC balance to the client while preserving funds held for other active contracts
 - releases pay the freelancer (less protocol fee) via SAC transfer BEFORE milestone state is updated, so a failed payout leaves state untouched
 - releases require a valid unreleased milestone, caller authorization via `caller.require_auth()`, and valid non-expired approvals matching the contract's `ReleaseAuthorization` mode
-- reputation is gated behind contract completion and is issued once per contract
+- reputation is gated behind contract completion and is issued once per contract; each completed escrow accrues one pending credit for its freelancer, while fully refunded escrows accrue none. Issuing reputation consumes one credit and updates the freelancer's completed-contract count
 - finalization records immutable close metadata for completed or disputed contracts and blocks later contract-specific mutations
 - one-time admin initialization protects pause and emergency controls; two-step admin transfer is planned in [#318](https://github.com/Talenttrust/Talenttrust-Contracts/issues/318)
 - pause and emergency controls block all state-changing escrow operations while active

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1430,7 +1430,9 @@ impl Escrow {
     /// The caller must be the stored client and must authorize the call. The
     /// contract must be in `Created` or `Funded` state, with no released
     /// balance, and the full remaining refundable balance is sent back to the
-    /// client before the contract is marked `Cancelled`.
+    /// client via the configured Stellar Asset Contract before the contract is
+    /// marked `Cancelled`. A zero-funded cancellation does not invoke a token
+    /// transfer and leaves unrelated contracts' escrowed token balances intact.
     ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -493,7 +493,9 @@ impl Escrow {
     ///
     /// This is called exactly once when a contract successfully transitions to
     /// the `Completed` state, either through the final milestone release
-    /// or via dispute resolution. It enables the client to later issue reputation.
+    /// or via dispute resolution. Credits accumulate independently for each
+    /// completed contract and are consumed one at a time by `issue_reputation`.
+    /// A `Refunded` contract never calls this helper and therefore earns no credit.
     fn grant_pending_reputation_credit(env: &Env, freelancer: &Address) {
         let pending_key = DataKey::PendingReputationCredits(freelancer.clone());
         let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
@@ -1661,6 +1663,11 @@ impl Escrow {
             .and_then(|scaled| scaled.checked_div(rep.completed_contracts))
     }
 
+    /// Returns the number of completed contracts awaiting a reputation rating.
+    ///
+    /// This value increments once per completed contract and decrements once
+    /// per successful `issue_reputation` call. Refunded contracts do not accrue
+    /// pending reputation credits.
     pub fn get_pending_reputation_credits(env: Env, address: Address) -> i128 {
         env.storage()
             .persistent()

--- a/contracts/escrow/src/test/cancel_contract.rs
+++ b/contracts/escrow/src/test/cancel_contract.rs
@@ -1,6 +1,10 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env,
+};
 
 use crate::{
     ContractStatus, Error, Escrow, EscrowClient, ReleaseAuthorization,
@@ -26,7 +30,7 @@ fn setup_cancel_context(env: &Env) -> (EscrowClient<'_>, Address, Address, u32) 
     let token_address = env.register_stellar_asset_contract(token_admin);
     client.set_settlement_token(&token_address);
 
-    let token_client = soroban_sdk::token::StellarAssetClient::new(env, &token_address);
+    let token_client = StellarAssetClient::new(env, &token_address);
     token_client.mint(&client_addr, &10_000_0000000_i128);
 
     let milestones = vec![env, 100_i128, 200_i128, 300_i128];
@@ -41,18 +45,32 @@ fn setup_cancel_context(env: &Env) -> (EscrowClient<'_>, Address, Address, u32) 
     (client, client_addr, freelancer_addr, contract_id)
 }
 
+/// Returns the address that owns settlement-token custody for this escrow.
+fn escrow_address(env: &Env, client: &EscrowClient<'_>) -> Address {
+    env.as_contract(&client.address, || env.current_contract_address())
+}
+
 #[test]
 fn cancel_created_contract_marks_it_cancelled_without_refund() {
     let env = Env::default();
     let (client, client_addr, _, contract_id) = setup_cancel_context(&env);
+    let token_address = client.get_settlement_token();
+    let token_client = TokenClient::new(&env, &token_address);
+    let escrow_addr = escrow_address(&env, &client);
+    let client_balance_before = token_client.balance(&client_addr);
+    let escrow_balance_before = token_client.balance(&escrow_addr);
 
     assert!(client.cancel_contract(&contract_id, &client_addr));
 
     let contract = client.get_contract(&contract_id);
     assert_eq!(contract.status, ContractStatus::Cancelled);
     assert_eq!(contract.refunded_amount, 0);
+    assert_eq!(token_client.balance(&client_addr), client_balance_before);
+    assert_eq!(token_client.balance(&escrow_addr), escrow_balance_before);
 }
 
+/// Cancelling a funded contract transfers its full remaining SAC balance to the
+/// client and removes only that contract's funds from escrow custody.
 #[test]
 fn cancel_funded_contract_refunds_the_remaining_balance_to_the_client() {
     let env = Env::default();
@@ -63,15 +81,52 @@ fn cancel_funded_contract_refunds_the_remaining_balance_to_the_client() {
     assert_eq!(contract.status, ContractStatus::Funded);
 
     let token_address = client.get_settlement_token();
-    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
-    let balance_before = token_client.balance(&client_addr);
+    let token_client = TokenClient::new(&env, &token_address);
+    let escrow_addr = escrow_address(&env, &client);
+    let client_balance_before = token_client.balance(&client_addr);
+    let escrow_balance_before = token_client.balance(&escrow_addr);
+    assert_eq!(escrow_balance_before, 600_i128);
 
     assert!(client.cancel_contract(&contract_id, &client_addr));
 
     let contract = client.get_contract(&contract_id);
     assert_eq!(contract.status, ContractStatus::Cancelled);
     assert_eq!(contract.refunded_amount, 600_i128);
-    assert_eq!(token_client.balance(&client_addr), balance_before + 600_i128);
+    assert_eq!(token_client.balance(&client_addr), client_balance_before + 600_i128);
+    assert_eq!(token_client.balance(&escrow_addr), escrow_balance_before - 600_i128);
+}
+
+/// Cancelling one funded contract preserves SAC custody for other active
+/// contracts sharing the same escrow contract address.
+#[test]
+fn cancel_refund_leaves_other_contract_funds_in_escrow() {
+    let env = Env::default();
+    let (client, client_addr, freelancer_addr, first_contract_id) = setup_cancel_context(&env);
+    let second_contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 400_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    let token_address = client.get_settlement_token();
+    let token_client = TokenClient::new(&env, &token_address);
+    let escrow_addr = escrow_address(&env, &client);
+
+    assert!(client.deposit_funds(&first_contract_id, &client_addr, &600_i128));
+    assert!(client.deposit_funds(&second_contract_id, &client_addr, &400_i128));
+    let client_balance_before = token_client.balance(&client_addr);
+    assert_eq!(token_client.balance(&escrow_addr), 1_000_i128);
+
+    assert!(client.cancel_contract(&first_contract_id, &client_addr));
+
+    assert_eq!(token_client.balance(&client_addr), client_balance_before + 600_i128);
+    assert_eq!(
+        token_client.balance(&escrow_addr),
+        client.get_refundable_balance(&second_contract_id),
+        "escrow balance must contain only the remaining active contract funds"
+    );
+    assert_eq!(client.get_refundable_balance(&first_contract_id), 0);
 }
 
 #[test]

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -7,6 +7,7 @@ use crate::{Contract, ContractStatus, Escrow, EscrowClient, EscrowError, Release
 
 // --- Submodules ---
 mod approval_expiry;
+mod cancel_contract;
 mod client_migration;
 mod dispute;
 mod emergency_controls;

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -15,6 +15,7 @@ mod mainnet_readiness;
 mod pause_controls;
 mod persistence;
 mod release_authorization;
+mod reputation;
 mod security;
 
 // --- Shared constants ---

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -1,9 +1,104 @@
 use super::{complete_contract, create_contract, register_client};
-use crate::{Contract, DataKey, EscrowError};
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
-
+use crate::{Contract, ContractStatus, DataKey, EscrowError, ReleaseAuthorization};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 fn valid_comment(env: &Env) -> String {
     String::from_str(env, "Great job!")
+}
+
+/// Completes a new escrow for the supplied participants so multiple contracts
+/// can accrue reputation credits to the same freelancer.
+fn complete_contract_for(
+    env: &Env,
+    client: &crate::EscrowClient<'_>,
+    client_addr: &Address,
+    freelancer_addr: &Address,
+) -> u32 {
+    let contract_id = client.create_contract(
+        client_addr,
+        freelancer_addr,
+        &None,
+        &super::default_milestones(env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+    let total = super::total_milestone_amount();
+    assert!(client.deposit_funds(&contract_id, client_addr, &total));
+    for milestone_index in 0..3 {
+        assert!(client.approve_milestone_release(&contract_id, client_addr, &milestone_index));
+        assert!(client.release_milestone(&contract_id, client_addr, &milestone_index));
+    }
+    assert_eq!(client.get_contract(&contract_id).status, ContractStatus::Completed);
+    contract_id
+}
+
+#[test]
+fn pending_reputation_credits_accumulate_and_drain_across_completed_contracts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    let freelancer = Address::generate(&env);
+    let first_client = Address::generate(&env);
+    let second_client = Address::generate(&env);
+    let third_client = Address::generate(&env);
+
+    let first_contract = complete_contract_for(&env, &client, &first_client, &freelancer);
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 1);
+
+    let second_contract = complete_contract_for(&env, &client, &second_client, &freelancer);
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 2);
+
+    let third_contract = complete_contract_for(&env, &client, &third_client, &freelancer);
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 3);
+
+    // A fully refunded contract is terminal but never earns a reputation credit.
+    let refunded_client = Address::generate(&env);
+    let refunded_contract = client.create_contract(
+        &refunded_client,
+        &freelancer,
+        &None,
+        &super::default_milestones(&env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(client.deposit_funds(
+        &refunded_contract,
+        &refunded_client,
+        &super::total_milestone_amount(),
+    ));
+    assert_eq!(
+        client.refund_unreleased_milestones(&refunded_contract, &vec![&env, 0_u32, 1, 2]),
+        super::total_milestone_amount()
+    );
+    assert_eq!(client.get_contract(&refunded_contract).status, ContractStatus::Refunded);
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 3);
+
+    assert!(client.issue_reputation(&first_contract, &first_client, &5, &valid_comment(&env)));
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 2);
+    assert_eq!(
+        client.get_reputation(&freelancer).unwrap().completed_contracts,
+        1
+    );
+
+    assert!(client.issue_reputation(&second_contract, &second_client, &4, &valid_comment(&env)));
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 1);
+    assert_eq!(
+        client.get_reputation(&freelancer).unwrap().completed_contracts,
+        2
+    );
+
+    assert!(client.issue_reputation(&third_contract, &third_client, &3, &valid_comment(&env)));
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 0);
+    assert_eq!(
+        client.get_reputation(&freelancer).unwrap().completed_contracts,
+        3
+    );
+
+    let duplicate = client.try_issue_reputation(
+        &first_contract,
+        &first_client,
+        &1,
+        &valid_comment(&env),
+    );
+    super::assert_contract_error(duplicate, EscrowError::ReputationAlreadyIssued);
+    assert_eq!(client.get_pending_reputation_credits(&freelancer), 0);
 }
 
 #[test]
@@ -147,7 +242,7 @@ fn get_average_rating_single_rating_returns_scaled_value() {
     let client = register_client(&env);
     let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    client.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &4);
+    client.issue_reputation(&contract_id, &client_addr, &4, &valid_comment(&env));
 
     // 4 * 10_000 / 1 = 40_000
     assert_eq!(client.get_average_rating(&freelancer_addr), Some(40_000));
@@ -161,7 +256,7 @@ fn get_average_rating_multiple_ratings_returns_correct_scaled_average() {
 
     // First contract: rating 3
     let (client_addr1, freelancer_addr, contract_id1) = complete_contract(&env, &client);
-    client.issue_reputation(&contract_id1, &client_addr1, &freelancer_addr, &3);
+    client.issue_reputation(&contract_id1, &client_addr1, &3, &valid_comment(&env));
 
     // Second contract: same freelancer, rating 5
     let client_addr2 = Address::generate(&env);
@@ -181,7 +276,7 @@ fn get_average_rating_multiple_ratings_returns_correct_scaled_average() {
     client.release_milestone(&contract_id2, &client_addr2, &1);
     client.approve_milestone_release(&contract_id2, &client_addr2, &2);
     client.release_milestone(&contract_id2, &client_addr2, &2);
-    client.issue_reputation(&contract_id2, &client_addr2, &freelancer_addr, &5);
+    client.issue_reputation(&contract_id2, &client_addr2, &5, &valid_comment(&env));
 
     // total_rating=8, completed_contracts=2 → 8 * 10_000 / 2 = 40_000
     assert_eq!(client.get_average_rating(&freelancer_addr), Some(40_000));
@@ -195,7 +290,7 @@ fn get_average_rating_fractional_average_is_preserved() {
 
     // First contract: rating 1
     let (client_addr1, freelancer_addr, contract_id1) = complete_contract(&env, &client);
-    client.issue_reputation(&contract_id1, &client_addr1, &freelancer_addr, &1);
+    client.issue_reputation(&contract_id1, &client_addr1, &1, &valid_comment(&env));
 
     // Second contract: rating 2
     let client_addr2 = Address::generate(&env);
@@ -215,7 +310,7 @@ fn get_average_rating_fractional_average_is_preserved() {
     client.release_milestone(&contract_id2, &client_addr2, &1);
     client.approve_milestone_release(&contract_id2, &client_addr2, &2);
     client.release_milestone(&contract_id2, &client_addr2, &2);
-    client.issue_reputation(&contract_id2, &client_addr2, &freelancer_addr, &2);
+    client.issue_reputation(&contract_id2, &client_addr2, &2, &valid_comment(&env));
 
     // total_rating=3, completed_contracts=2 → 3 * 10_000 / 2 = 15_000
     assert_eq!(client.get_average_rating(&freelancer_addr), Some(15_000));

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -22,7 +22,7 @@ Lifecycle and reputation:
 - `deposit_funds(contract_id, amount) -> bool`
 - `submit_work_evidence(contract_id, caller, milestone_index, evidence) -> bool`
 - `release_milestone(contract_id, milestone_index) -> bool`
-- `issue_reputation(contract_id, caller, freelancer, rating) -> bool`
+- `issue_reputation(contract_id, caller, rating, comment) -> bool`
 - `cancel_contract(contract_id, caller) -> bool`
 - `finalize_contract(contract_id, finalizer) -> bool`
 
@@ -40,7 +40,7 @@ Read-only queries:
 - `get_finalization_record(contract_id) -> Option<FinalizationRecord>`
 - `get_reputation(freelancer) -> Option<ReputationRecord>`
 - `get_average_rating(freelancer) -> Option<i128>` — scaled average (see [Average Rating](#average-rating))
-- `get_pending_reputation_credits(freelancer) -> u32`
+- `get_pending_reputation_credits(freelancer) -> i128`
 - `get_admin() -> Option<Address>`
 - `get_settlement_token() -> Option<Address>`
 - `is_paused() -> bool`

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -12,6 +12,7 @@ issues so integrators can distinguish live API from roadmap.
 - `contracts/escrow/src/release_milestone.rs`: inlined in `lib.rs`; transfers tokens from escrow to freelancer net of protocol fee.
 - `contracts/escrow/src/refund.rs`: `refund_unreleased_milestones` lifecycle entrypoint.
 - `contracts/escrow/src/test/sac_custody.rs`: SAC custody tests for `bind_settlement_token`, `deposit_funds` (SAC path), and `release_milestone` (SAC path).
+- `contracts/escrow/src/test/cancel_contract.rs`: cancellation tests, including SAC client-refund and shared-escrow balance assertions.
 
 ## Implemented API Surface
 

--- a/docs/escrow/sac-custody.md
+++ b/docs/escrow/sac-custody.md
@@ -111,6 +111,11 @@ Escrow contract address ──[SAC transfer, all unreleased]──► Client wal
 
 Transitions status to `Cancelled`.
 
+Cancellation tests assert the actual SAC balances before and after the transfer:
+the client receives the full refundable amount, and the shared escrow address
+retains exactly the funds that remain escrowed for other active contracts. A
+zero-funded cancellation performs no token transfer.
+
 ---
 
 ## Protocol-Fee Withdrawal (`withdraw_protocol_fees`)


### PR DESCRIPTION
close #727 

Implemented and pushed.
Branch: test/contracts-pending-reputation-credits
Commit: 387a1e4 test(reputation): cover pending credit accrual and drain across contracts
PR: https://github.com/Primex-hub/Talenttrust-Contracts/pull/new/test/contracts-pending-reputation-credits
Coverage adds three-contract accrual/drain, refunded non-accrual, reputation count checks, and duplicate issuance balance protection. Documentation and Rust /// comments updated.