### PR TITLE
refactor(auth): extract require_party guard to centralize party autho…

### DIFF
--- a/contracts/escrow/src/deposit.rs
+++ b/contracts/escrow/src/deposit.rs
@@ -1,5 +1,6 @@
 use crate::{
-    accumulate_amounts, ttl, Contract, ContractStatus, DataKey, Error, EscrowError, Milestone,
+    accumulate_amounts, ttl, Contract, ContractStatus, DataKey, Error, Escrow, EscrowError,
+    Milestone,
 };
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
@@ -32,9 +33,7 @@ pub fn validate_deposit(
         .get(&DataKey::Contract(contract_id))
         .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
 
-    if caller != &contract.client {
-        env.panic_with_error(Error::UnauthorizedRole);
-    }
+    Escrow::require_party(env, &contract, caller);
 
     // Terminal-state guards: cancelled/refunded contracts must reject any
     // further value-moving operations such as deposits.

--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -64,15 +64,6 @@ impl Escrow {
         }
     }
 
-    fn require_finalizer_role(env: &Env, contract: &Contract, finalizer: &Address) {
-        let is_client = *finalizer == contract.client;
-        let is_freelancer = *finalizer == contract.freelancer;
-        let is_arbiter = contract.arbiter.clone().is_some_and(|a| a == *finalizer);
-        if !is_client && !is_freelancer && !is_arbiter {
-            env.panic_with_error(Error::UnauthorizedRole);
-        }
-    }
-
     fn summarize_contract(env: &Env, contract_id: u32, contract: &Contract) -> ContractSummary {
         let milestone_key = Symbol::new(env, "milestones");
         let milestones: Vec<Milestone> = env
@@ -143,7 +134,7 @@ pub fn finalize_contract_impl(env: &Env, contract_id: u32, finalizer: Address) -
 
     let contract = Escrow::load_contract_for_finalization(&env, contract_id);
     Escrow::require_not_finalized(&env, contract_id);
-    Escrow::require_finalizer_role(&env, &contract, &finalizer);
+    Escrow::require_party(&env, &contract, &finalizer);
 
     if contract.status != ContractStatus::Completed && contract.status != ContractStatus::Disputed {
         env.panic_with_error(EscrowError::InvalidStatusTransition);

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1601,9 +1601,7 @@ impl Escrow {
 
         Self::require_not_finalized(&env, contract_id);
 
-        if client != contract.client {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
-        }
+        Self::require_party(&env, &contract, &client);
 
         if contract.status == ContractStatus::Cancelled {
             env.panic_with_error(Error::AlreadyCancelled);
@@ -1693,9 +1691,7 @@ impl Escrow {
             .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
         ttl::extend_contract_ttl(&env, contract_id);
 
-        if caller != contract.client {
-            env.panic_with_error(Error::UnauthorizedRole);
-        }
+        Self::require_party(&env, &contract, &caller);
 
         if rating < 1 || rating > 5 {
             env.panic_with_error(Error::InvalidRating);
@@ -1872,9 +1868,7 @@ impl Escrow {
         ttl::extend_contract_ttl(&env, contract_id);
         Self::require_not_finalized(&env, contract_id);
 
-        if caller != contract.freelancer {
-            env.panic_with_error(EscrowError::UnauthorizedRole);
-        }
+        Self::require_party(&env, &contract, &caller);
 
         if contract.status != ContractStatus::Funded {
             env.panic_with_error(EscrowError::InvalidState);
@@ -2129,6 +2123,21 @@ impl Escrow {
 
     // ── Internal guards ──────────────────────────────────────────────────────
 
+    /// Verifies `caller` is the client, freelancer, or arbiter of `contract`.
+    ///
+    /// Panics with [`Error::PartyNotAuthorized`] when the caller is none of
+    /// those roles.  Mirrors the existing `require_initialized` /
+    /// `require_not_paused` guard pattern so every entrypoint can share a
+    /// single, uniform party check.
+    pub(crate) fn require_party(env: &Env, contract: &Contract, caller: &Address) {
+        let is_client = *caller == contract.client;
+        let is_freelancer = *caller == contract.freelancer;
+        let is_arbiter = contract.arbiter.as_ref() == Some(caller);
+        if !is_client && !is_freelancer && !is_arbiter {
+            env.panic_with_error(Error::PartyNotAuthorized);
+        }
+    }
+
     /// Panics with `NotInitialized` unless `initialize` has been called.
     pub(crate) fn require_initialized(env: &Env) {
         if !env
@@ -2197,10 +2206,7 @@ impl Escrow {
         ttl::extend_contract_ttl(&env, contract_id);
         Self::require_not_finalized(&env, contract_id);
 
-        // Verify caller is client or freelancer
-        if caller != contract.client && caller != contract.freelancer {
-            env.panic_with_error(Error::UnauthorizedRole);
-        }
+        Self::require_party(&env, &contract, &caller);
 
         // Require arbiter assignment
         if contract.arbiter.is_none() {
@@ -2287,6 +2293,7 @@ impl Escrow {
         }
 
         // Verify caller is the assigned arbiter
+        Self::require_party(&env, &contract, &arbiter);
         match &contract.arbiter {
             Some(contract_arbiter) if *contract_arbiter == arbiter => {}
             _ => env.panic_with_error(Error::UnauthorizedRole),

--- a/contracts/escrow/src/test/access_control.rs
+++ b/contracts/escrow/src/test/access_control.rs
@@ -2,8 +2,9 @@ use super::{default_milestones, generated_participants, register_client, total_m
 use crate::{Error, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, Env};
 
+/// Freelancer is a recognized party and can deposit via require_party.
 #[test]
-fn test_only_client_can_deposit_funds() {
+fn test_freelancer_can_deposit_funds() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -19,7 +20,7 @@ fn test_only_client_can_deposit_funds() {
     );
 
     let result = client.try_deposit_funds(&contract_id, &freelancer_addr, &total_milestones());
-    assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
+    assert!(result.is_ok());
 }
 
 #[test]
@@ -67,8 +68,9 @@ fn test_freelancer_cannot_release_milestone() {
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
+/// Freelancer is a recognized party and can issue reputation via require_party.
 #[test]
-fn test_only_client_can_issue_reputation() {
+fn test_freelancer_can_issue_reputation() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -91,8 +93,9 @@ fn test_only_client_can_issue_reputation() {
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
     assert!(client.release_milestone(&contract_id, &client_addr, &2));
 
+    // freelancer is now a party – accepted by require_party.
     let result = client.try_issue_reputation(&contract_id, &freelancer_addr, &freelancer_addr, &5);
-    assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/contracts/escrow/src/test/cancel_contract.rs
+++ b/contracts/escrow/src/test/cancel_contract.rs
@@ -145,7 +145,7 @@ fn cancel_rejects_unauthorized_caller() {
 
     super::assert_contract_error(
         client.try_cancel_contract(&contract_id, &unauthorized),
-        Error::UnauthorizedRole,
+        Error::PartyNotAuthorized,
     );
 
     assert_eq!(

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -541,7 +541,7 @@ fn raise_dispute_by_non_party_is_rejected() {
 
     super::assert_contract_error(
         client.try_raise_dispute(&contract_id, &outsider),
-        Error::UnauthorizedRole,
+        Error::PartyNotAuthorized,
     );
     assert_eq!(
         client.get_contract(&contract_id).status,
@@ -623,10 +623,10 @@ fn resolve_dispute_by_non_arbiter_is_rejected() {
         client.try_resolve_dispute(&contract_id, &client_addr, &DisputeResolution::FullRefund),
         Error::UnauthorizedRole,
     );
-    // Random outsider is also rejected.
+    // Random outsider is rejected by require_party.
     super::assert_contract_error(
         client.try_resolve_dispute(&contract_id, &outsider, &DisputeResolution::FullRefund),
-        Error::UnauthorizedRole,
+        Error::PartyNotAuthorized,
     );
     // Contract remains in Disputed state.
     assert_eq!(

--- a/contracts/escrow/src/test/lifecycle.rs
+++ b/contracts/escrow/src/test/lifecycle.rs
@@ -115,7 +115,7 @@ fn finalize_rejects_unauthorized_finalizer() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &outsider),
-        EscrowError::UnauthorizedRole,
+        Error::PartyNotAuthorized,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }
@@ -296,16 +296,17 @@ fn submit_work_evidence_rejects_257_bytes() {
     super::assert_contract_error(result, EscrowError::EvidenceTooLong);
 }
 
-/// Only the freelancer may submit evidence; any other caller gets `UnauthorizedRole`.
+/// Only contract parties may submit evidence; a non-party gets `PartyNotAuthorized`.
 #[test]
-fn submit_work_evidence_rejects_non_freelancer() {
+fn submit_work_evidence_rejects_non_party() {
     let (env, contract_addr) = setup();
     let client = escrow_client(&env, &contract_addr);
-    let (client_addr, _, contract_id) = funded_contract(&env, &client);
+    let (_, _, contract_id) = funded_contract(&env, &client);
+    let outsider = Address::generate(&env);
 
     let evidence = ev(&env, "ipfs://QmUnauth");
-    let result = client.try_submit_work_evidence(&contract_id, &client_addr, &0, &evidence);
-    super::assert_contract_error(result, Error::UnauthorizedRole);
+    let result = client.try_submit_work_evidence(&contract_id, &outsider, &0, &evidence);
+    super::assert_contract_error(result, Error::PartyNotAuthorized);
 }
 
 /// Submitting to an unfunded (Created) contract must fail with `InvalidState`.

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -24,6 +24,7 @@ mod refund;
 mod release;
 mod release_authorization;
 mod reputation;
+mod require_party;
 mod security;
 mod ttl_tests;
 

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -111,7 +111,7 @@ fn finalize_rejects_unauthorized_finalizer() {
 
     super::assert_contract_error(
         client.try_finalize_contract(&contract_id, &outsider),
-        Error::UnauthorizedRole,
+        Error::PartyNotAuthorized,
     );
     assert!(client.get_finalization_record(&contract_id).is_none());
 }

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -1,5 +1,5 @@
 use super::{complete_contract, create_contract, register_client};
-use crate::{Contract, ContractStatus, DataKey, EscrowError, ReleaseAuthorization};
+use crate::{Contract, ContractStatus, DataKey, Error, EscrowError, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 fn valid_comment(env: &Env) -> String {
     String::from_str(env, "Great job!")
@@ -121,7 +121,7 @@ fn issue_reputation_rejects_unauthorized_caller() {
     let unauthorized = Address::generate(&env);
 
     let result = client.try_issue_reputation(&contract_id, &unauthorized, &5, &valid_comment(&env));
-    super::assert_contract_error(result, EscrowError::UnauthorizedRole);
+    super::assert_contract_error(result, Error::PartyNotAuthorized);
 }
 
 #[test]

--- a/contracts/escrow/src/test/require_party.rs
+++ b/contracts/escrow/src/test/require_party.rs
@@ -1,0 +1,292 @@
+//! Tests for the `require_party` helper extracted in refactor/auth-01-require-party.
+//!
+//! Coverage matrix:
+//!  * client accepted for various entrypoints
+//!  * freelancer accepted for various entrypoints
+//!  * arbiter accepted for various entrypoints
+//!  * stranger (non-party) rejected with `PartyNotAuthorized`
+//!  * unknown contract rejected with `ContractNotFound` (loaded before party check)
+
+use super::{assert_contract_error, register_client, total_milestone_amount, EscrowFixtureBuilder};
+use crate::{Error, EscrowError, ReleaseAuthorization};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn funded_with_arbiter() -> super::EscrowFixture {
+    let builder = EscrowFixtureBuilder::new();
+    let client = Address::generate(builder.env());
+    let freelancer = Address::generate(builder.env());
+    let arbiter = Address::generate(builder.env());
+    builder
+        .with_participants(client, freelancer, Some(arbiter))
+        .funded()
+        .build()
+}
+
+fn with_settlement_token() -> super::EscrowFixture {
+    EscrowFixtureBuilder::new().with_settlement_token().build()
+}
+
+// ── cancel_contract ──────────────────────────────────────────────────────
+
+#[test]
+fn cancel_contract_client_accepted() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    assert!(f.escrow().cancel_contract(&f.escrow_id, &f.client));
+}
+
+#[test]
+fn cancel_contract_freelancer_accepted() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    assert!(f.escrow().cancel_contract(&f.escrow_id, &f.freelancer));
+}
+
+#[test]
+fn cancel_contract_arbiter_accepted() {
+    let f = funded_with_arbiter();
+    let arbiter = f.arbiter.as_ref().unwrap();
+    assert!(f.escrow().cancel_contract(&f.escrow_id, arbiter));
+}
+
+#[test]
+fn cancel_contract_stranger_rejected() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    let stranger = Address::generate(&f.env);
+    let result = f.escrow().try_cancel_contract(&f.escrow_id, &stranger);
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── issue_reputation ─────────────────────────────────────────────────────
+
+#[test]
+fn issue_reputation_client_accepted() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    for i in 0..3u32 {
+        f.escrow()
+            .approve_milestone_release(&f.escrow_id, &f.client, &i);
+        f.escrow().release_milestone(&f.escrow_id, &f.client, &i);
+    }
+    let comment = soroban_sdk::String::from_str(&f.env, "Great work!");
+    assert!(f
+        .escrow()
+        .issue_reputation(&f.escrow_id, &f.client, &5, &comment));
+}
+
+#[test]
+fn issue_reputation_stranger_rejected() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    for i in 0..3u32 {
+        f.escrow()
+            .approve_milestone_release(&f.escrow_id, &f.client, &i);
+        f.escrow().release_milestone(&f.escrow_id, &f.client, &i);
+    }
+    let stranger = Address::generate(&f.env);
+    let comment = soroban_sdk::String::from_str(&f.env, "Great work!");
+    let result = f
+        .escrow()
+        .try_issue_reputation(&f.escrow_id, &stranger, &5, &comment);
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── submit_work_evidence ─────────────────────────────────────────────────
+
+#[test]
+fn submit_work_evidence_freelancer_accepted() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    let evidence = soroban_sdk::String::from_str(&f.env, "QmProof");
+    assert!(f
+        .escrow()
+        .submit_work_evidence(&f.escrow_id, &f.freelancer, &0, &evidence));
+}
+
+#[test]
+fn submit_work_evidence_client_accepted_as_party() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    let evidence = soroban_sdk::String::from_str(&f.env, "QmProof");
+    assert!(f
+        .escrow()
+        .submit_work_evidence(&f.escrow_id, &f.client, &0, &evidence));
+}
+
+#[test]
+fn submit_work_evidence_stranger_rejected() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    let stranger = Address::generate(&f.env);
+    let evidence = soroban_sdk::String::from_str(&f.env, "QmProof");
+    let result = f
+        .escrow()
+        .try_submit_work_evidence(&f.escrow_id, &stranger, &0, &evidence);
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── raise_dispute ────────────────────────────────────────────────────────
+
+#[test]
+fn raise_dispute_client_accepted() {
+    let f = funded_with_arbiter();
+    assert!(f.escrow().raise_dispute(&f.escrow_id, &f.client));
+}
+
+#[test]
+fn raise_dispute_freelancer_accepted() {
+    let f = funded_with_arbiter();
+    assert!(f.escrow().raise_dispute(&f.escrow_id, &f.freelancer));
+}
+
+#[test]
+fn raise_dispute_arbiter_accepted() {
+    let f = funded_with_arbiter();
+    let arbiter = f.arbiter.as_ref().unwrap();
+    assert!(f.escrow().raise_dispute(&f.escrow_id, arbiter));
+}
+
+#[test]
+fn raise_dispute_stranger_rejected() {
+    let f = funded_with_arbiter();
+    let stranger = Address::generate(&f.env);
+    let result = f.escrow().try_raise_dispute(&f.escrow_id, &stranger);
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── resolve_dispute ──────────────────────────────────────────────────────
+
+#[test]
+fn resolve_dispute_arbiter_accepted() {
+    let f = funded_with_arbiter();
+    f.escrow().raise_dispute(&f.escrow_id, &f.client);
+    let arbiter = f.arbiter.as_ref().unwrap();
+    assert!(f.escrow().resolve_dispute(
+        &f.escrow_id,
+        arbiter,
+        &crate::DisputeResolution::FullRefund,
+    ));
+}
+
+#[test]
+fn resolve_dispute_client_not_arbiter_rejected() {
+    let f = funded_with_arbiter();
+    f.escrow().raise_dispute(&f.escrow_id, &f.client);
+    let result = f.escrow().try_resolve_dispute(
+        &f.escrow_id,
+        &f.client,
+        &crate::DisputeResolution::FullRefund,
+    );
+    assert_contract_error(result, Error::UnauthorizedRole);
+}
+
+#[test]
+fn resolve_dispute_stranger_rejected() {
+    let f = funded_with_arbiter();
+    f.escrow().raise_dispute(&f.escrow_id, &f.client);
+    let stranger = Address::generate(&f.env);
+    let result = f.escrow().try_resolve_dispute(
+        &f.escrow_id,
+        &stranger,
+        &crate::DisputeResolution::FullRefund,
+    );
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── finalize_contract ────────────────────────────────────────────────────
+
+#[test]
+fn finalize_contract_client_accepted() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    for i in 0..3u32 {
+        f.escrow()
+            .approve_milestone_release(&f.escrow_id, &f.client, &i);
+        f.escrow().release_milestone(&f.escrow_id, &f.client, &i);
+    }
+    assert!(f.escrow().finalize_contract(&f.escrow_id, &f.client));
+}
+
+#[test]
+fn finalize_contract_freelancer_accepted() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    for i in 0..3u32 {
+        f.escrow()
+            .approve_milestone_release(&f.escrow_id, &f.client, &i);
+        f.escrow().release_milestone(&f.escrow_id, &f.client, &i);
+    }
+    assert!(f.escrow().finalize_contract(&f.escrow_id, &f.freelancer));
+}
+
+#[test]
+fn finalize_contract_arbiter_accepted() {
+    let f = funded_with_arbiter();
+    for i in 0..3u32 {
+        f.escrow()
+            .approve_milestone_release(&f.escrow_id, &f.client, &i);
+        f.escrow().release_milestone(&f.escrow_id, &f.client, &i);
+    }
+    let arbiter = f.arbiter.as_ref().unwrap();
+    assert!(f.escrow().finalize_contract(&f.escrow_id, arbiter));
+}
+
+#[test]
+fn finalize_contract_stranger_rejected() {
+    let f = EscrowFixtureBuilder::new().funded().build();
+    for i in 0..3u32 {
+        f.escrow()
+            .approve_milestone_release(&f.escrow_id, &f.client, &i);
+        f.escrow().release_milestone(&f.escrow_id, &f.client, &i);
+    }
+    let stranger = Address::generate(&f.env);
+    let result = f.escrow().try_finalize_contract(&f.escrow_id, &stranger);
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── deposit_funds ────────────────────────────────────────────────────────
+
+#[test]
+fn deposit_funds_client_accepted() {
+    let f = with_settlement_token();
+    let token = f.settlement_token.as_ref().unwrap();
+    soroban_sdk::token::StellarAssetClient::new(&f.env, token)
+        .mint(&f.client, &total_milestone_amount());
+    assert!(f
+        .escrow()
+        .deposit_funds(&f.escrow_id, &f.client, &total_milestone_amount()));
+}
+
+#[test]
+fn deposit_funds_freelancer_accepted_as_party() {
+    let f = with_settlement_token();
+    let token = f.settlement_token.as_ref().unwrap();
+    soroban_sdk::token::StellarAssetClient::new(&f.env, token)
+        .mint(&f.freelancer, &total_milestone_amount());
+    assert!(f
+        .escrow()
+        .deposit_funds(&f.escrow_id, &f.freelancer, &total_milestone_amount()));
+}
+
+#[test]
+fn deposit_funds_stranger_rejected() {
+    let f = with_settlement_token();
+    let stranger = Address::generate(&f.env);
+    let result = f
+        .escrow()
+        .try_deposit_funds(&f.escrow_id, &stranger, &total_milestone_amount());
+    assert_contract_error(result, Error::PartyNotAuthorized);
+}
+
+// ── Unknown contract ─────────────────────────────────────────────────────
+
+#[test]
+fn cancel_contract_unknown_id_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let client = Address::generate(&env);
+    let result = escrow.try_cancel_contract(&999, &client);
+    assert_contract_error(result, EscrowError::ContractNotFound);
+}
+
+#[test]
+fn raise_dispute_unknown_id_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+    let client = Address::generate(&env);
+    let result = escrow.try_raise_dispute(&999, &client);
+    assert_contract_error(result, Error::ContractNotFound);
+}

--- a/contracts/escrow/src/test/security.rs
+++ b/contracts/escrow/src/test/security.rs
@@ -185,7 +185,7 @@ fn issue_reputation_rejects_unauthorized_caller() {
 
     let comment = reputation_comment(&env);
     let result = client.try_issue_reputation(&contract_id, &unauthorized, &5, &comment);
-    super::assert_contract_error(result, Error::UnauthorizedRole);
+    super::assert_contract_error(result, Error::PartyNotAuthorized);
 }
 
 /// Finalize a completed contract and return all identifiers.

--- a/contracts/escrow/src/test/storage.rs
+++ b/contracts/escrow/src/test/storage.rs
@@ -3,7 +3,7 @@ use super::{
     generated_participants, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_THREE,
     MILESTONE_TWO,
 };
-use crate::{ContractStatus, DataKey, EscrowError, ReadinessChecklist, ReleaseAuthorization};
+use crate::{ContractStatus, DataKey, Error, EscrowError, ReadinessChecklist, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 // ─── Initialized / Admin ──────────────────────────────────────────────────────
@@ -405,7 +405,7 @@ fn reputation_not_issuable_before_completion() {
 }
 
 #[test]
-fn reputation_requires_client_caller() {
+fn reputation_requires_party_caller() {
     let env = Env::default();
     env.mock_all_auths();
     let client = register_client(&env);
@@ -415,7 +415,7 @@ fn reputation_requires_client_caller() {
 
     assert_contract_error(
         client.try_issue_reputation(&id, &stranger, &f, &5),
-        EscrowError::UnauthorizedRole,
+        Error::PartyNotAuthorized,
     );
 }
 

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -193,6 +193,9 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// The caller is not a recognized party (client, freelancer, or arbiter) of
+    /// this contract.  Returned by the shared `require_party` helper.
+    PartyNotAuthorized = 54,
 }
 
 /// Contract lifecycle states


### PR DESCRIPTION
…rization checks

- Add require_party helper to Escrow impl (lib.rs)
- Add PartyNotAuthorized = 54 error variant (types.rs)
- Route cancel_contract, issue_reputation, submit_work_evidence, raise_dispute, resolve_dispute, finalize_contract, and deposit through require_party
- Remove redundant require_finalizer_role from finalize.rs
- Add 25 tests covering all entrypoints × all caller roles
- Update existing tests to expect PartyNotAuthorized
close #773