### PR TITLE
docs(escrow): mark refund as implemented in custody lifecycle table

### DIFF
--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -304,7 +304,7 @@ to the contract's accounting counters is paired with the matching SAC
 | Token binding (admin, single-use) | `bind_settlement_token(sac)` | `—` | `DataKey::SettlementToken = sac` |
 | Funding | `deposit_funds(id, client, amount)` | `transfer(client, escrow, amount)` | `contract.funded_amount += amount` |
 | Release | `release_milestone(id, caller, idx)` | `transfer(escrow, freelancer, milestone.amount - fee)` | `milestone.released = true`, `contract.released_amount += milestone.amount`, `DataKey::AccumulatedProtocolFees += fee` |
-| Refund (planned) | `refund_unreleased_milestones(id, indices)` | `transfer(escrow, client, sum)` | `milestone.refunded = true`, `contract.refunded_amount += sum` |
+| Refund | `refund_unreleased_milestones(id, indices)` | `transfer(escrow, client, sum)` | `milestone.refunded = true`, `contract.refunded_amount += sum` |
 
 The pause/emergency gate, fail-closed validation, and TTL bumps from the
 existing lifecycle are preserved unchanged on each path.


### PR DESCRIPTION
## Summary
This one-line change removes the stale tag.

## Why

- Implemented in `contracts/escrow/src/refund.rs`.
- Documented as a live entrypoint in `docs/escrow/sac-custody.md`.
- Covered by the SAC custody / cancellation balance-assertion tests.

The guide's own intro states its purpose is to "distinguish live API from
roadmap," so the `(planned)` label contradicted the document's intent.

Docs-only change — no code or behavior is affected.

Closes #679