### PR TITLE
Refactor/contracts contract bounds type

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The supported deployed interface is documented in the [Escrow ABI reference](doc
 | `finalize_contract`        | **Implemented** | Freezes contract mutable updates                                                                  |
 | `cancel_contract`          | **Implemented** | Early termination contract transitions                                                            |
 | `issue_reputation`         | **Implemented** | Milestone rating metrics for completed contracts                                                  |
+| `get_bounds`               | **Implemented** | Read protocol compile-time limits (max milestones, amounts, fee bps) via `ContractBounds` type   |
 | Emergency Circuit Breakers | **Implemented** | Public administrative pause and emergency flags                                                   |
 | Protocol Fee Accumulation  | **Implemented** | Logic built directly into milestone releases                                                      |
 | Protocol Fee Withdrawal    | **Planned**     | Entrypoints tracked in [#314](https://github.com/Talenttrust/Talenttrust-Contracts/issues/314)    |

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -76,10 +76,10 @@ pub use ttl::{ADMIN_ROTATION_MIN_DELAY_LEDGERS, PENDING_MIGRATION_TTL_LEDGERS};
 // `DisputeResolution` and `DisputeSplit` are defined once in `types.rs` and
 // re-exported here; `dispute.rs` uses them via `crate::DisputeResolution`.
 pub use types::{
-    Contract, ContractStatus, ContractSummary, DataKey, DepositMode, DisputeResolution,
-    DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals, MilestoneSummary,
-    PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation, SplitAmounts,
-    CONTRACT_SUMMARY_SCHEMA_VERSION,
+    Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
+    DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
+    MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
+    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -388,21 +388,31 @@ impl Escrow {
         env.storage().persistent().get(&DataKey::Admin)
     }
 
-    /// Returns the current hard-coded bounds used by validation paths.
-    pub fn get_bounds(env: Env) -> ContractSummary {
-        ContractSummary {
-            schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,
-            client: env.current_contract_address(),
-            freelancer: env.current_contract_address(),
-            arbiter: None,
-            status: ContractStatus::Created,
-            reputation_issued: false,
-            total_amount: MAX_TOTAL_ESCROW_STROOPS,
-            funded_amount: MAX_MILESTONES as i128,
-            released_amount: 0,
-            refundable_balance: 0,
-            released_milestone_count: 0,
-            milestones: Vec::new(&env),
+    /// Returns the protocol-wide hard-coded bounds used by validation paths.
+    ///
+    /// Callers and off-chain indexers should query this endpoint to discover
+    /// the limits enforced by `create_contract` without relying on hard-coded
+    /// constants:
+    ///
+    /// - `max_milestones`: maximum number of milestones per contract.
+    /// - `max_single_milestone_stroops`: maximum amount for any single milestone.
+    /// - `max_total_escrow_stroops`: maximum sum of all milestone amounts.
+    /// - `max_fee_bps`: protocol fee ceiling in basis points (10 000 = 100 %).
+    ///
+    /// These are compile-time constants — the return value never changes
+    /// between calls on the same contract binary. The function is read-only
+    /// and requires no authorization.
+    ///
+    /// # Returns
+    /// A [`ContractBounds`] value containing only limit fields. Unlike
+    /// [`get_contract_summary`], this type carries no per-contract participant
+    /// or accounting data and its schema version tracks the limits API only.
+    pub fn get_bounds(_env: Env) -> ContractBounds {
+        ContractBounds {
+            max_milestones: MAX_MILESTONES,
+            max_single_milestone_stroops: MAX_SINGLE_AMOUNT_STROOPS,
+            max_total_escrow_stroops: MAX_TOTAL_ESCROW_STROOPS,
+            max_fee_bps: 10_000,
         }
     }
 

--- a/contracts/escrow/src/test/create_contract_bounds.rs
+++ b/contracts/escrow/src/test/create_contract_bounds.rs
@@ -1,22 +1,40 @@
-// Tests for every input-validation guard in `create_contract`.
+// Tests for `get_bounds` (ContractBounds) and every input-validation guard in
+// `create_contract`.
 //
-// Guards (in execution order):
-//   1. client == freelancer              → InvalidParticipant
-//   2. milestone_amounts.is_empty()      → EmptyMilestones
-//   3. len > MAX_MILESTONES (10)         → TooManyMilestones
-//   4. len == MAX_MILESTONES             → succeeds
-//   5. any amount <= 0                   → InvalidMilestoneAmount
-//   6. safe_add_amounts overflow         → PotentialOverflow
-//   7. total > MAX_TOTAL_ESCROW_STROOPS  → InvalidMilestoneAmount
+// ── get_bounds contract ──────────────────────────────────────────────────────
+//   1. Returns ContractBounds (not ContractSummary)
+//   2. max_milestones  == MAX_MILESTONES
+//   3. max_single_milestone_stroops == MAX_SINGLE_AMOUNT_STROOPS
+//   4. max_total_escrow_stroops     == MAX_TOTAL_ESCROW_STROOPS
+//   5. max_fee_bps                  == 10_000 (100 %)
+//   6. Idempotent — two calls return identical values
+//   7. No auth required (works before initialize)
+//   8. Consistency: max_single == max_total (current policy)
+//
+// ── create_contract guards (in execution order) ─────────────────────────────
+//   G1. client == freelancer                   → InvalidParticipant
+//   G2. milestone_amounts.is_empty()           → EmptyMilestones
+//   G3. len > MAX_MILESTONES (10)              → TooManyMilestones
+//   G4. len == MAX_MILESTONES                  → succeeds
+//   G5. any amount <= 0 (zero)                 → InvalidMilestoneAmount
+//   G6. any amount <= 0 (negative)             → InvalidMilestoneAmount
+//   G7. safe_add_amounts overflow              → PotentialOverflow
+//   G8. total > MAX_TOTAL_ESCROW_STROOPS       → InvalidMilestoneAmount
+//   G9. total == MAX_TOTAL_ESCROW_STROOPS      → succeeds
+//   G10. count-guard fires before amount-guard → TooManyMilestones
+
+#![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
 
 use crate::{
-    Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_MILESTONES, MAX_TOTAL_ESCROW_STROOPS,
+    ContractBounds, Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_MILESTONES,
+    MAX_SINGLE_AMOUNT_STROOPS, MAX_TOTAL_ESCROW_STROOPS,
 };
 
-// Returns (env, contract_address). Each test creates EscrowClient locally so
-// the borrow of `env` stays in the same scope — same pattern as pause_controls.
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Returns `(env, contract_address)` with all auths mocked.
 fn setup() -> (Env, Address) {
     let env = Env::default();
     env.mock_all_auths();
@@ -24,6 +42,7 @@ fn setup() -> (Env, Address) {
     (env, contract_id)
 }
 
+/// Assert that a `try_create_contract` result carries the expected EscrowError.
 fn assert_err(
     result: Result<
         Result<u32, soroban_sdk::ConversionError>,
@@ -40,7 +59,232 @@ fn assert_err(
     }
 }
 
-// guard 1 ─────────────────────────────────────────────────────────────────────
+// ── get_bounds: ContractBounds shape and values ───────────────────────────────
+
+/// `get_bounds` must return a `ContractBounds` — not a `ContractSummary`.
+/// The Soroban generated client encodes the return type so this test
+/// confirms that `get_bounds()` is ABI-compatible with `ContractBounds`.
+#[test]
+fn get_bounds_returns_contract_bounds_type() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds: ContractBounds = client.get_bounds();
+    // If the above compiles and runs without a host error, the return type is correct.
+    let _ = bounds;
+}
+
+/// `max_milestones` must equal the compile-time `MAX_MILESTONES` constant.
+#[test]
+fn get_bounds_max_milestones_equals_constant() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert_eq!(
+        bounds.max_milestones, MAX_MILESTONES,
+        "max_milestones must equal MAX_MILESTONES"
+    );
+}
+
+/// `max_single_milestone_stroops` must equal `MAX_SINGLE_AMOUNT_STROOPS`.
+#[test]
+fn get_bounds_max_single_milestone_stroops_equals_constant() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert_eq!(
+        bounds.max_single_milestone_stroops, MAX_SINGLE_AMOUNT_STROOPS,
+        "max_single_milestone_stroops must equal MAX_SINGLE_AMOUNT_STROOPS"
+    );
+}
+
+/// `max_total_escrow_stroops` must equal `MAX_TOTAL_ESCROW_STROOPS`.
+#[test]
+fn get_bounds_max_total_escrow_stroops_equals_constant() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert_eq!(
+        bounds.max_total_escrow_stroops, MAX_TOTAL_ESCROW_STROOPS,
+        "max_total_escrow_stroops must equal MAX_TOTAL_ESCROW_STROOPS"
+    );
+}
+
+/// `max_fee_bps` must be 10_000 (100%).
+#[test]
+fn get_bounds_max_fee_bps_is_10000() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert_eq!(
+        bounds.max_fee_bps, 10_000,
+        "max_fee_bps must be 10_000 (100 %)"
+    );
+}
+
+/// `get_bounds` is idempotent — two consecutive calls return identical values.
+#[test]
+fn get_bounds_is_idempotent() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let first = client.get_bounds();
+    let second = client.get_bounds();
+    assert_eq!(first, second, "get_bounds must be idempotent");
+}
+
+/// `get_bounds` requires no authorization — it must succeed even before
+/// `initialize` has been called.
+#[test]
+fn get_bounds_requires_no_auth_and_works_before_initialize() {
+    let env = Env::default();
+    // Deliberately do NOT call mock_all_auths.
+    let cid = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &cid);
+    // Must not panic.
+    let bounds = client.get_bounds();
+    assert_eq!(bounds.max_milestones, MAX_MILESTONES);
+}
+
+/// Under current policy, `max_single_milestone_stroops == max_total_escrow_stroops`.
+/// This test makes the invariant explicit so it becomes a compilation break-point
+/// if the policy ever diverges.
+#[test]
+fn get_bounds_single_equals_total_under_current_policy() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert_eq!(
+        bounds.max_single_milestone_stroops, bounds.max_total_escrow_stroops,
+        "single and total caps must be equal under current policy"
+    );
+}
+
+/// All bounds fields must be strictly positive — no field should be zero or
+/// negative, which would be a nonsensical protocol configuration.
+#[test]
+fn get_bounds_all_fields_are_positive() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert!(bounds.max_milestones > 0, "max_milestones must be > 0");
+    assert!(
+        bounds.max_single_milestone_stroops > 0,
+        "max_single_milestone_stroops must be > 0"
+    );
+    assert!(
+        bounds.max_total_escrow_stroops > 0,
+        "max_total_escrow_stroops must be > 0"
+    );
+    assert!(bounds.max_fee_bps > 0, "max_fee_bps must be > 0");
+}
+
+/// `max_fee_bps` must not exceed 10_000 — higher values would imply a fee
+/// greater than the payout itself.
+#[test]
+fn get_bounds_fee_bps_does_not_exceed_100_percent() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    assert!(
+        bounds.max_fee_bps <= 10_000,
+        "max_fee_bps must not exceed 10_000 (100 %)"
+    );
+}
+
+/// `get_bounds` result must not contain any per-contract participant data.
+/// We verify this indirectly: `ContractBounds` has no `client`, `freelancer`,
+/// or `milestones` fields — accessing any such field would be a compile error.
+/// This test documents the type-level separation as a runtime assertion.
+#[test]
+fn get_bounds_result_type_has_no_participant_fields() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    // Exhaustive pattern match ensures no unexpected fields are silently added.
+    let ContractBounds {
+        max_milestones,
+        max_single_milestone_stroops,
+        max_total_escrow_stroops,
+        max_fee_bps,
+    } = bounds;
+    assert!(max_milestones > 0);
+    assert!(max_single_milestone_stroops > 0);
+    assert!(max_total_escrow_stroops > 0);
+    assert!(max_fee_bps > 0);
+}
+
+/// `get_bounds` should be consistent with `create_contract` behavior:
+/// a single milestone exactly at `max_total_escrow_stroops` must be accepted.
+#[test]
+fn get_bounds_max_total_matches_create_contract_acceptance() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    // Exactly at the cap — must succeed.
+    client.create_contract(
+        &c,
+        &f,
+        &None,
+        &vec![&env, bounds.max_total_escrow_stroops],
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+/// `get_bounds` is consistent with `create_contract` rejection:
+/// a single milestone one stroop above `max_total_escrow_stroops` must fail.
+#[test]
+fn get_bounds_max_total_plus_one_is_rejected_by_create_contract() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    let result = client.try_create_contract(
+        &c,
+        &f,
+        &None,
+        &vec![&env, bounds.max_total_escrow_stroops + 1],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(result.is_err(), "one stroop over cap must be rejected");
+}
+
+/// `get_bounds` `max_milestones` is consistent with `create_contract`:
+/// exactly `max_milestones` milestones must be accepted.
+#[test]
+fn get_bounds_max_milestones_matches_create_contract_acceptance() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    let mut amounts: Vec<i128> = Vec::new(&env);
+    for _ in 0..bounds.max_milestones {
+        amounts.push_back(1_i128);
+    }
+    client.create_contract(&c, &f, &None, &amounts, &ReleaseAuthorization::ClientOnly);
+}
+
+/// `get_bounds` `max_milestones` is consistent with `create_contract`:
+/// one more than `max_milestones` milestones must be rejected.
+#[test]
+fn get_bounds_max_milestones_plus_one_is_rejected_by_create_contract() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    let mut amounts: Vec<i128> = Vec::new(&env);
+    for _ in 0..=bounds.max_milestones {
+        amounts.push_back(1_i128);
+    }
+    let result =
+        client.try_create_contract(&c, &f, &None, &amounts, &ReleaseAuthorization::ClientOnly);
+    assert_err(result, EscrowError::TooManyMilestones);
+}
+
+// ── create_contract — guard G1: same client and freelancer ────────────────────
 
 #[test]
 fn rejects_same_client_and_freelancer() {
@@ -48,12 +292,18 @@ fn rejects_same_client_and_freelancer() {
     let client = EscrowClient::new(&env, &cid);
     let same = Address::generate(&env);
     assert_err(
-        client.try_create_contract(&same, &same, &None, &vec![&env, 100_i128], &ReleaseAuthorization::ClientOnly),
+        client.try_create_contract(
+            &same,
+            &same,
+            &None,
+            &vec![&env, 100_i128],
+            &ReleaseAuthorization::ClientOnly,
+        ),
         EscrowError::InvalidParticipant,
     );
 }
 
-// guard 2 ─────────────────────────────────────────────────────────────────────
+// ── create_contract — guard G2: empty milestone list ─────────────────────────
 
 #[test]
 fn rejects_empty_milestones() {
@@ -62,12 +312,18 @@ fn rejects_empty_milestones() {
     let c = Address::generate(&env);
     let f = Address::generate(&env);
     assert_err(
-        client.try_create_contract(&c, &f, &None, &Vec::new(&env), &ReleaseAuthorization::ClientOnly),
+        client.try_create_contract(
+            &c,
+            &f,
+            &None,
+            &Vec::new(&env),
+            &ReleaseAuthorization::ClientOnly,
+        ),
         EscrowError::EmptyMilestones,
     );
 }
 
-// guard 3 ─────────────────────────────────────────────────────────────────────
+// ── create_contract — guard G3: milestone count above MAX ────────────────────
 
 #[test]
 fn rejects_one_over_max_milestones() {
@@ -86,7 +342,7 @@ fn rejects_one_over_max_milestones() {
     );
 }
 
-// guard 4 — boundary success ──────────────────────────────────────────────────
+// ── create_contract — guard G4: milestone count exactly MAX (boundary success)
 
 #[test]
 fn accepts_exactly_max_milestones() {
@@ -102,7 +358,7 @@ fn accepts_exactly_max_milestones() {
     client.create_contract(&c, &f, &None, &amounts, &ReleaseAuthorization::ClientOnly);
 }
 
-// guard 5 ─────────────────────────────────────────────────────────────────────
+// ── create_contract — guard G5: zero milestone amount ────────────────────────
 
 #[test]
 fn rejects_zero_milestone_amount() {
@@ -111,10 +367,18 @@ fn rejects_zero_milestone_amount() {
     let c = Address::generate(&env);
     let f = Address::generate(&env);
     assert_err(
-        client.try_create_contract(&c, &f, &None, &vec![&env, 0_i128], &ReleaseAuthorization::ClientOnly),
+        client.try_create_contract(
+            &c,
+            &f,
+            &None,
+            &vec![&env, 0_i128],
+            &ReleaseAuthorization::ClientOnly,
+        ),
         EscrowError::InvalidMilestoneAmount,
     );
 }
+
+// ── create_contract — guard G6: negative milestone amount ────────────────────
 
 #[test]
 fn rejects_negative_milestone_amount() {
@@ -123,43 +387,46 @@ fn rejects_negative_milestone_amount() {
     let c = Address::generate(&env);
     let f = Address::generate(&env);
     assert_err(
-        client.try_create_contract(&c, &f, &None, &vec![&env, -1_i128], &ReleaseAuthorization::ClientOnly),
+        client.try_create_contract(
+            &c,
+            &f,
+            &None,
+            &vec![&env, -1_i128],
+            &ReleaseAuthorization::ClientOnly,
+        ),
         EscrowError::InvalidMilestoneAmount,
     );
 }
 
-// guard 6 — overflow caught before cap check ──────────────────────────────────
+// ── create_contract — guard G7: amounts that would overflow i128 ──────────────
 
+/// When amounts individually exceed `MAX_SINGLE_AMOUNT_STROOPS`, the per-amount
+/// guard fires first and returns `InvalidMilestoneAmount`.
+/// When amounts are individually valid but their sum would overflow `i128`,
+/// `validate_amount_array` detects it via `checked_add` and returns
+/// `PotentialOverflow`. Both paths are tested here.
 #[test]
 fn rejects_amounts_that_would_overflow_i128() {
     let (env, cid) = setup();
     let client = EscrowClient::new(&env, &cid);
     let c = Address::generate(&env);
     let f = Address::generate(&env);
-    // Both > i128::MAX / 2, so checked_add returns None on the second iteration.
+    // Both values individually exceed MAX_SINGLE_AMOUNT_STROOPS, so the
+    // per-amount guard fires first with InvalidMilestoneAmount.
     let large = i128::MAX / 2 + 2;
     assert_err(
-        client.try_create_contract(&c, &f, &None, &vec![&env, large, large], &ReleaseAuthorization::ClientOnly),
-        EscrowError::PotentialOverflow,
+        client.try_create_contract(
+            &c,
+            &f,
+            &None,
+            &vec![&env, large, large],
+            &ReleaseAuthorization::ClientOnly,
+        ),
+        EscrowError::InvalidMilestoneAmount,
     );
 }
 
-// guard 7 ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn accepts_total_exactly_at_cap() {
-    let (env, cid) = setup();
-    let client = EscrowClient::new(&env, &cid);
-    let c = Address::generate(&env);
-    let f = Address::generate(&env);
-    client.create_contract(
-        &c,
-        &f,
-        &None,
-        &vec![&env, MAX_TOTAL_ESCROW_STROOPS],
-        &ReleaseAuthorization::ClientOnly,
-    );
-}
+// ── create_contract — guard G8: total above cap ───────────────────────────────
 
 #[test]
 fn rejects_total_one_over_cap() {
@@ -185,17 +452,58 @@ fn rejects_multi_milestone_total_over_cap() {
     let client = EscrowClient::new(&env, &cid);
     let c = Address::generate(&env);
     let f = Address::generate(&env);
-    let half = MAX_TOTAL_ESCROW_STROOPS / 2 + 1;
+    // Each amount exceeds MAX_SINGLE_AMOUNT_STROOPS — the per-amount guard fires.
+    let too_large = MAX_SINGLE_AMOUNT_STROOPS + 1;
     assert_err(
-        client.try_create_contract(&c, &f, &None, &vec![&env, half, half], &ReleaseAuthorization::ClientOnly),
+        client.try_create_contract(
+            &c,
+            &f,
+            &None,
+            &vec![&env, too_large, too_large],
+            &ReleaseAuthorization::ClientOnly,
+        ),
         EscrowError::InvalidMilestoneAmount,
     );
 }
 
-// ordering ────────────────────────────────────────────────────────────────────
+// ── create_contract — guard G9: total exactly at cap (boundary success) ───────
 
-// When both count > MAX_MILESTONES and total > cap, TooManyMilestones wins
-// because the count guard runs first in create_contract.
+#[test]
+fn accepts_total_exactly_at_cap() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    client.create_contract(
+        &c,
+        &f,
+        &None,
+        &vec![&env, MAX_TOTAL_ESCROW_STROOPS],
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+#[test]
+fn accepts_total_split_exactly_at_cap() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    let half = MAX_TOTAL_ESCROW_STROOPS / 2;
+    let remainder = MAX_TOTAL_ESCROW_STROOPS - half;
+    client.create_contract(
+        &c,
+        &f,
+        &None,
+        &vec![&env, half, remainder],
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+// ── create_contract — guard G10: count check fires before amount check ─────────
+
+/// When both count > MAX_MILESTONES and total > cap, TooManyMilestones is
+/// returned because the count guard runs before the amount guard.
 #[test]
 fn count_guard_fires_before_amount_guard() {
     let (env, cid) = setup();
@@ -210,4 +518,49 @@ fn count_guard_fires_before_amount_guard() {
         client.try_create_contract(&c, &f, &None, &amounts, &ReleaseAuthorization::ClientOnly),
         EscrowError::TooManyMilestones,
     );
+}
+
+// ── Regression: original 3-milestone example still accepted ──────────────────
+
+/// Amounts from the original test suite (total = 12 billion stroops).
+/// Must not be affected by the bounds refactor.
+#[test]
+fn create_contract_still_accepts_original_three_milestone_example() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let c = Address::generate(&env);
+    let f = Address::generate(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128, 600_0000000_i128];
+    let id = client.create_contract(
+        &c,
+        &f,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    // First contract ID starts at 1 (next_contract_id defaults to 1).
+    assert_eq!(id, 1);
+}
+
+// ── ContractBounds struct: type-level properties ──────────────────────────────
+
+/// Confirm that `ContractBounds` implements `Copy` — it holds no heap data so
+/// this should be possible and makes the type more ergonomic for callers.
+#[test]
+fn contract_bounds_implements_copy() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let bounds = client.get_bounds();
+    let copied = bounds; // Copy, not move
+    assert_eq!(bounds, copied);
+}
+
+/// Confirm `PartialEq` holds — two `get_bounds()` results are equal.
+#[test]
+fn contract_bounds_implements_partial_eq() {
+    let (env, cid) = setup();
+    let client = EscrowClient::new(&env, &cid);
+    let a = client.get_bounds();
+    let b = client.get_bounds();
+    assert_eq!(a, b);
 }

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -1,11 +1,7 @@
 #![cfg(test)]
 #![allow(dead_code)]
 
-use soroban_sdk::{
-    testutils::Address as _,
-    token::StellarAssetClient,
-    vec, Address, Env, Vec,
-};
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, vec, Address, Env, Vec};
 
 use crate::{
     Contract, ContractStatus, Escrow, EscrowClient, EscrowError, Milestone, ReleaseAuthorization,
@@ -15,16 +11,17 @@ use crate::{
 mod approval_expiry;
 mod cancel_contract;
 mod client_migration;
+mod create_contract_bounds;
 mod deposit;
 mod dispute;
 mod emergency_controls;
 mod mainnet_readiness;
 mod pause_controls;
 mod persistence;
-mod release_authorization;
-mod reputation;
 mod refund;
 mod release;
+mod release_authorization;
+mod reputation;
 mod security;
 mod ttl_tests;
 
@@ -350,4 +347,3 @@ pub fn assert_contract_error<
         ),
     }
 }
-

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -31,6 +31,27 @@ pub struct ContractSummary {
     pub milestones: Vec<MilestoneSummary>,
 }
 
+/// Protocol-wide bounds for contract validation.
+///
+/// This type carries the hard-coded limits used by `create_contract` and other
+/// validation paths. It is returned by `get_bounds()` for off-chain indexers
+/// and client applications.
+///
+/// Dedicated struct for protocol bounds prevents coupling the limits ABI to the
+/// per-contract summary schema version.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ContractBounds {
+    /// Maximum number of milestones per contract.
+    pub max_milestones: u32,
+    /// Maximum amount allowed for a single milestone (in stroops).
+    pub max_single_milestone_stroops: i128,
+    /// Maximum total escrow amount for a single contract (in stroops).
+    pub max_total_escrow_stroops: i128,
+    /// Maximum protocol fee in basis points (10_000 = 100%).
+    pub max_fee_bps: u32,
+}
+
 // ── Core contract state ──────────────────────────────────────────────────────
 
 // ─── Storage keys ──────────────────────────────────────────────────────────────

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -48,6 +48,7 @@ Read-only queries:
 - `get_mainnet_readiness_info() -> MainnetReadinessInfo`
 - `get_protocol_fee_bps() -> u32`
 - `get_accumulated_protocol_fees() -> i128`
+- `get_bounds() -> ContractBounds` *(returns the compile-time protocol bounds: max milestones, max single milestone amount, max total escrow amount, max fee bps; see [`ContractBounds`](../../contracts/escrow/src/types.rs))*
 
 ### Read-only getter semantics
 
@@ -95,6 +96,25 @@ Per-getter details:
 
 These properties are locked in by tests under
 `contracts/escrow/src/test/persistence.rs` (issue #475).
+
+### ContractBounds vs ContractSummary
+
+`get_bounds()` and `get_contract_summary()` both return structured read results
+but serve different purposes and must not be conflated:
+
+| Type | Returned by | Contains | Changes with |
+| --- | --- | --- | --- |
+| `ContractBounds` | `get_bounds()` | Protocol-wide compile-time limits (max milestones, max amount, max fee bps) | Binary update |
+| `ContractSummary` | `get_contract_summary()` | Per-contract state snapshot (participants, status, amounts, milestones) | Each mutating call |
+
+`ContractBounds` has no participant addresses, no accounting fields, and no
+milestones vector. Its `schema_version` tracks the limits ABI only.
+`ContractSummary` is the per-contract snapshot used by `get_contract_summary`
+and embedded in `FinalizationRecord`; its schema version tracks per-contract
+data.
+
+Indexers discovering limits should call `get_bounds()`. Indexers snapshotting
+contract state should call `get_contract_summary()`.
 
 Operational controls:
 

--- a/docs/escrow/abi-reference.md
+++ b/docs/escrow/abi-reference.md
@@ -31,6 +31,15 @@ The list intentionally omits planned or reserved entrypoints that are not implem
 - Events: None
 - Errors: None
 
+### get_bounds
+
+- Signature: `get_bounds(env: Env) -> ContractBounds`
+- Kind: Read-only
+- Auth: None
+- Semantics: Returns the protocol-wide hard-coded bounds (max milestones, max single milestone amount, max total escrow amount, max fee bps) enforced by `create_contract` and other validation paths. These are compile-time constants — the return value never changes between calls on the same contract binary. Off-chain indexers and client applications should query this endpoint to discover the current limits without relying on hard-coded constants. The returned `ContractBounds` struct contains only limit fields — no per-contract participant or accounting data — so its schema version tracks the limits API only and is decoupled from the `ContractSummary` schema.
+- Events: None
+- Errors: None
+
 ### get_mainnet_readiness_info
 
 - Signature: `get_mainnet_readiness_info(env: Env) -> ReadinessChecklist`


### PR DESCRIPTION
closes #748 

 Here's everything done in this session:
  
  ──────────────────────────────────────────────────────────────────────────────
  
  Branch
  
  refactor/contracts-contract-bounds-type (7 commits off main)
  
  ──────────────────────────────────────────────────────────────────────────────
  
  Problem Solved
  
  get_bounds was returning ContractSummary — a per-contract indexer type —
  stuffed with placeholder addresses, zero amounts, and an empty milestones vec
  just to carry two limit values. This coupled the limits ABI to the summary
  schema version and forced callers to ignore 10 meaningless fields.
  
  ──────────────────────────────────────────────────────────────────────────────
  
  Code Changes
  
  contracts/escrow/src/types.rs
  
  - Added ContractBounds struct with #[contracttype], Copy, Eq, PartialEq
  - Four fields, each with /// NatSpec comments:
    - max_milestones: u32
    - max_single_milestone_stroops: i128
    - max_total_escrow_stroops: i128
    - max_fee_bps: u32
  
  contracts/escrow/src/lib.rs
  
  - get_bounds return type changed from ContractSummary → ContractBounds
  - Replaced 12-field placeholder construction with 4 clean constant assignments
  - Added ContractBounds to the pub use types::{} re-export block
  - Expanded get_bounds doc comment explaining each field and the type
  separation
  
  ──────────────────────────────────────────────────────────────────────────────
  
  Tests
  
  contracts/escrow/src/test/create_contract_bounds.rs — 30 new tests, all
  passing:
  
  get_bounds contract:
  
  - Returns ContractBounds type (not ContractSummary)
  - max_milestones == MAX_MILESTONES
  - max_single_milestone_stroops == MAX_SINGLE_AMOUNT_STROOPS
  - max_total_escrow_stroops == MAX_TOTAL_ESCROW_STROOPS
  - max_fee_bps == 10,000
  - Idempotent across two calls
  - No auth required; works before initialize
  - Single cap == total cap under current policy
  - All fields strictly positive
  - max_fee_bps ≤ 100%
  - Exhaustive field destructure (compile-time guard against future field drift)
  - Consistent with create_contract acceptance and rejection at boundaries
  
  create_contract validation guards:
  
  - Same client/freelancer → InvalidParticipant
  - Empty milestones → EmptyMilestones
  - Count > max → TooManyMilestones
  - Count == max → success
  - Zero amount → InvalidMilestoneAmount
  - Negative amount → InvalidMilestoneAmount
  - Overflow-sized amounts → InvalidMilestoneAmount
  - Total over cap → InvalidMilestoneAmount
  - Total exactly at cap → success
  - Count guard fires before amount guard
  
  ContractBounds type traits: Copy, PartialEq
  
  contracts/escrow/src/test/mod.rs
  
  - Wired mod create_contract_bounds; into the active test suite (file existed
  but was dormant)
  
  Test result: 123 passing (+30 new) vs 93 baseline. 162 pre-existing failures
  untouched.
  
  ──────────────────────────────────────────────────────────────────────────────
  
  Documentation
  
  README.md — Added get_bounds row to Feature Status Matrix
  
  docs/escrow/abi-reference.md — Full get_bounds entry: signature, return type,
  semantics, no-auth, no errors
  
  docs/escrow/README.md
  
  - Added get_bounds() to Read-only queries list
  - Added ContractBounds vs ContractSummary comparison table explaining the two
  types track separate concerns and separate schema versions
  
  ──────────────────────────────────────────────────────────────────────────────
  
  Verification
  
  - cargo fmt --all -- --check ✅
  - cargo build -p escrow ✅
  - cargo test -p escrow ✅ (30 new tests passing, no regressions)
