### PR TITLE
test(arbiter): cover overflow and saturation at extreme values (Issue #890)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2297,9 +2297,16 @@ impl Escrow {
             dispute::resolution_payouts(&contract, &resolution)
                 .unwrap_or_else(|e| env.panic_with_error(e));
 
-        // Update contract accounting
-        contract.refunded_amount += client_payout;
-        contract.released_amount += freelancer_payout;
+        // Update contract accounting — use checked arithmetic to guard against
+        // overflow at extreme values (Issue #890).
+        contract.refunded_amount = contract
+            .refunded_amount
+            .checked_add(client_payout)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+        contract.released_amount = contract
+            .released_amount
+            .checked_add(freelancer_payout)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
 
         // Set final status
         contract.status = dispute::final_status_after_resolution(&contract);

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -748,7 +748,221 @@ fn raise_dispute_on_refunded_contract_is_rejected() {
     );
 }
 
-/// Resolving after the contract has been finalized is rejected with AlreadyFinalized.
+// ---------------------------------------------------------------------------
+// Extreme-value tests for arbiter arithmetic overflow (Issue #890)
+// ---------------------------------------------------------------------------
+
+/// FullRefund with i128::MAX available must succeed and route all to client.
+#[test]
+fn resolution_payouts_full_refund_with_i128_max_ok() {
+    let env = make_env();
+    let contract = payout_contract(&env, i128::MAX, 0, 0);
+    let result = resolution_payouts(&contract, &DisputeResolution::FullRefund);
+    assert_eq!(result, Ok((i128::MAX, 0)));
+}
+
+/// FullPayout with i128::MAX available must succeed and route all to freelancer.
+#[test]
+fn resolution_payouts_full_payout_with_i128_max_ok() {
+    let env = make_env();
+    let contract = payout_contract(&env, i128::MAX, 0, 0);
+    let result = resolution_payouts(&contract, &DisputeResolution::FullPayout);
+    assert_eq!(result, Ok((0, i128::MAX)));
+}
+
+/// PartialRefund with available so large that `available * 30` would overflow
+/// must return PotentialOverflow.
+/// i128::MAX / 30 gives a safe upper bound; anything above overflows mul.
+#[test]
+fn resolution_payouts_partial_refund_rejects_overflowing_mul() {
+    let env = make_env();
+    // available = i128::MAX → mul(30) overflows i128
+    let contract = payout_contract(&env, i128::MAX, 0, 0);
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::PartialRefund),
+        Err(Error::PotentialOverflow)
+    );
+}
+
+/// PartialRefund with the maximum available value that does NOT overflow mul(30).
+/// max_safe = i128::MAX / 30  (division floors, so mul(30) is safe).
+#[test]
+fn resolution_payouts_partial_refund_at_max_safe_available() {
+    let env = make_env();
+    let max_safe = i128::MAX / 30; // largest value where mul(30) won't overflow
+    let contract = payout_contract(&env, max_safe, 0, 0);
+    // freelancer = floor(max_safe * 30 / 100) = floor(i128::MAX / 100)
+    let result = resolution_payouts(&contract, &DisputeResolution::PartialRefund)
+        .expect("PartialRefund should succeed at max_safe available");
+    let (client, freelancer) = result;
+    assert_eq!(client + freelancer, max_safe, "sum must equal available");
+    let expected_freelancer = (max_safe * 30) / 100;
+    assert_eq!(freelancer, expected_freelancer);
+    assert_eq!(client, max_safe - expected_freelancer);
+}
+
+/// Split with components whose sum exceeds i128::MAX must return PotentialOverflow.
+#[test]
+fn resolution_payouts_split_rejects_overflowing_sum_extreme() {
+    let env = make_env();
+    // Both legs individually fit, but their sum overflows i128.
+    let split = DisputeSplit {
+        client_amount: i128::MAX,
+        freelancer_amount: 1,
+    };
+    let contract = payout_contract(&env, i128::MAX, 0, 0);
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(split)),
+        Err(Error::PotentialOverflow)
+    );
+    // Symmetric: freelancer_amount = i128::MAX, client_amount = 1
+    let split = DisputeSplit {
+        client_amount: 1,
+        freelancer_amount: i128::MAX,
+    };
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(split)),
+        Err(Error::PotentialOverflow)
+    );
+}
+
+/// Split with the maximum sum that exactly fits i128::MAX matches available
+/// and must succeed.
+#[test]
+fn resolution_payouts_split_at_i128_max_sum_succeeds() {
+    let env = make_env();
+    // client_amount = i128::MAX / 2, freelancer_amount = i128::MAX - (i128::MAX / 2)
+    // Their sum is exactly i128::MAX, matching available.
+    let client_half = i128::MAX / 2;
+    let freelancer_half = i128::MAX - client_half;
+    let split = DisputeSplit {
+        client_amount: client_half,
+        freelancer_amount: freelancer_half,
+    };
+    let contract = payout_contract(&env, i128::MAX, 0, 0);
+    let result = resolution_payouts(&contract, &DisputeResolution::Split(split))
+        .expect("Split at i128::MAX sum should succeed");
+    assert_eq!(result, (client_half, freelancer_half));
+    assert_eq!(client_half + freelancer_half, i128::MAX);
+}
+
+/// Split with zero available and zero amounts succeeds.
+#[test]
+fn resolution_payouts_split_zero_available_zero_split_ok() {
+    let env = make_env();
+    let split = DisputeSplit {
+        client_amount: 0,
+        freelancer_amount: 0,
+    };
+    let contract = payout_contract(&env, 0, 0, 0);
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::Split(split)),
+        Ok((0, 0))
+    );
+}
+
+/// Available calculation near i128::MAX with non-zero released and refunded.
+/// Verifies subtraction edge cases.
+#[test]
+fn resolution_payouts_available_near_max_with_released_refunded() {
+    let env = make_env();
+    // funded = i128::MAX - 1, released = 1, refunded = 0 => available = i128::MAX - 2
+    let funded = i128::MAX - 1;
+    let released = 1;
+    let refunded = 0;
+    let contract = payout_contract(&env, funded, released, refunded);
+    let expected_available = funded - released - refunded;
+    let result = resolution_payouts(&contract, &DisputeResolution::FullRefund)
+        .expect("FullRefund should succeed");
+    assert_eq!(result, (expected_available, 0));
+
+    // FullPayout
+    let result = resolution_payouts(&contract, &DisputeResolution::FullPayout)
+        .expect("FullPayout should succeed");
+    assert_eq!(result, (0, expected_available));
+}
+
+/// Available calculation with i128::MIN involvement — negative intermediate must
+/// be caught by checked_sub before reaching the final check.
+#[test]
+fn resolution_payouts_rejects_negative_intermediate_subtraction() {
+    let env = make_env();
+    // funded < released, so first checked_sub fails
+    let contract = payout_contract(&env, 0, i128::MAX, 0);
+    assert_eq!(
+        resolution_payouts(&contract, &DisputeResolution::FullRefund),
+        Err(Error::AccountingInvariantViolated)
+    );
+}
+
+/// Integration: resolve_dispute with large (but safe) values must not overflow.
+/// This exercises the checked_add guards added to the entrypoint (Issue #890).
+#[test]
+fn resolve_dispute_large_amount_flow_succeeds() {
+    let env = make_env();
+    let client = make_client(&env);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let large_amt = 1_000_000_000_000_000i128;
+    let milestones = soroban_sdk::vec![&env, large_amt];
+    let escrow_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    client.deposit_funds(&escrow_id, &client_addr, &large_amt);
+    client.raise_dispute(&escrow_id, &client_addr);
+
+    // FullPayout adds available all to released_amount.
+    assert!(client.resolve_dispute(
+        &escrow_id,
+        &arbiter_addr,
+        &DisputeResolution::FullPayout,
+    ));
+    let contract = client.get_contract(&escrow_id);
+    assert_eq!(contract.released_amount, large_amt);
+    assert_eq!(contract.status, ContractStatus::Completed);
+}
+
+/// Integration: resolve_dispute with FullRefund at large (but safe) values
+/// must correctly update refunded_amount without overflow.
+#[test]
+fn resolve_dispute_full_refund_large_amounts() {
+    let env = make_env();
+    let client = make_client(&env);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let large = 500_000_000_000_000_000i128;
+    let milestones = soroban_sdk::vec![&env, large];
+    let escrow_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    client.deposit_funds(&escrow_id, &client_addr, &large);
+    client.raise_dispute(&escrow_id, &client_addr);
+
+    assert!(client.resolve_dispute(
+        &escrow_id,
+        &arbiter_addr,
+        &DisputeResolution::FullRefund,
+    ));
+    let contract = client.get_contract(&escrow_id);
+    assert_eq!(contract.refunded_amount, large);
+    assert_eq!(contract.status, ContractStatus::Refunded);
+    assert_eq!(
+        contract.released_amount + contract.refunded_amount,
+        contract.funded_amount
+    );
+}
+
+/// Resolve after finalize is rejected with AlreadyFinalized.
 #[test]
 fn resolve_after_finalize_is_rejected() {
     let env = make_env();


### PR DESCRIPTION
## Summary

Fixes unchecked arithmetic in the dispute resolution payout path that could overflow at extreme `i128` values (Issue #890).

## Changes

### Bug fix: `resolve_dispute` entrypoint (`lib.rs`)

The `contract.refunded_amount += client_payout` and `contract.released_amount += freelancer_payout` lines used raw `+=` which could silently wrap around at extreme values. Replaced with `checked_add()`, panicking with `PotentialOverflow` — consistent with the pattern used elsewhere in the contract.

### Tests: extreme-value coverage (`dispute.rs`)

Added 11 new tests exercising arbiter arithmetic at boundary conditions:

| Test | What it covers |
|------|----------------|
| `resolution_payouts_full_refund_with_i128_max_ok` | FullRefund with i128::MAX available |
| `resolution_payouts_full_payout_with_i128_max_ok` | FullPayout with i128::MAX available |
| `resolution_payouts_partial_refund_rejects_overflowing_mul` | PartialRefund overflow on `available * 30` |
| `resolution_payouts_partial_refund_at_max_safe_available` | PartialRefund at max-safe boundary (i128::MAX / 30) |
| `resolution_payouts_split_rejects_overflowing_sum_extreme` | Split overflow on `client + freelancer` sum |
| `resolution_payouts_split_at_i128_max_sum_succeeds` | Split with sum exactly == i128::MAX |
| `resolution_payouts_split_zero_available_zero_split_ok` | Split with zero amounts |
| `resolution_payouts_available_near_max_with_released_refunded` | Available calc near i128::MAX with non-zero released/refunded |
| `resolution_payouts_rejects_negative_intermediate_subtraction` | Negative intermediate caught by checked_sub |
| `resolve_dispute_large_amount_flow_succeeds` | Integration: FullPayout with large amounts |
| `resolve_dispute_full_refund_large_amounts` | Integration: FullRefund with large amounts |

## Edge cases covered
- `i128` extremes: i128::MAX, i128::MAX / 30, i128::MAX / 2
- Sum near max: client+freelancer approaching i128::MAX
- Subtraction near zero: funded < released case
- Checked multiplication overflow
- Checked addition overflow
- Conservation invariant at every boundary

## Related issue

Closes #890