### PR TITLE
feat(escrow): make escrow and milestone limits admin-configurable

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -21,11 +21,26 @@ pub use ttl::{
 
 // ─── Bounds constants ─────────────────────────────────────────────────────────
 
-/// Maximum number of milestones allowed per contract.
-pub const MAX_MILESTONES: u32 = 10;
+/// Default maximum number of milestones allowed per contract.
+pub const DEFAULT_MAX_MILESTONES: u32 = 10;
 
-/// Hard cap on the total escrow value per contract, in stroops.
-pub const MAX_TOTAL_ESCROW_STROOPS: i128 = 10_000_000_000_000;
+/// Default hard cap on the total escrow value per contract, in stroops.
+pub const DEFAULT_MAX_TOTAL_ESCROW_STROOPS: i128 = 10_000_000_000_000;
+
+/// Backward-compatible alias for the default max milestones.
+pub const MAX_MILESTONES: u32 = DEFAULT_MAX_MILESTONES;
+
+/// Backward-compatible alias for the default max escrow stroops.
+pub const MAX_TOTAL_ESCROW_STROOPS: i128 = DEFAULT_MAX_TOTAL_ESCROW_STROOPS;
+
+/// Absolute minimum for the max milestones setting.
+pub const MIN_MAX_MILESTONES: u32 = 1;
+
+/// Absolute maximum for the max milestones setting.
+pub const MAX_MAX_MILESTONES: u32 = 100;
+
+/// Absolute minimum for the max escrow stroops setting (0.01 XLM).
+pub const MIN_MAX_ESCROW_STROOPS: i128 = 1_000_000;
 
 pub const MAINNET_PROTOCOL_VERSION: u32 = 1u32;
 pub const MAINNET_MAX_TOTAL_ESCROW_PER_CONTRACT_STROOPS: i128 = 1_000_000_000_000_000i128;
@@ -297,6 +312,86 @@ impl Escrow {
             .unwrap_or_default()
     }
 
+    // ─── Configurable limits ──────────────────────────────────────────────────
+
+    /// Returns the effective max milestones, falling back to the default.
+    fn effective_max_milestones(env: &Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MaxMilestones)
+            .unwrap_or(DEFAULT_MAX_MILESTONES)
+    }
+
+    /// Returns the effective max escrow stroops, falling back to the default.
+    fn effective_max_escrow_stroops(env: &Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MaxEscrowStroops)
+            .unwrap_or(DEFAULT_MAX_TOTAL_ESCROW_STROOPS)
+    }
+
+    /// Set the max milestones limit. Admin only. Rejects out-of-range values.
+    pub fn set_max_milestones(env: Env, max_milestones: u32) -> bool {
+        Self::require_initialized(&env);
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+        admin.require_auth();
+
+        if max_milestones < MIN_MAX_MILESTONES || max_milestones > MAX_MAX_MILESTONES {
+            env.panic_with_error(EscrowError::LimitOutOfRange);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MaxMilestones, &max_milestones);
+
+        env.events().publish(
+            (symbol_short!("limits"), Symbol::new(&env, "max_milestones")),
+            (max_milestones, env.ledger().timestamp()),
+        );
+        true
+    }
+
+    /// Returns the current max milestones limit (or the default if not set).
+    pub fn get_max_milestones(env: Env) -> u32 {
+        Self::effective_max_milestones(&env)
+    }
+
+    /// Set the max escrow stroops limit. Admin only. Rejects out-of-range values.
+    pub fn set_max_escrow_stroops(env: Env, max_escrow_stroops: i128) -> bool {
+        Self::require_initialized(&env);
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+        admin.require_auth();
+
+        if max_escrow_stroops < MIN_MAX_ESCROW_STROOPS
+            || max_escrow_stroops > MAINNET_MAX_TOTAL_ESCROW_PER_CONTRACT_STROOPS
+        {
+            env.panic_with_error(EscrowError::LimitOutOfRange);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MaxEscrowStroops, &max_escrow_stroops);
+
+        env.events().publish(
+            (symbol_short!("limits"), Symbol::new(&env, "max_escrow")),
+            (max_escrow_stroops, env.ledger().timestamp()),
+        );
+        true
+    }
+
+    /// Returns the current max escrow stroops limit (or the default if not set).
+    pub fn get_max_escrow_stroops(env: Env) -> i128 {
+        Self::effective_max_escrow_stroops(&env)
+    }
+
     // ─── Contract lifecycle ───────────────────────────────────────────────────
 
     /// Create a new escrow contract. Blocked when paused.
@@ -315,7 +410,8 @@ impl Escrow {
         if milestone_amounts.is_empty() {
             env.panic_with_error(EscrowError::EmptyMilestones);
         }
-        if milestone_amounts.len() > MAX_MILESTONES {
+        let max_milestones = Self::effective_max_milestones(&env);
+        if milestone_amounts.len() > max_milestones {
             env.panic_with_error(EscrowError::TooManyMilestones);
         }
 
@@ -328,7 +424,8 @@ impl Escrow {
             total = safe_add_amounts(total, amt)
                 .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
         }
-        if total > MAX_TOTAL_ESCROW_STROOPS {
+        let max_escrow = Self::effective_max_escrow_stroops(&env);
+        if total > max_escrow {
             env.panic_with_error(EscrowError::InvalidMilestoneAmount);
         }
 

--- a/contracts/escrow/src/test/configurable_limits.rs
+++ b/contracts/escrow/src/test/configurable_limits.rs
@@ -1,0 +1,257 @@
+use super::register_client;
+use crate::{
+    EscrowError, Escrow, EscrowClient, MAX_MAX_MILESTONES, DEFAULT_MAX_TOTAL_ESCROW_STROOPS,
+    MIN_MAX_ESCROW_STROOPS,
+};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+fn setup_initialized() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    assert!(client.initialize(&admin));
+    (env, contract_id, admin)
+}
+
+// ─── Default values ──────────────────────────────────────────────────────────
+
+#[test]
+fn max_milestones_returns_default_before_any_set() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_max_milestones(), 10);
+}
+
+#[test]
+fn max_escrow_stroops_returns_default_before_any_set() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_max_escrow_stroops(), DEFAULT_MAX_TOTAL_ESCROW_STROOPS);
+}
+
+// ─── Setting limits ─────────────────────────────────────────────────────────
+
+#[test]
+fn admin_can_set_max_milestones_within_bounds() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_milestones(&20));
+    assert_eq!(client.get_max_milestones(), 20);
+}
+
+#[test]
+fn admin_can_set_max_escrow_stroops_within_bounds() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let new_limit: i128 = 5_000_000_000_000;
+    assert!(client.set_max_escrow_stroops(&new_limit));
+    assert_eq!(client.get_max_escrow_stroops(), new_limit);
+}
+
+// ─── Out-of-range rejection ──────────────────────────────────────────────────
+
+#[test]
+fn set_max_milestones_rejects_zero() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    super::assert_contract_error(
+        client.try_set_max_milestones(&0),
+        EscrowError::LimitOutOfRange,
+    );
+}
+
+#[test]
+fn set_max_milestones_rejects_above_maximum() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    super::assert_contract_error(
+        client.try_set_max_milestones(&(MAX_MAX_MILESTONES + 1)),
+        EscrowError::LimitOutOfRange,
+    );
+}
+
+#[test]
+fn set_max_escrow_stroops_rejects_below_minimum() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    super::assert_contract_error(
+        client.try_set_max_escrow_stroops(&0),
+        EscrowError::LimitOutOfRange,
+    );
+}
+
+#[test]
+fn set_max_escrow_stroops_rejects_above_mainnet_cap() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let too_high: i128 = 1_000_000_000_000_000i128 + 1;
+    super::assert_contract_error(
+        client.try_set_max_escrow_stroops(&too_high),
+        EscrowError::LimitOutOfRange,
+    );
+}
+
+// ─── Requires initialization ─────────────────────────────────────────────────
+
+#[test]
+fn set_max_milestones_requires_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    super::assert_contract_error(
+        client.try_set_max_milestones(&20),
+        EscrowError::NotInitialized,
+    );
+}
+
+#[test]
+fn set_max_escrow_stroops_requires_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    super::assert_contract_error(
+        client.try_set_max_escrow_stroops(&5_000_000_000_000),
+        EscrowError::NotInitialized,
+    );
+}
+
+// ─── create_contract respects configurable limits ────────────────────────────
+
+#[test]
+fn create_contract_respects_lower_max_milestones() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_milestones(&2));
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 100_i128, 200_i128, 300_i128];
+    super::assert_contract_error(
+        client.try_create_contract(&client_addr, &freelancer_addr, &milestones),
+        EscrowError::TooManyMilestones,
+    );
+}
+
+#[test]
+fn create_contract_respects_higher_max_milestones() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_milestones(&20));
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![
+        &env, 100_i128, 100_i128, 100_i128, 100_i128, 100_i128,
+        100_i128, 100_i128, 100_i128, 100_i128, 100_i128,
+        100_i128, 100_i128, 100_i128, 100_i128, 100_i128,
+    ];
+    let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.milestones.len(), 15);
+}
+
+#[test]
+fn create_contract_respects_lower_max_escrow() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_escrow_stroops(&500));
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 300_i128, 300_i128];
+    super::assert_contract_error(
+        client.try_create_contract(&client_addr, &freelancer_addr, &milestones),
+        EscrowError::InvalidMilestoneAmount,
+    );
+}
+
+#[test]
+fn create_contract_respects_higher_max_escrow() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_escrow_stroops(&50_000_000_000_000));
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![&env, 20_000_000_000_000_i128, 20_000_000_000_000_i128];
+    let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.milestones.len(), 2);
+}
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+#[test]
+fn set_max_milestones_at_boundary_succeeds() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_milestones(&1));
+    assert_eq!(client.get_max_milestones(), 1);
+    assert!(client.set_max_milestones(&MAX_MAX_MILESTONES));
+    assert_eq!(client.get_max_milestones(), MAX_MAX_MILESTONES);
+}
+
+#[test]
+fn set_max_escrow_at_minimum_boundary_succeeds() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_escrow_stroops(&MIN_MAX_ESCROW_STROOPS));
+    assert_eq!(client.get_max_escrow_stroops(), MIN_MAX_ESCROW_STROOPS);
+}
+
+#[test]
+fn default_limits_apply_when_not_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = vec![
+        &env, 100_i128, 100_i128, 100_i128, 100_i128, 100_i128,
+        100_i128, 100_i128, 100_i128, 100_i128, 100_i128,
+    ];
+    let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn set_max_milestones_event_is_emitted() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_milestones(&15));
+    assert_eq!(client.get_max_milestones(), 15);
+}
+
+#[test]
+fn set_max_escrow_stroops_event_is_emitted() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    assert!(client.set_max_escrow_stroops(&25_000_000_000_000));
+    assert_eq!(client.get_max_escrow_stroops(), 25_000_000_000_000);
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -8,6 +8,7 @@ use crate::{Escrow, EscrowClient, EscrowError};
 
 mod pause_controls;
 mod emergency_controls;
+mod configurable_limits;
 
 // ─── Shared constants ─────────────────────────────────────────────────────────
 

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -23,6 +23,9 @@ pub enum DataKey {
     ProtocolFeeBps,
     AccumulatedProtocolFees,
     ReadinessChecklist,
+    // Configurable limits
+    MaxMilestones,
+    MaxEscrowStroops,
 }
 
 #[contracterror]
@@ -71,6 +74,8 @@ pub enum EscrowError {
     AmountExceedsMaximum = 38,
     InvalidStroopPrecision = 39,
     ExceedsContractMaximum = 40,
+    // Configurable limits
+    LimitOutOfRange = 41,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary
- Closes #911
- Closes #916

Replace hard-coded `MAX_MILESTONES` and `MAX_TOTAL_ESCROW_STROOPS` constants with admin-configurable parameters stored in persistent storage.

## Changes
- **`types.rs`**: Added `DataKey::MaxMilestones`, `DataKey::MaxEscrowStroops` storage keys and `EscrowError::LimitOutOfRange` error variant
- **`lib.rs`**: 
  - Renamed constants to `DEFAULT_MAX_MILESTONES` / `DEFAULT_MAX_TOTAL_ESCROW_STROOPS` with backward-compatible aliases
  - Added bounds constants: `MIN_MAX_MILESTONES` (1), `MAX_MAX_MILESTONES` (100), `MIN_MAX_ESCROW_STROOPS` (0.01 XLM)
  - Added admin-only `set_max_milestones` / `get_max_milestones` functions (bounds: 1–100)
  - Added admin-only `set_max_escrow_stroops` / `get_max_escrow_stroops` functions (bounds: 0.01 XLM – 1M XLM)
  - `create_contract` now reads limits from storage instead of hard-coded constants
  - Both setters emit audit events via `limits` topic
- **`test/configurable_limits.rs`**: Comprehensive test suite (15 tests) covering:
  - Default values when no limit is set
  - Admin set/get within bounds
  - Out-of-range value rejection (too low, too high)
  - Requires initialization
  - Integration with `create_contract` (lower/higher limits)
  - Boundary value edge cases

## Defaults preserve current behaviour
- Default max milestones: **10** (same as before)
- Default max escrow: **10,000,000,000,000 stroops** (same as before)

## Admin auth
Both setters require admin authentication via `require_auth()` and will reject calls from non-admin addresses.