### PR TITLE
refactor(reputation): type the reputation failures

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1737,7 +1737,7 @@ impl Escrow {
         let pending_key = DataKey::PendingReputationCredits(contract.freelancer.clone());
         let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
         if pending <= 0 {
-            env.panic_with_error(Error::InvalidState);
+            env.panic_with_error(Error::NoPendingCredit);
         }
         env.storage().persistent().set(&pending_key, &(pending - 1));
 

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -193,6 +193,10 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// The work evidence string is empty.
+    EvidenceEmpty = 54,
+    /// No pending reputation credit is available for this contract (contract must complete before reputation can be issued).
+    NoPendingCredit = 55,
 }
 
 /// Contract lifecycle states


### PR DESCRIPTION
Closes #772 
- Map 'pending credit exhausted' panic to NoPendingCredit error code
- Add EvidenceEmpty and NoPendingCredit error discriminants (codes 54 and 55)
- Replace InvalidState with NoPendingCredit for reputation credit validation
- Preserves exact failure conditions, enables stable testable failures

Closes #772