### PR TITLE
Fix: Bound-check authorization inputs

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -609,6 +609,9 @@ impl Escrow {
         caller: Address,
         milestone_index: u32,
     ) -> bool {
+        if milestone_index >= MAX_MILESTONES {
+            env.panic_with_error(Error::IndexOutOfBounds);
+        }
         Self::require_not_paused(&env);
         Self::require_not_finalized(&env, contract_id);
         approvals::approve_milestone(&env, contract_id, milestone_index, &caller)
@@ -1390,6 +1393,9 @@ impl Escrow {
         contract_id: u32,
         milestone_index: u32,
     ) -> Option<MilestoneApprovals> {
+        if milestone_index >= MAX_MILESTONES {
+            env.panic_with_error(Error::IndexOutOfBounds);
+        }
         let approval_key = DataKey::MilestoneApprovals(contract_id, milestone_index);
         let approvals = env.storage().temporary().get(&approval_key);
         if approvals.is_some() {
@@ -1408,6 +1414,9 @@ impl Escrow {
     /// `None` when no live approval exists,
     /// distinguishing "never approved" from "approved and evicted".
     pub fn get_approval_deadline(env: Env, contract_id: u32, milestone_index: u32) -> Option<u32> {
+        if milestone_index >= MAX_MILESTONES {
+            env.panic_with_error(Error::IndexOutOfBounds);
+        }
         let approval_key = DataKey::MilestoneApprovals(contract_id, milestone_index);
         if !env.storage().temporary().has(&approval_key) {
             return None;

--- a/contracts/escrow/src/test_bounds.rs
+++ b/contracts/escrow/src/test_bounds.rs
@@ -183,3 +183,35 @@ fn create_contract_still_accepts_original_three_milestone_example() {
     let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
     assert_eq!(id, 0);
 }
+
+#[test]
+fn authorization_entrypoints_reject_out_of_bounds_milestone_index() {
+    let (env, contract_id, client_addr, freelancer_addr) = setup();
+    let client = EscrowClient::new(&env, &contract_id);
+    let milestones = vec![&env, 100_0000000_i128];
+    // In test_bounds, setup() doesn't wrap create_contract, we call it directly on client
+    // We pass only 3 args based on the existing tests in test_bounds.rs
+    let id = client.create_contract(&client_addr, &freelancer_addr, &milestones);
+
+    // approve_milestone_release
+    let approve_res = client.try_approve_milestone_release(&id, &client_addr, &MAX_MILESTONES);
+    match approve_res {
+        Err(Ok(EscrowError::IndexOutOfBounds)) => {}
+        other => panic!("expected IndexOutOfBounds for approve_milestone_release, got {:?}", other),
+    }
+
+    // get_milestone_approvals
+    let get_res = client.try_get_milestone_approvals(&id, &MAX_MILESTONES);
+    match get_res {
+        Err(Ok(EscrowError::IndexOutOfBounds)) => {}
+        other => panic!("expected IndexOutOfBounds for get_milestone_approvals, got {:?}", other),
+    }
+
+    // get_approval_deadline
+    let deadline_res = client.try_get_approval_deadline(&id, &MAX_MILESTONES);
+    match deadline_res {
+        Err(Ok(EscrowError::IndexOutOfBounds)) => {}
+        other => panic!("expected IndexOutOfBounds for get_approval_deadline, got {:?}", other),
+    }
+}
+


### PR DESCRIPTION
closes #909

Add input bounds validation to the authorization entrypoints