### PR TITLE
test: add resolution_payouts split-math coverage for dispute.rs

### DIFF
--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -255,31 +255,42 @@ fn resolution_payouts_rejects_corrupted_accounting_state() {
 #[test]
 fn resolution_payouts_conserves_available_balance() {
     let env = make_env();
-    let available = 12345_i128;
+    let balances = &[0, 1, 2, 5, 10, 33, 99, 100, 101, 1000, 12345, 1000000];
 
-    // FullRefund
-    let c = payout_contract(&env, available, 0, 0);
-    let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::FullRefund).unwrap();
-    assert_eq!(client + freelancer, available);
+    for &available in balances {
+        let c = payout_contract(&env, available, 0, 0);
 
-    // FullPayout
-    let c = payout_contract(&env, available, 0, 0);
-    let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::FullPayout).unwrap();
-    assert_eq!(client + freelancer, available);
+        // FullRefund
+        let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::FullRefund).unwrap();
+        assert_eq!(client + freelancer, available);
+        assert_eq!(client, available);
+        assert_eq!(freelancer, 0);
 
-    // PartialRefund
-    let c = payout_contract(&env, available, 0, 0);
-    let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::PartialRefund).unwrap();
-    assert_eq!(client + freelancer, available);
+        // FullPayout
+        let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::FullPayout).unwrap();
+        assert_eq!(client + freelancer, available);
+        assert_eq!(client, 0);
+        assert_eq!(freelancer, available);
 
-    // Split (exact)
-    let c = payout_contract(&env, available, 0, 0);
-    let split = DisputeSplit {
-        client_amount: 5000,
-        freelancer_amount: available - 5000,
-    };
-    let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::Split(split)).unwrap();
-    assert_eq!(client + freelancer, available);
+        // PartialRefund
+        let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::PartialRefund).unwrap();
+        assert_eq!(client + freelancer, available);
+        let expected_freelancer = (available * 30) / 100;
+        assert_eq!(freelancer, expected_freelancer);
+        assert_eq!(client, available - expected_freelancer);
+
+        // Split (exact)
+        let split_client = available / 2;
+        let split_freelancer = available - split_client;
+        let split = DisputeSplit {
+            client_amount: split_client,
+            freelancer_amount: split_freelancer,
+        };
+        let (client, freelancer) = resolution_payouts(&c, &DisputeResolution::Split(split)).unwrap();
+        assert_eq!(client + freelancer, available);
+        assert_eq!(client, split_client);
+        assert_eq!(freelancer, split_freelancer);
+    }
 }
 
 /// final_status returns Refunded only when the full deposit has been refunded.


### PR DESCRIPTION
Resolves #705

### Description
This PR adds comprehensive unit test coverage for the dispute `resolution_payouts` split-math calculations in `contracts/escrow/src/dispute.rs`.

Specifically, it updates `resolution_payouts_conserves_available_balance` to test each `DisputeResolution` variant against a range of available balances (`[0, 1, 2, 5, 10, 33, 99, 100, 101, 1000, 12345, 1000000]`), verifying that:
- Payouts always sum exactly to the available balance.
- Payout amounts match the expected split/rounding math:
  - `FullRefund` (100% to client)
  - `FullPayout` (100% to freelancer)
  - `PartialRefund` (70/30 split with floor division)
  - `Split` (exact client/freelancer split halves)

Additionally, the test suite verifies edge cases such as zero available balance, odd amount rounding truncation, split rejection for mismatching/negative values, and the accounting-invariant guardrails.

### Verification Plan
- Built the escrow contract targeting WebAssembly successfully:
  ```bash
  cargo build --target wasm32-unknown-unknown