### PR TITLE
fix(escrow): restrict submit_work_evidence caller and milestone state…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The supported deployed interface is documented in the [Escrow ABI reference](doc
 | `create_contract`          | **Implemented** | Core initialization and state persistence                                                         |
 | `deposit_funds`            | **Implemented** | Escrow fund collection tracking                                                                   |
 | `release_milestone`        | **Implemented** | Authenticated milestone payouts via `caller.require_auth()`                                       |
+| `submit_work_evidence`     | **Implemented** | Freelancer-only deliverable evidence gated to pre-release milestone states ([#745](https://github.com/Talenttrust/Talenttrust-Contracts/issues/745)) |
 | `finalize_contract`        | **Implemented** | Freezes contract mutable updates                                                                  |
 | `cancel_contract`          | **Implemented** | Early termination contract transitions                                                            |
 | `issue_reputation`         | **Implemented** | Milestone rating metrics for completed contracts                                                  |

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1830,26 +1830,34 @@ impl Escrow {
     /// unreleased milestone.
     ///
     /// Only the contract's freelancer may call this. The contract must be in
-    /// `Funded` status and the target milestone must not yet be released or
-    /// refunded. Evidence may be overwritten before release.
+    /// a pre-release state (`Funded` or `PartiallyFunded`) and the target
+    /// milestone must not yet be released or refunded. Evidence may be
+    /// overwritten before release but may not be submitted to a settled,
+    /// cancelled, disputed, or finalized contract to protect the on-chain
+    /// audit trail.
     ///
     /// # Arguments
-    /// * `contract_id` - The escrow contract to update
-    /// * `caller`      - Must equal the stored `freelancer`; requires auth
-    /// * `milestone_index` - Zero-based index of the milestone
-    /// * `evidence`    - Deliverable reference; max 256 bytes
+    /// * `contract_id`     - The escrow contract to update
+    /// * `caller`          - Must equal the stored `freelancer`; requires auth
+    /// * `milestone_index` - Zero-based index of the milestone to attach evidence to
+    /// * `evidence`        - Deliverable reference (e.g. IPFS CID or URL hash);
+    ///                       must be non-empty and at most 256 bytes
     ///
     /// # Errors
-    /// * `NotInitialized`     — `initialize` has not been called
-    /// * `ContractPaused` / `EmergencyActive` — pause/emergency gate
-    /// * `ContractNotFound`   — unknown `contract_id`
-    /// * `AlreadyFinalized`   — contract has been finalized
-    /// * `UnauthorizedRole`   — `caller` is not the freelancer
-    /// * `InvalidState`       — contract is not `Funded`
-    /// * `IndexOutOfBounds`   — `milestone_index` exceeds milestone count
-    /// * `MilestoneAlreadyReleased` — milestone is already released
-    /// * `AlreadyRefunded`    — milestone has been refunded
-    /// * `EvidenceTooLong`    — evidence string exceeds 256 bytes
+    /// * `NotInitialized`           — `initialize` has not been called
+    /// * `ContractPaused`           — contract is paused; all mutations blocked
+    /// * `EmergencyActive`          — emergency mode is active; all mutations blocked
+    /// * `ContractNotFound`         — unknown `contract_id`
+    /// * `AlreadyFinalized`         — contract has been finalized; audit trail is immutable
+    /// * `UnauthorizedRole`         — `caller` is not the stored freelancer
+    /// * `InvalidState`             — contract is not `Funded` or `PartiallyFunded`;
+    ///                                rejects `Cancelled`, `Disputed`, `Completed`,
+    ///                                `Refunded`, `Created`, and `Accepted` contracts
+    /// * `IndexOutOfBounds`         — `milestone_index` exceeds milestone count
+    /// * `MilestoneAlreadyReleased` — milestone has already been paid out
+    /// * `AlreadyRefunded`          — milestone has already been refunded
+    /// * `EvidenceEmpty`            — evidence string is empty
+    /// * `EvidenceTooLong`          — evidence string exceeds 256 bytes
     pub fn submit_work_evidence(
         env: Env,
         contract_id: u32,
@@ -1876,8 +1884,22 @@ impl Escrow {
             env.panic_with_error(EscrowError::UnauthorizedRole);
         }
 
-        if contract.status != ContractStatus::Funded {
+        /// Gate: only pre-release contract states are eligible. Funded and
+        /// PartiallyFunded represent contracts where milestones are in-flight;
+        /// any other status (Cancelled, Disputed, Completed, Refunded, Created,
+        /// Accepted) means settlement is terminal or the contract has not yet
+        /// been funded, so the evidence submission window is closed.
+        if contract.status != ContractStatus::Funded
+            && contract.status != ContractStatus::PartiallyFunded
+        {
             env.panic_with_error(EscrowError::InvalidState);
+        }
+
+        /// Gate: reject empty evidence strings. An empty string carries no
+        /// meaningful deliverable reference and would silently replace a prior
+        /// valid evidence entry with a no-op, corrupting the audit trail.
+        if evidence.len() == 0 {
+            env.panic_with_error(Error::EvidenceEmpty);
         }
 
         // Bound evidence to 256 bytes to prevent storage bloat.

--- a/contracts/escrow/src/test/access_control.rs
+++ b/contracts/escrow/src/test/access_control.rs
@@ -1,15 +1,48 @@
-use super::{default_milestones, generated_participants, register_client, total_milestones};
-use crate::{Error, ReleaseAuthorization};
-use soroban_sdk::{testutils::Address as _, Env};
+use super::{
+    assert_contract_error, default_milestones, generated_participants, register_client,
+    total_milestone_amount,
+};
+use crate::{ContractStatus, Error, EscrowError, ReleaseAuthorization};
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, vec, Address, Env, String};
+
+// ---------------------------------------------------------------------------
+// Internal helper: build a funded escrow with a bound SAC token.
+// Returns (EscrowClient, escrow_id, client_addr, freelancer_addr).
+// ---------------------------------------------------------------------------
+fn funded_setup(
+    env: &Env,
+) -> (crate::EscrowClient<'_>, u32, Address, Address) {
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(env, &escrow_addr);
+    let admin = Address::generate(env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+    let total = total_milestone_amount();
+    StellarAssetClient::new(env, &token).mint(&client_addr, &total);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &default_milestones(env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+    escrow.deposit_funds(&contract_id, &client_addr, &total);
+    (escrow, contract_id, client_addr, freelancer_addr)
+}
+
+// ===========================================================================
+// Existing access-control tests (fixed: import names, tuple arity, SAC setup)
+// ===========================================================================
 
 #[test]
 fn test_only_client_can_deposit_funds() {
     let env = Env::default();
     env.mock_all_auths();
-
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let contract_id = client.create_contract(
         &client_addr,
         &freelancer_addr,
@@ -17,110 +50,56 @@ fn test_only_client_can_deposit_funds() {
         &default_milestones(&env),
         &ReleaseAuthorization::ClientOnly,
     );
-
-    let result = client.try_deposit_funds(&contract_id, &freelancer_addr, &total_milestones());
+    let result =
+        client.try_deposit_funds(&contract_id, &freelancer_addr, &total_milestone_amount());
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
 #[test]
 fn test_freelancer_cannot_approve_milestone_release() {
     let env = Env::default();
-    env.mock_all_auths();
-
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-
-    let result = client.try_approve_milestone_release(&contract_id, &freelancer_addr, &0);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _client_addr, freelancer_addr) = funded_setup(&env);
+    let result = escrow.try_approve_milestone_release(&contract_id, &freelancer_addr, &0);
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
 #[test]
 fn test_freelancer_cannot_release_milestone() {
     let env = Env::default();
-    env.mock_all_auths();
-
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-
-    let result = client.try_release_milestone(&contract_id, &freelancer_addr, &0);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    let result = escrow.try_release_milestone(&contract_id, &freelancer_addr, &0);
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
 #[test]
 fn test_only_client_can_issue_reputation() {
     let env = Env::default();
-    env.mock_all_auths();
-
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
-    assert!(client.release_milestone(&contract_id, &client_addr, &1));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
-    assert!(client.release_milestone(&contract_id, &client_addr, &2));
-
-    let result = client.try_issue_reputation(&contract_id, &freelancer_addr, &freelancer_addr, &5);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client_addr, &i);
+        escrow.release_milestone(&contract_id, &client_addr, &i);
+    }
+    let result =
+        escrow.try_issue_reputation(&contract_id, &freelancer_addr, &freelancer_addr, &5);
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
 #[test]
 fn test_issue_reputation_rejects_freelancer_mismatch() {
     let env = Env::default();
-    env.mock_all_auths();
-
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-    let wrong_freelancer = soroban_sdk::Address::generate(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
-    assert!(client.release_milestone(&contract_id, &client_addr, &1));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
-    assert!(client.release_milestone(&contract_id, &client_addr, &2));
-
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &wrong_freelancer, &5);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    let wrong_freelancer = Address::generate(&env);
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client_addr, &i);
+        escrow.release_milestone(&contract_id, &client_addr, &i);
+    }
+    let result =
+        escrow.try_issue_reputation(&contract_id, &client_addr, &wrong_freelancer, &5);
     assert_eq!(result, Err(Ok(Error::FreelancerMismatch)));
 }
 
@@ -128,10 +107,8 @@ fn test_issue_reputation_rejects_freelancer_mismatch() {
 fn test_create_rejects_arbiter_modes_without_arbiter() {
     let env = Env::default();
     env.mock_all_auths();
-
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let result = client.try_create_contract(
         &client_addr,
         &freelancer_addr,
@@ -146,10 +123,8 @@ fn test_create_rejects_arbiter_modes_without_arbiter() {
 fn test_create_rejects_invalid_arbiter_role_overlap() {
     let env = Env::default();
     env.mock_all_auths();
-
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let result = client.try_create_contract(
         &client_addr,
         &freelancer_addr,
@@ -164,10 +139,9 @@ fn test_create_rejects_invalid_arbiter_role_overlap() {
 #[should_panic]
 fn test_create_contract_requires_authentication_of_roles() {
     let env = Env::default();
+    // Intentionally no mock_all_auths — auth must be provided.
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    // No env.mock_all_auths() in this test: role addresses must authorize.
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let _ = client.create_contract(
         &client_addr,
         &freelancer_addr,
@@ -182,8 +156,7 @@ fn test_create_rejects_same_client_and_freelancer() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
-    let (client_addr, _freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, _) = generated_participants(&env);
     let result = client.try_create_contract(
         &client_addr,
         &client_addr,
@@ -199,9 +172,8 @@ fn test_create_rejects_empty_milestones() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let empty = soroban_sdk::Vec::<i128>::new(&env);
-
     let result = client.try_create_contract(
         &client_addr,
         &freelancer_addr,
@@ -217,8 +189,7 @@ fn test_deposit_rejects_non_positive_amount() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let contract_id = client.create_contract(
         &client_addr,
         &freelancer_addr,
@@ -226,28 +197,17 @@ fn test_deposit_rejects_non_positive_amount() {
         &default_milestones(&env),
         &ReleaseAuthorization::ClientOnly,
     );
-
     let result = client.try_deposit_funds(&contract_id, &client_addr, &0);
     assert_eq!(result, Err(Ok(Error::AmountMustBePositive)));
 }
 
 #[test]
-fn test_deposit_rejects_when_contract_not_created() {
+fn test_deposit_rejects_when_contract_already_funded() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    let result = client.try_deposit_funds(&contract_id, &client_addr, &total_milestones());
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, _) = funded_setup(&env);
+    // Contract is now Funded; a second deposit must be rejected.
+    let result = escrow.try_deposit_funds(&contract_id, &client_addr, &total_milestone_amount());
     assert_eq!(result, Err(Ok(Error::InvalidState)));
 }
 
@@ -256,8 +216,7 @@ fn test_approve_requires_funded_state() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let contract_id = client.create_contract(
         &client_addr,
         &freelancer_addr,
@@ -265,7 +224,6 @@ fn test_approve_requires_funded_state() {
         &default_milestones(&env),
         &ReleaseAuthorization::ClientOnly,
     );
-
     let result = client.try_approve_milestone_release(&contract_id, &client_addr, &0);
     assert_eq!(result, Err(Ok(Error::InvalidState)));
 }
@@ -273,65 +231,49 @@ fn test_approve_requires_funded_state() {
 #[test]
 fn test_approve_rejects_already_released_milestone() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-
-    let result = client.try_approve_milestone_release(&contract_id, &client_addr, &0);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, _) = funded_setup(&env);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    escrow.release_milestone(&contract_id, &client_addr, &0);
+    let result = escrow.try_approve_milestone_release(&contract_id, &client_addr, &0);
     assert_eq!(result, Err(Ok(Error::MilestoneAlreadyReleased)));
 }
 
 #[test]
 fn test_approve_rejects_duplicate_client_approval() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    let result = client.try_approve_milestone_release(&contract_id, &client_addr, &0);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, _) = funded_setup(&env);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    let result = escrow.try_approve_milestone_release(&contract_id, &client_addr, &0);
     assert_eq!(result, Err(Ok(Error::AlreadyApproved)));
 }
 
 #[test]
 fn test_approve_rejects_duplicate_arbiter_approval() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let total = total_milestone_amount();
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &total);
+    let contract_id = escrow.create_contract(
         &client_addr,
         &freelancer_addr,
         &Some(arbiter_addr.clone()),
         &default_milestones(&env),
         &ReleaseAuthorization::ArbiterOnly,
     );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &arbiter_addr, &0));
-    let result = client.try_approve_milestone_release(&contract_id, &arbiter_addr, &0);
+    escrow.deposit_funds(&contract_id, &client_addr, &total);
+    escrow.approve_milestone_release(&contract_id, &arbiter_addr, &0);
+    let result = escrow.try_approve_milestone_release(&contract_id, &arbiter_addr, &0);
     assert_eq!(result, Err(Ok(Error::AlreadyApproved)));
 }
 
@@ -340,8 +282,7 @@ fn test_release_requires_funded_state() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let contract_id = client.create_contract(
         &client_addr,
         &freelancer_addr,
@@ -349,7 +290,6 @@ fn test_release_requires_funded_state() {
         &default_milestones(&env),
         &ReleaseAuthorization::ClientOnly,
     );
-
     let result = client.try_release_milestone(&contract_id, &client_addr, &0);
     assert_eq!(result, Err(Ok(Error::InvalidState)));
 }
@@ -357,49 +297,24 @@ fn test_release_requires_funded_state() {
 #[test]
 fn test_release_rejects_already_released_milestone() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-    let result = client.try_release_milestone(&contract_id, &client_addr, &0);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, _) = funded_setup(&env);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    escrow.release_milestone(&contract_id, &client_addr, &0);
+    let result = escrow.try_release_milestone(&contract_id, &client_addr, &0);
     assert_eq!(result, Err(Ok(Error::MilestoneAlreadyReleased)));
 }
 
 #[test]
 fn test_issue_reputation_rejects_invalid_rating() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
-    assert!(client.release_milestone(&contract_id, &client_addr, &1));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
-    assert!(client.release_milestone(&contract_id, &client_addr, &2));
-
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &0);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client_addr, &i);
+        escrow.release_milestone(&contract_id, &client_addr, &i);
+    }
+    let result = escrow.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &0);
     assert_eq!(result, Err(Ok(Error::InvalidRating)));
 }
 
@@ -408,8 +323,7 @@ fn test_issue_reputation_requires_completed_contract() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
+    let (client_addr, freelancer_addr) = generated_participants(&env);
     let contract_id = client.create_contract(
         &client_addr,
         &freelancer_addr,
@@ -417,7 +331,6 @@ fn test_issue_reputation_requires_completed_contract() {
         &default_milestones(&env),
         &ReleaseAuthorization::ClientOnly,
     );
-
     let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5);
     assert_eq!(result, Err(Ok(Error::InvalidState)));
 }
@@ -425,72 +338,470 @@ fn test_issue_reputation_requires_completed_contract() {
 #[test]
 fn test_issue_reputation_rejects_duplicate_issuance() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, _arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
-        &client_addr,
-        &freelancer_addr,
-        &None,
-        &default_milestones(&env),
-        &ReleaseAuthorization::ClientOnly,
-    );
-
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &0));
-    assert!(client.release_milestone(&contract_id, &client_addr, &0));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &1));
-    assert!(client.release_milestone(&contract_id, &client_addr, &1));
-    assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
-    assert!(client.release_milestone(&contract_id, &client_addr, &2));
-
-    assert!(client.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5));
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &4);
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client_addr, &i);
+        escrow.release_milestone(&contract_id, &client_addr, &i);
+    }
+    assert!(escrow.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5));
+    let result = escrow.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &4);
     assert_eq!(result, Err(Ok(Error::ReputationAlreadyIssued)));
 }
 
 #[test]
 fn test_client_and_arbiter_mode_rejects_third_party_approval() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, arbiter_addr) = generated_participants(&env);
-    let outsider = soroban_sdk::Address::generate(&env);
-
-    let contract_id = client.create_contract(
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let total = total_milestone_amount();
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &total);
+    let contract_id = escrow.create_contract(
         &client_addr,
         &freelancer_addr,
         &Some(arbiter_addr),
         &default_milestones(&env),
         &ReleaseAuthorization::ClientAndArbiter,
     );
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
-
-    let result = client.try_approve_milestone_release(&contract_id, &outsider, &0);
+    escrow.deposit_funds(&contract_id, &client_addr, &total);
+    let result = escrow.try_approve_milestone_release(&contract_id, &outsider, &0);
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
 #[test]
 fn test_arbiter_only_flow_enforces_arbiter_approval_and_release() {
     let env = Env::default();
-    env.mock_all_auths();
-    let client = register_client(&env);
-    let (client_addr, freelancer_addr, arbiter_addr) = generated_participants(&env);
-
-    let contract_id = client.create_contract(
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let total = total_milestone_amount();
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &total);
+    let contract_id = escrow.create_contract(
         &client_addr,
         &freelancer_addr,
         &Some(arbiter_addr.clone()),
         &default_milestones(&env),
         &ReleaseAuthorization::ArbiterOnly,
     );
-    assert!(client.deposit_funds(&contract_id, &client_addr, &total_milestones()));
+    escrow.deposit_funds(&contract_id, &client_addr, &total);
+    // Client cannot approve in ArbiterOnly mode.
+    let r = escrow.try_approve_milestone_release(&contract_id, &client_addr, &0);
+    assert_eq!(r, Err(Ok(Error::UnauthorizedRole)));
+    assert!(escrow.approve_milestone_release(&contract_id, &arbiter_addr, &0));
+    assert!(escrow.release_milestone(&contract_id, &arbiter_addr, &0));
+}
 
-    // Client cannot approve in ArbiterOnly.
-    let client_approval = client.try_approve_milestone_release(&contract_id, &client_addr, &0);
-    assert_eq!(client_approval, Err(Ok(Error::UnauthorizedRole)));
+// ===========================================================================
+// submit_work_evidence — #745: caller-identity and milestone-state gates
+// ===========================================================================
 
-    assert!(client.approve_milestone_release(&contract_id, &arbiter_addr, &0));
-    assert!(client.release_milestone(&contract_id, &arbiter_addr, &0));
+// ---------------------------------------------------------------------------
+// Caller-identity gates
+// ---------------------------------------------------------------------------
+
+/// The client must be rejected; only the stored freelancer may submit evidence.
+#[test]
+fn submit_work_evidence_rejects_client_as_caller() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, _) = funded_setup(&env);
+    let evidence = String::from_str(&env, "ipfs://QmClientAttempt");
+    let result = escrow.try_submit_work_evidence(&contract_id, &client_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+/// An arbiter must be rejected; they cannot submit evidence on a freelancer's behalf.
+#[test]
+fn submit_work_evidence_rejects_arbiter_as_caller() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let total = total_milestone_amount();
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &total);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &default_milestones(&env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+    escrow.deposit_funds(&contract_id, &client_addr, &total);
+    let evidence = String::from_str(&env, "ipfs://QmArbiterAttempt");
+    let result = escrow.try_submit_work_evidence(&contract_id, &arbiter_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+/// A random third party must be rejected with `UnauthorizedRole`.
+#[test]
+fn submit_work_evidence_rejects_third_party_as_caller() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, _) = funded_setup(&env);
+    let outsider = Address::generate(&env);
+    let evidence = String::from_str(&env, "ipfs://QmOutsider");
+    let result = escrow.try_submit_work_evidence(&contract_id, &outsider, &0, &evidence);
+    assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+// ---------------------------------------------------------------------------
+// Milestone-state gates
+// ---------------------------------------------------------------------------
+
+/// Evidence must not be accepted for a milestone that has already been released.
+/// The on-chain audit trail for a settled payment must be immutable.
+#[test]
+fn submit_work_evidence_rejects_released_milestone() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    escrow.approve_milestone_release(&contract_id, &client_addr, &0);
+    escrow.release_milestone(&contract_id, &client_addr, &0);
+    let evidence = String::from_str(&env, "ipfs://QmAfterRelease");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, Error::MilestoneAlreadyReleased);
+}
+
+/// Evidence must not be accepted for a milestone that has already been refunded.
+#[test]
+fn submit_work_evidence_rejects_refunded_milestone() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    // Two milestones; deposit only the first so the contract is PartiallyFunded.
+    let partial = 100_i128;
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &partial);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 100_i128, 200_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    escrow.deposit_funds(&contract_id, &client_addr, &partial);
+    // Refund milestone 0 while PartiallyFunded.
+    escrow.refund_unreleased_milestones(&contract_id, &vec![&env, 0_u32]);
+    let evidence = String::from_str(&env, "ipfs://QmAfterRefund");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::AlreadyRefunded);
+}
+
+// ---------------------------------------------------------------------------
+// Contract-state gates
+// ---------------------------------------------------------------------------
+
+/// A cancelled contract must reject evidence submissions.
+#[test]
+fn submit_work_evidence_rejects_cancelled_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 100_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    // Cancel before any deposit — no SAC transfer needed.
+    escrow.cancel_contract(&contract_id, &client_addr);
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Cancelled
+    );
+    let evidence = String::from_str(&env, "ipfs://QmCancelledContract");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// A disputed contract must reject evidence submissions.
+#[test]
+fn submit_work_evidence_rejects_disputed_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &100_i128);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr),
+        &vec![&env, 100_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    escrow.deposit_funds(&contract_id, &client_addr, &100_i128);
+    escrow.raise_dispute(&contract_id, &client_addr);
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Disputed
+    );
+    let evidence = String::from_str(&env, "ipfs://QmDisputedContract");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// A completed contract (all milestones released) must reject evidence.
+#[test]
+fn submit_work_evidence_rejects_completed_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client_addr, &i);
+        escrow.release_milestone(&contract_id, &client_addr, &i);
+    }
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Completed
+    );
+    let evidence = String::from_str(&env, "ipfs://QmCompletedContract");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+/// A finalized contract must reject evidence with `AlreadyFinalized`.
+#[test]
+fn submit_work_evidence_rejects_finalized_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, client_addr, freelancer_addr) = funded_setup(&env);
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client_addr, &i);
+        escrow.release_milestone(&contract_id, &client_addr, &i);
+    }
+    escrow.finalize_contract(&contract_id, &client_addr);
+    let evidence = String::from_str(&env, "ipfs://QmFinalizedContract");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::AlreadyFinalized);
+}
+
+/// A contract still in `Created` state (never funded) must reject evidence.
+#[test]
+fn submit_work_evidence_rejects_created_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let (client_addr, freelancer_addr) = generated_participants(&env);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 100_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    let evidence = String::from_str(&env, "ipfs://QmCreatedContract");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    assert_contract_error(result, EscrowError::InvalidState);
+}
+
+// ---------------------------------------------------------------------------
+// Evidence-content gates
+// ---------------------------------------------------------------------------
+
+/// An empty evidence string must be rejected with `EvidenceEmpty`.
+/// Empty submissions would silently corrupt a prior valid entry.
+#[test]
+fn submit_work_evidence_rejects_empty_string() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    let empty = String::from_str(&env, "");
+    let result = escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &empty);
+    assert_contract_error(result, Error::EvidenceEmpty);
+}
+
+/// Evidence exceeding 256 bytes must be rejected with `EvidenceTooLong`.
+#[test]
+fn submit_work_evidence_rejects_257_bytes() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    let too_long = String::from_str(&env, &"x".repeat(257));
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &too_long);
+    assert_contract_error(result, Error::EvidenceTooLong);
+}
+
+/// Exactly 256 bytes must be accepted (upper boundary).
+#[test]
+fn submit_work_evidence_accepts_exactly_256_bytes() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    let boundary = String::from_str(&env, &"x".repeat(256));
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &boundary));
+    assert_eq!(
+        escrow.get_work_evidence(&contract_id, &0).map(|s| s.len()),
+        Some(256)
+    );
+}
+
+/// An out-of-bounds milestone index must be rejected with `IndexOutOfBounds`.
+#[test]
+fn submit_work_evidence_rejects_out_of_bounds_index() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    // Default fixture has 3 milestones (indices 0–2); index 3 is out of bounds.
+    let evidence = String::from_str(&env, "ipfs://QmBoundsCheck");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &3, &evidence);
+    assert_contract_error(result, Error::IndexOutOfBounds);
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path and functional tests
+// ---------------------------------------------------------------------------
+
+/// The freelancer can submit evidence for a fully-funded contract and the
+/// value is readable back via `get_work_evidence`.
+#[test]
+fn submit_work_evidence_succeeds_for_funded_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    let evidence = String::from_str(&env, "ipfs://QmHappyPath");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence));
+    assert_eq!(
+        escrow.get_work_evidence(&contract_id, &0),
+        Some(evidence)
+    );
+}
+
+/// Evidence submission succeeds when the contract is only PartiallyFunded
+/// (a valid pre-release state where work may already be in progress).
+#[test]
+fn submit_work_evidence_succeeds_for_partially_funded_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let escrow_addr = env.register(crate::Escrow, ());
+    let escrow = crate::EscrowClient::new(&env, &escrow_addr);
+    let admin = Address::generate(&env);
+    escrow.initialize(&admin);
+    let token = env.register_stellar_asset_contract(admin.clone());
+    escrow.bind_settlement_token(&admin, &token);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    // Deposit less than the full total so the contract stays PartiallyFunded.
+    let partial = 100_i128;
+    StellarAssetClient::new(&env, &token).mint(&client_addr, &partial);
+    let contract_id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &vec![&env, 100_i128, 200_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    escrow.deposit_funds(&contract_id, &client_addr, &partial);
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::PartiallyFunded
+    );
+    let evidence = String::from_str(&env, "ipfs://QmPartialFunded");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence));
+    assert_eq!(
+        escrow.get_work_evidence(&contract_id, &0),
+        Some(evidence)
+    );
+}
+
+/// The freelancer may overwrite evidence before a milestone is released;
+/// only the latest value must be visible.
+#[test]
+fn submit_work_evidence_overwrites_previous_value() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    let first = String::from_str(&env, "ipfs://QmFirst");
+    let second = String::from_str(&env, "ipfs://QmSecond");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &first));
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &second));
+    assert_eq!(
+        escrow.get_work_evidence(&contract_id, &0),
+        Some(second)
+    );
+}
+
+/// Evidence for different milestones is stored independently.
+#[test]
+fn submit_work_evidence_stores_per_milestone() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    let ev0 = String::from_str(&env, "ipfs://QmMilestone0");
+    let ev1 = String::from_str(&env, "ipfs://QmMilestone1");
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &0, &ev0));
+    assert!(escrow.submit_work_evidence(&contract_id, &freelancer_addr, &1, &ev1));
+    assert_eq!(escrow.get_work_evidence(&contract_id, &0), Some(ev0));
+    assert_eq!(escrow.get_work_evidence(&contract_id, &1), Some(ev1));
+    // Milestone 2 was never touched — must return None.
+    assert_eq!(escrow.get_work_evidence(&contract_id, &2), None);
+}
+
+/// An emergency-mode contract must reject evidence submissions.
+///
+/// `activate_emergency_pause` sets both the `Paused` and `Emergency` flags.
+/// The `require_not_paused` guard checks `Paused` first, so `ContractPaused`
+/// is the expected error regardless of whether emergency mode is active alone
+/// or combined with the paused flag.
+#[test]
+fn submit_work_evidence_rejects_emergency_mode() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (escrow, contract_id, _, freelancer_addr) = funded_setup(&env);
+    // Activate emergency mode (also sets Paused=true).
+    escrow.activate_emergency_pause();
+    let evidence = String::from_str(&env, "ipfs://QmEmergency");
+    let result =
+        escrow.try_submit_work_evidence(&contract_id, &freelancer_addr, &0, &evidence);
+    // `require_not_paused` checks the Paused flag first, so ContractPaused is emitted.
+    assert_contract_error(result, Error::ContractPaused);
 }

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 // --- Submodules ---
+mod access_control;
 mod approval_expiry;
 mod cancel_contract;
 mod client_migration;

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -193,6 +193,8 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// The work evidence string is empty.
+    EvidenceEmpty = 54,
 }
 
 /// Contract lifecycle states

--- a/docs/escrow/abi-reference.md
+++ b/docs/escrow/abi-reference.md
@@ -334,10 +334,10 @@ The list intentionally omits planned or reserved entrypoints that are not implem
 
 - Signature: `submit_work_evidence(env: Env, contract_id: u32, caller: Address, milestone_index: u32, evidence: String) -> bool`
 - Kind: Mutating
-- Auth: `caller.require_auth()`
-- Semantics: Stores evidence for an unreleased milestone. Evidence is capped to 256 bytes.
-- Events: `("evidence", contract_id)`
-- Errors: `ContractPaused`, `EmergencyActive`, `ContractNotFound`, `AlreadyFinalized`, `UnauthorizedRole`, `InvalidState`, `IndexOutOfBounds`, `MilestoneAlreadyReleased`, `AlreadyRefunded`, `EvidenceTooLong`
+- Auth: `caller.require_auth()` — `caller` must equal the stored freelancer
+- Semantics: Stores deliverable evidence for an unreleased milestone. The caller must be the contract's freelancer; client, arbiter, and third parties are rejected. The contract must be `Funded` or `PartiallyFunded`. Evidence must be non-empty and at most 256 bytes. The milestone must not have been released or refunded. The call is blocked when the contract is paused, under emergency, or finalized.
+- Events: `("evidence", contract_id)` → `(milestone_index, freelancer, timestamp)`
+- Errors: `NotInitialized`, `ContractPaused`, `EmergencyActive`, `ContractNotFound`, `AlreadyFinalized`, `UnauthorizedRole`, `InvalidState`, `EvidenceEmpty`, `EvidenceTooLong`, `IndexOutOfBounds`, `MilestoneAlreadyReleased`, `AlreadyRefunded`
 
 ### get_work_evidence
 

--- a/docs/escrow/access-control.md
+++ b/docs/escrow/access-control.md
@@ -69,6 +69,36 @@ code. `load_and_auth_admin` supersedes it.
 
 ---
 
+## `submit_work_evidence` Security Gates (issue #745)
+
+`submit_work_evidence(contract_id, caller, milestone_index, evidence)` enforces
+the following gates **in order**:
+
+| Gate | Error emitted | Description |
+|---|---|---|
+| `require_initialized` | `NotInitialized` | Contract must have been initialized. |
+| `require_not_paused` | `ContractPaused` / `EmergencyActive` | Rejects calls while paused or under emergency. |
+| `caller.require_auth()` | Auth failure | Soroban auth engine must record caller authorization. |
+| Freelancer identity check | `UnauthorizedRole` | `caller` must equal the stored `contract.freelancer`; client, arbiter, and third parties are all rejected. |
+| Contract status check | `InvalidState` | Contract must be `Funded` or `PartiallyFunded`. Rejects `Created`, `Accepted`, `Cancelled`, `Disputed`, `Completed`, and `Refunded` states. |
+| Empty evidence check | `EvidenceEmpty` | Evidence string must have length > 0. |
+| Length bound | `EvidenceTooLong` | Evidence string must not exceed 256 bytes. |
+| `require_not_finalized` | `AlreadyFinalized` | Rejects evidence on a finalized contract. |
+| Milestone bounds | `IndexOutOfBounds` | `milestone_index` must be within the stored milestone vector. |
+| Released flag | `MilestoneAlreadyReleased` | Milestone must not have been paid out. |
+| Refunded flag | `AlreadyRefunded` | Milestone must not have been individually refunded. |
+
+### Rationale
+
+`work_evidence` in a `Milestone` is the on-chain audit trail for the
+deliverable that justified a payment. Permitting post-release or post-refund
+mutations would silently overwrite the record of an already-settled payment,
+making it impossible to reconstruct the evidence that was reviewed at the time
+of release. All gates are fail-closed: any condition that would corrupt the
+audit trail causes the transaction to revert.
+
+---
+
 ## Current Release Caveat
 
 `release_milestone(contract_id, milestone_index)` does not authenticate a


### PR DESCRIPTION
Closes #745
… (#745)

Gate submit_work_evidence to the contract's freelancer and pre-release milestone/contract states to prevent post-settlement audit trail rewrites.

Security gates (in order of evaluation):
- require_initialized: blocks calls before admin setup
- require_not_paused: blocks calls under ContractPaused or EmergencyActive
- caller.require_auth(): Soroban auth engine records caller authorization
- Freelancer identity: caller must equal contract.freelancer (client, arbiter, and third parties all rejected with UnauthorizedRole)
- Contract status: must be Funded or PartiallyFunded; rejects Created, Accepted, Cancelled, Disputed, Completed, Refunded (InvalidState)
- EvidenceEmpty: empty evidence strings rejected (audit trail corruption)
- EvidenceTooLong: evidence capped at 256 bytes
- require_not_finalized: finalized contracts are immutable (AlreadyFinalized)
- IndexOutOfBounds: milestone_index must be within bounds
- MilestoneAlreadyReleased: settled milestones are immutable
- AlreadyRefunded: refunded milestones are immutable

Tests added in contracts/escrow/src/test/access_control.rs:
- Caller-identity gates: client, arbiter, and third-party rejections
- Milestone-state gates: released and refunded milestone rejections
- Contract-state gates: cancelled, disputed, completed, finalized, created
- Evidence-content gates: empty string, 257-byte overlong, 256-byte boundary
- Happy-path tests: funded, partially-funded, overwrite, per-milestone storage
- Emergency-mode blocking (new test: submit_work_evidence_rejects_emergency_mode)

Docs updated:
- README.md: add submit_work_evidence to feature matrix
- docs/escrow/access-control.md: document all 11 security gates with table
- docs/escrow/abi-reference.md: add EvidenceEmpty to error list, expand semantics

Closes #745