### PR TITLE
test(arbiter): cover boundaries and rejections

### DIFF
--- a/contracts/escrow/src/test/approval_expiry.rs
+++ b/contracts/escrow/src/test/approval_expiry.rs
@@ -477,6 +477,86 @@ fn test_client_and_arbiter_approval_expires_after_ttl() {
 }
 
 #[test]
+fn test_arbiter_only_approval_valid_at_exactly_ttl_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones(&env),
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total()));
+    assert!(client.approve_milestone_release(&contract_id, &arbiter_addr, &0));
+
+    advance_ledger(&env, &escrow_id, PENDING_APPROVAL_TTL_LEDGERS);
+
+    let approvals = client.get_milestone_approvals(&contract_id, &0);
+    assert!(
+        approvals.is_some(),
+        "arbiter approval should survive at exact TTL boundary"
+    );
+
+    advance_ledger(&env, &escrow_id, 1);
+
+    let approvals_expired = client.get_milestone_approvals(&contract_id, &0);
+    assert!(
+        approvals_expired.is_none(),
+        "arbiter approval expires one ledger past TTL"
+    );
+}
+
+#[test]
+fn test_client_and_arbiter_approval_valid_at_exactly_ttl_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones(&env),
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+    assert!(client.deposit_funds(&contract_id, &client_addr, &total()));
+    assert!(client.approve_milestone_release(&contract_id, &arbiter_addr, &0));
+
+    advance_ledger(&env, &escrow_id, PENDING_APPROVAL_TTL_LEDGERS);
+
+    let approvals = client.get_milestone_approvals(&contract_id, &0);
+    assert!(
+        approvals.is_some(),
+        "arbiter approval should survive at exact TTL boundary in ClientAndArbiter mode"
+    );
+
+    advance_ledger(&env, &escrow_id, 1);
+
+    let approvals_expired = client.get_milestone_approvals(&contract_id, &0);
+    assert!(
+        approvals_expired.is_none(),
+        "arbiter approval expires one ledger past TTL in ClientAndArbiter mode"
+    );
+}
+
+#[test]
 fn test_multisig_one_approval_expires_before_second_arrives() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -688,6 +688,67 @@ fn raise_dispute_after_settle_is_rejected() {
     );
 }
 
+/// The assigned arbiter cannot resolve a dispute when the contract is not in
+/// `Disputed` state; the status guard must fire first and return
+/// `InvalidStatusTransition`.
+#[test]
+fn resolve_dispute_by_arbiter_when_not_disputed_is_rejected() {
+    let env = make_env();
+    let client = make_client(&env);
+    let milestones = vec![&env, 100_i128];
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr),
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
+    assert_eq!(
+        client.get_contract(&contract_id).status,
+        ContractStatus::Funded
+    );
+
+    super::assert_contract_error(
+        client.try_resolve_dispute(&contract_id, &arbiter_addr, &DisputeResolution::FullRefund),
+        Error::InvalidStatusTransition,
+    );
+}
+
+/// Raising a dispute on a contract that is already `Disputed` is rejected with
+/// `InvalidState`. The first successful raise must emit the `dispute opened`
+/// event; the second attempt must fail without changing state.
+#[test]
+fn raise_dispute_when_already_disputed_is_rejected() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (client_addr, _, _, contract_id) = funded_contract_with_arbiter(&env, &client);
+
+    assert!(client.raise_dispute(&contract_id, &client_addr));
+    assert_eq!(
+        client.get_contract(&contract_id).status,
+        ContractStatus::Disputed
+    );
+
+    let events = env.events().all();
+    assert!(
+        events.iter().any(|event| event.0 == symbol_short!("dispute")),
+        "expected dispute opened event after first raise"
+    );
+
+    super::assert_contract_error(
+        client.try_raise_dispute(&contract_id, &client_addr),
+        Error::InvalidState,
+    );
+    assert_eq!(
+        client.get_contract(&contract_id).status,
+        ContractStatus::Disputed
+    );
+}
+
 /// Resolving a dispute moves funds: FullPayout sets released_amount and marks
 /// Completed; FullRefund sets refunded_amount and marks Refunded. Verify that
 /// the accounting is correct after each resolution type.


### PR DESCRIPTION
Closes #801

Add focused boundary and rejection tests for arbiter logic:

- ArbiterOnly and ClientAndArbiter approval TTL exact-boundary tests
  (valid at exactly PENDING_APPROVAL_TTL_LEDGERS, expired one past)
- Arbiter resolve rejected when contract is not Disputed
- Double raise_dispute rejected with InvalidState and event assertion