### PR TITLE
test(contracts): cover overflow and saturation

### DIFF
--- a/contracts/escrow/src/amount_validation.rs
+++ b/contracts/escrow/src/amount_validation.rs
@@ -212,6 +212,37 @@ pub fn safe_subtract_amounts(a: i128, b: i128) -> Option<i128> {
     a.checked_sub(b)
 }
 
+/// Computes the currently available (unreleased, unrefunded) balance for a
+/// contract using checked arithmetic.
+///
+/// `available = funded_amount - released_amount - refunded_amount`
+///
+/// This expression is duplicated across `lib.rs`, `finalize.rs`, and
+/// `dispute.rs` call sites that read contract accounting state; centralizing
+/// it here ensures every reader fails closed the same way instead of each
+/// site risking a silent wraparound (in a release build, where
+/// `overflow-checks` is off) or an inconsistent panic message.
+///
+/// # Errors
+/// `AccountingInvariantViolated` if either checked subtraction underflows, or
+/// if the result would be negative — both signal that `released_amount +
+/// refunded_amount` has already exceeded `funded_amount`, i.e. corrupted
+/// accounting state rather than an ordinary overflow.
+pub fn checked_available_balance(
+    funded_amount: i128,
+    released_amount: i128,
+    refunded_amount: i128,
+) -> Result<i128, crate::Error> {
+    let available = funded_amount
+        .checked_sub(released_amount)
+        .and_then(|value| value.checked_sub(refunded_amount))
+        .ok_or(crate::Error::AccountingInvariantViolated)?;
+    if available < 0 {
+        return Err(crate::Error::AccountingInvariantViolated);
+    }
+    Ok(available)
+}
+
 /// Safely accumulates amounts into a total with overflow protection.
 ///
 /// Iterates through amounts, validating each amount for positivity and bounds,
@@ -404,5 +435,38 @@ mod tests {
         assert_eq!(safe_subtract_amounts(300, 100), Some(200));
         assert_eq!(safe_subtract_amounts(0, 1), Some(-1));
         assert_eq!(safe_subtract_amounts(i128::MIN, 1), None);
+    }
+
+    #[test]
+    fn test_checked_available_balance_extremes() {
+        // Ordinary case.
+        assert_eq!(checked_available_balance(100, 20, 10), Ok(70));
+
+        // Subtraction near zero: released + refunded exactly consume funded.
+        assert_eq!(checked_available_balance(100, 60, 40), Ok(0));
+
+        // One stroop of headroom left.
+        assert_eq!(checked_available_balance(100, 60, 39), Ok(1));
+
+        // i128::MAX extremes: funded at the ceiling, nothing released/refunded yet.
+        assert_eq!(checked_available_balance(i128::MAX, 0, 0), Ok(i128::MAX));
+        assert_eq!(checked_available_balance(i128::MAX, i128::MAX, 0), Ok(0));
+
+        // Corrupted state: released + refunded exceed funded by one stroop.
+        assert_eq!(
+            checked_available_balance(100, 60, 41),
+            Err(crate::Error::AccountingInvariantViolated)
+        );
+
+        // Underflow at the i128::MIN boundary is reported the same way as an
+        // ordinary invariant violation, not a silent wraparound.
+        assert_eq!(
+            checked_available_balance(i128::MIN, 1, 0),
+            Err(crate::Error::AccountingInvariantViolated)
+        );
+        assert_eq!(
+            checked_available_balance(0, i128::MIN, 1),
+            Err(crate::Error::AccountingInvariantViolated)
+        );
     }
 }

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -31,14 +31,11 @@ pub fn resolution_payouts(
     contract: &Contract,
     resolution: &DisputeResolution,
 ) -> Result<(i128, i128), Error> {
-    let available = contract
-        .funded_amount
-        .checked_sub(contract.released_amount)
-        .and_then(|value| value.checked_sub(contract.refunded_amount))
-        .ok_or(Error::AccountingInvariantViolated)?;
-    if available < 0 {
-        return Err(Error::AccountingInvariantViolated);
-    }
+    let available = crate::checked_available_balance(
+        contract.funded_amount,
+        contract.released_amount,
+        contract.refunded_amount,
+    )?;
 
     match resolution {
         DisputeResolution::FullRefund => Ok((available, 0)),

--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -115,9 +115,12 @@ impl Escrow {
             total_amount,
             funded_amount: contract.funded_amount,
             released_amount: contract.released_amount,
-            refundable_balance: contract.funded_amount
-                - contract.released_amount
-                - contract.refunded_amount,
+            refundable_balance: crate::checked_available_balance(
+                contract.funded_amount,
+                contract.released_amount,
+                contract.refunded_amount,
+            )
+            .unwrap_or_else(|e| env.panic_with_error(e)),
             released_milestone_count,
             milestones: milestone_summaries,
         }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -67,6 +67,7 @@ use soroban_sdk::{
 };
 
 pub use amount_validation::accumulate_amounts;
+pub use amount_validation::checked_available_balance;
 pub use amount_validation::safe_add_amounts;
 pub use amount_validation::safe_subtract_amounts;
 pub use amount_validation::validate_deposit_amount;
@@ -625,7 +626,10 @@ impl Escrow {
     fn grant_pending_reputation_credit(env: &Env, freelancer: &Address) {
         let pending_key = DataKey::PendingReputationCredits(freelancer.clone());
         let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
-        env.storage().persistent().set(&pending_key, &(pending + 1));
+        let new_pending = pending
+            .checked_add(1)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+        env.storage().persistent().set(&pending_key, &new_pending);
     }
 
     /// Releases a specific milestone, transferring the net payout to the freelancer.
@@ -788,8 +792,12 @@ impl Escrow {
 
         // Check contract-level funding (per-milestone funded_amount is set after
         // release, so we check the aggregate contract balance here).
-        let available =
-            contract.funded_amount - contract.released_amount - contract.refunded_amount;
+        let available = crate::checked_available_balance(
+            contract.funded_amount,
+            contract.released_amount,
+            contract.refunded_amount,
+        )
+        .unwrap_or_else(|e| env.panic_with_error(e));
         if available < milestone.amount {
             env.panic_with_error(Error::InsufficientFunds);
         }
@@ -815,7 +823,9 @@ impl Escrow {
 
         /// `net_amount` — the amount actually transferred to the freelancer
         /// after deducting the protocol fee.
-        let net_amount = gross_amount - protocol_fee;
+        let net_amount = gross_amount
+            .checked_sub(protocol_fee)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
 
         // The available balance must cover the full gross milestone amount
         // (net payout + fee) without dipping into already-accumulated fees or
@@ -825,10 +835,17 @@ impl Escrow {
             .persistent()
             .get(&DataKey::AccumulatedProtocolFees)
             .unwrap_or(0);
-        let available_balance = contract.funded_amount
-            - contract.released_amount
-            - contract.refunded_amount
-            - accumulated_fees;
+        let new_accumulated_fees = accumulated_fees
+            .checked_add(protocol_fee)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+        let available_balance = crate::checked_available_balance(
+            contract.funded_amount,
+            contract.released_amount,
+            contract.refunded_amount,
+        )
+        .unwrap_or_else(|e| env.panic_with_error(e))
+        .checked_sub(accumulated_fees)
+        .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
         if available_balance < gross_amount {
             env.panic_with_error(EscrowError::InsufficientFunds);
         }
@@ -847,10 +864,9 @@ impl Escrow {
 
         // Accrue the fee into the protocol's accumulated balance.
         if protocol_fee > 0 {
-            env.storage().persistent().set(
-                &DataKey::AccumulatedProtocolFees,
-                &(accumulated_fees + protocol_fee),
-            );
+            env.storage()
+                .persistent()
+                .set(&DataKey::AccumulatedProtocolFees, &new_accumulated_fees);
         }
 
         milestone.released = true;
@@ -867,8 +883,11 @@ impl Escrow {
 
         // Accounting invariant: net released + refunded + all accumulated fees
         // must never exceed the total funded amount.
-        let new_accumulated = accumulated_fees + protocol_fee;
-        let invariant_sum = contract.released_amount + contract.refunded_amount + new_accumulated;
+        let invariant_sum = contract
+            .released_amount
+            .checked_add(contract.refunded_amount)
+            .and_then(|value| value.checked_add(new_accumulated_fees))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
         if invariant_sum > contract.funded_amount {
             env.panic_with_error(EscrowError::AccountingInvariantViolated);
         }
@@ -1091,12 +1110,18 @@ impl Escrow {
             }
             // If no deadline (None), allow refund anytime (backward compatibility)
 
-            total_refund_amount += milestone.amount;
+            total_refund_amount = total_refund_amount
+                .checked_add(milestone.amount)
+                .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
         }
 
         // Check if there's enough balance
-        let available_balance =
-            contract.funded_amount - contract.released_amount - contract.refunded_amount;
+        let available_balance = crate::checked_available_balance(
+            contract.funded_amount,
+            contract.released_amount,
+            contract.refunded_amount,
+        )
+        .unwrap_or_else(|e| env.panic_with_error(e));
         if available_balance < total_refund_amount {
             env.panic_with_error(EscrowError::InsufficientFunds);
         }
@@ -1291,8 +1316,12 @@ impl Escrow {
             .get::<_, bool>(&DataKey::ReputationIssued(contract_id))
             .unwrap_or(contract.reputation_issued);
 
-        let refundable_balance =
-            contract.funded_amount - contract.released_amount - contract.refunded_amount;
+        let refundable_balance = crate::checked_available_balance(
+            contract.funded_amount,
+            contract.released_amount,
+            contract.refunded_amount,
+        )
+        .unwrap_or_else(|e| env.panic_with_error(e));
 
         ContractSummary {
             schema_version: CONTRACT_SUMMARY_SCHEMA_VERSION,
@@ -1365,7 +1394,12 @@ impl Escrow {
             .get(&DataKey::Contract(contract_id))
             .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
         ttl::extend_contract_ttl(&env, contract_id);
-        contract.funded_amount - contract.released_amount - contract.refunded_amount
+        crate::checked_available_balance(
+            contract.funded_amount,
+            contract.released_amount,
+            contract.refunded_amount,
+        )
+        .unwrap_or_else(|e| env.panic_with_error(e))
     }
 
     /// Retrieves approval status for a milestone.
@@ -1619,8 +1653,12 @@ impl Escrow {
 
         client.require_auth();
 
-        let refund_amount =
-            contract.funded_amount - contract.released_amount - contract.refunded_amount;
+        let refund_amount = crate::checked_available_balance(
+            contract.funded_amount,
+            contract.released_amount,
+            contract.refunded_amount,
+        )
+        .unwrap_or_else(|e| env.panic_with_error(e));
         if refund_amount > 0 {
             let token = Self::read_settlement_token(&env)
                 .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
@@ -1744,8 +1782,14 @@ impl Escrow {
         let rep_key = DataKey::Reputation(contract.freelancer.clone());
         let mut rep: types::Reputation =
             env.storage().persistent().get(&rep_key).unwrap_or_default();
-        rep.completed_contracts += 1;
-        rep.total_rating += rating as i128;
+        rep.completed_contracts = rep
+            .completed_contracts
+            .checked_add(1)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+        rep.total_rating = rep
+            .total_rating
+            .checked_add(rating as i128)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
         rep.last_rating = rating as i128;
         env.storage().persistent().set(&rep_key, &rep);
 
@@ -2048,7 +2092,9 @@ impl Escrow {
             None => env.panic_with_error(Error::SettlementTokenNotConfigured),
         };
 
-        let new_accumulated = accumulated - amount;
+        let new_accumulated = accumulated
+            .checked_sub(amount)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::InsufficientAccumulatedFees));
         env.storage()
             .persistent()
             .set(&DataKey::AccumulatedProtocolFees, &new_accumulated);

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -18,6 +18,7 @@ mod emergency_controls;
 mod input_sanitization_amounts;
 mod input_sanitization_identities;
 mod mainnet_readiness;
+mod overflow_saturation;
 mod pause_controls;
 mod persistence;
 mod refund;

--- a/contracts/escrow/src/test/overflow_saturation.rs
+++ b/contracts/escrow/src/test/overflow_saturation.rs
@@ -1,0 +1,335 @@
+//! Overflow and saturation coverage for the escrow contract's money-moving
+//! arithmetic (issue #870).
+//!
+//! Every public entrypoint already caps individual milestone amounts at
+//! `MAX_SINGLE_AMOUNT_STROOPS` and the milestone count at `MAX_MILESTONES`, so
+//! a single contract can never *organically* reach i128 extremes through the
+//! public API alone. These tests inject extreme values directly into contract
+//! storage — mirroring the pattern already used in `test/reputation.rs` and
+//! `test/persistence.rs` — to prove the accounting arithmetic fails closed
+//! with a typed error instead of silently wrapping. Wrapping is the failure
+//! mode that would otherwise be reachable in a release build, where
+//! `overflow-checks` is off by default.
+//!
+//! See `amount_validation::checked_available_balance`, the shared helper
+//! these call sites were refactored to use.
+
+#![cfg(test)]
+
+use soroban_sdk::{token::StellarAssetClient, vec, Env, String, Symbol};
+
+use super::{EscrowFixture, MILESTONE_ONE};
+use crate::{Contract, DataKey, Error, Escrow, EscrowError, Milestone, Reputation};
+
+fn milestone_key(env: &Env) -> Symbol {
+    Symbol::new(env, "milestones")
+}
+
+/// Read-modify-write the stored `Contract` for a fixture, bypassing the
+/// public deposit/release/refund flows so accounting fields can be pushed to
+/// values the public API could never produce on its own.
+fn overwrite_contract(fixture: &EscrowFixture, mutate: impl FnOnce(&mut Contract)) {
+    fixture.env.as_contract(&fixture.escrow_address, || {
+        let key = DataKey::Contract(fixture.escrow_id);
+        let mut contract: Contract = fixture.env.storage().persistent().get(&key).unwrap();
+        mutate(&mut contract);
+        fixture.env.storage().persistent().set(&key, &contract);
+    });
+}
+
+/// Overwrite a single milestone's `amount` field directly in storage.
+fn overwrite_milestone_amount(fixture: &EscrowFixture, index: u32, amount: i128) {
+    fixture.env.as_contract(&fixture.escrow_address, || {
+        let key = (
+            DataKey::Contract(fixture.escrow_id),
+            milestone_key(&fixture.env),
+        );
+        let mut milestones: soroban_sdk::Vec<Milestone> =
+            fixture.env.storage().persistent().get(&key).unwrap();
+        let mut milestone = milestones.get(index).unwrap();
+        milestone.amount = amount;
+        milestones.set(index, milestone);
+        fixture.env.storage().persistent().set(&key, &milestones);
+    });
+}
+
+fn release_all_milestones(fixture: &EscrowFixture) {
+    for index in 0..3u32 {
+        fixture
+            .escrow()
+            .approve_milestone_release(&fixture.escrow_id, &fixture.client, &index);
+        fixture
+            .escrow()
+            .release_milestone(&fixture.escrow_id, &fixture.client, &index);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// calculate_protocol_fee: checked_mul at i128 extremes
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic] // Error::PotentialOverflow
+fn calculate_protocol_fee_rejects_overflowing_product() {
+    let env = Env::default();
+    Escrow::calculate_protocol_fee(&env, i128::MAX, 10_000);
+}
+
+#[test]
+fn calculate_protocol_fee_handles_full_rate_without_overflow() {
+    let env = Env::default();
+    // 100% fee on the largest single amount the contract ever accepts must
+    // not overflow — this is the realistic ceiling, not an injected extreme.
+    let fee = Escrow::calculate_protocol_fee(&env, crate::MAX_SINGLE_AMOUNT_STROOPS, 10_000);
+    assert_eq!(fee, crate::MAX_SINGLE_AMOUNT_STROOPS);
+}
+
+// ---------------------------------------------------------------------------
+// checked_available_balance via get_refundable_balance / get_contract_summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_refundable_balance_handles_i128_max_funded_amount() {
+    let fixture = EscrowFixture::builder().funded().build();
+    overwrite_contract(&fixture, |c| {
+        c.funded_amount = i128::MAX;
+        c.released_amount = 0;
+        c.refunded_amount = 0;
+    });
+
+    assert_eq!(
+        fixture.escrow().get_refundable_balance(&fixture.escrow_id),
+        i128::MAX
+    );
+}
+
+#[test]
+fn get_refundable_balance_is_zero_at_exact_consumption() {
+    let fixture = EscrowFixture::builder().funded().build();
+    overwrite_contract(&fixture, |c| {
+        c.funded_amount = i128::MAX;
+        c.released_amount = i128::MAX - 1;
+        c.refunded_amount = 1;
+    });
+
+    assert_eq!(
+        fixture.escrow().get_refundable_balance(&fixture.escrow_id),
+        0
+    );
+}
+
+#[test]
+fn get_refundable_balance_rejects_corrupted_state_at_extreme_values() {
+    let fixture = EscrowFixture::builder().funded().build();
+    overwrite_contract(&fixture, |c| {
+        c.funded_amount = 100;
+        c.released_amount = 0;
+        c.refunded_amount = i128::MAX;
+    });
+
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_get_refundable_balance(&fixture.escrow_id),
+        Error::AccountingInvariantViolated,
+    );
+}
+
+#[test]
+fn get_contract_summary_rejects_corrupted_state_at_extreme_values() {
+    let fixture = EscrowFixture::builder().funded().build();
+    overwrite_contract(&fixture, |c| {
+        c.funded_amount = 100;
+        c.released_amount = i128::MAX;
+        c.refunded_amount = 1;
+    });
+
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_get_contract_summary(&fixture.escrow_id),
+        Error::AccountingInvariantViolated,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// release_milestone: available-balance and fee-accrual checked arithmetic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn release_milestone_succeeds_when_funded_amount_is_near_i128_max() {
+    let fixture = EscrowFixture::builder().funded().build();
+    // Simulate a contract whose accounting has accrued a near-maximal
+    // funded_amount (e.g. across a very long history of top-up deposits)
+    // while an ordinary small milestone remains unreleased.
+    overwrite_contract(&fixture, |c| {
+        c.funded_amount = i128::MAX;
+    });
+
+    fixture
+        .escrow()
+        .approve_milestone_release(&fixture.escrow_id, &fixture.client, &0);
+    assert!(fixture
+        .escrow()
+        .release_milestone(&fixture.escrow_id, &fixture.client, &0));
+
+    let contract = fixture.escrow().get_contract(&fixture.escrow_id);
+    assert_eq!(contract.released_amount, MILESTONE_ONE);
+    assert_eq!(contract.funded_amount, i128::MAX);
+}
+
+#[test]
+fn release_milestone_rejects_when_fee_accrual_would_overflow() {
+    let fixture = EscrowFixture::builder().funded().build();
+    fixture.escrow().set_protocol_fee_bps(&1000u32); // 10%
+
+    fixture.env.as_contract(&fixture.escrow_address, || {
+        fixture
+            .env
+            .storage()
+            .persistent()
+            .set(&DataKey::AccumulatedProtocolFees, &i128::MAX);
+    });
+
+    fixture
+        .escrow()
+        .approve_milestone_release(&fixture.escrow_id, &fixture.client, &0);
+
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_release_milestone(&fixture.escrow_id, &fixture.client, &0),
+        EscrowError::PotentialOverflow,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// refund_unreleased_milestones: checked accumulation loop
+// ---------------------------------------------------------------------------
+
+#[test]
+fn refund_unreleased_milestones_rejects_overflowing_milestone_sum() {
+    let fixture = EscrowFixture::builder().funded().build();
+    overwrite_milestone_amount(&fixture, 0, i128::MAX);
+    overwrite_milestone_amount(&fixture, 1, 1);
+
+    let indices = vec![&fixture.env, 0u32, 1u32];
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_refund_unreleased_milestones(&fixture.escrow_id, &indices),
+        EscrowError::PotentialOverflow,
+    );
+}
+
+#[test]
+fn refund_unreleased_milestones_conserves_sum_near_i128_max() {
+    let fixture = EscrowFixture::builder().funded().build();
+    // Large enough to be many orders of magnitude past `MAX_SINGLE_AMOUNT_STROOPS`
+    // (proving the checked_add loop doesn't falsely reject a big-but-valid sum),
+    // while staying within what the underlying token's own i64-scale balance
+    // representation can actually hold — a real settlement-token transfer for
+    // the refund still has to succeed.
+    let half: i128 = 4_000_000_000_000_000_000;
+    overwrite_milestone_amount(&fixture, 0, half);
+    overwrite_milestone_amount(&fixture, 1, half);
+    overwrite_contract(&fixture, |c| {
+        c.funded_amount = half.checked_add(half).unwrap();
+    });
+
+    // The accounting fields are injected directly, but `refund_unreleased_milestones`
+    // still performs a real settlement-token transfer for the refunded amount, so
+    // custody needs to actually hold it.
+    let token = fixture
+        .settlement_token
+        .clone()
+        .expect("funded fixture always configures a settlement token");
+    StellarAssetClient::new(&fixture.env, &token)
+        .mint(&fixture.escrow_address, &half.checked_add(half).unwrap());
+
+    let indices = vec![&fixture.env, 0u32, 1u32];
+    assert_eq!(
+        fixture
+            .escrow()
+            .refund_unreleased_milestones(&fixture.escrow_id, &indices),
+        half.checked_add(half).unwrap()
+    );
+
+    let contract = fixture.escrow().get_contract(&fixture.escrow_id);
+    assert_eq!(contract.refunded_amount, half.checked_add(half).unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// cancel_contract: checked-subtraction fail-closed at extremes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cancel_contract_rejects_corrupted_state_at_extreme_values() {
+    let fixture = EscrowFixture::builder().funded().build();
+    overwrite_contract(&fixture, |c| {
+        c.refunded_amount = i128::MAX;
+    });
+
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_cancel_contract(&fixture.escrow_id, &fixture.client),
+        Error::AccountingInvariantViolated,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// issue_reputation: checked increments on completed_contracts / total_rating
+// ---------------------------------------------------------------------------
+
+#[test]
+fn issue_reputation_rejects_overflowing_completed_contracts_counter() {
+    let fixture = EscrowFixture::builder().funded().build();
+    release_all_milestones(&fixture);
+
+    fixture.env.as_contract(&fixture.escrow_address, || {
+        let key = DataKey::Reputation(fixture.freelancer.clone());
+        fixture.env.storage().persistent().set(
+            &key,
+            &Reputation {
+                completed_contracts: i128::MAX,
+                total_rating: 0,
+                last_rating: 0,
+            },
+        );
+    });
+
+    let comment = String::from_str(&fixture.env, "great work");
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_issue_reputation(&fixture.escrow_id, &fixture.client, &5u32, &comment),
+        Error::PotentialOverflow,
+    );
+}
+
+#[test]
+fn issue_reputation_rejects_overflowing_total_rating() {
+    let fixture = EscrowFixture::builder().funded().build();
+    release_all_milestones(&fixture);
+
+    fixture.env.as_contract(&fixture.escrow_address, || {
+        let key = DataKey::Reputation(fixture.freelancer.clone());
+        fixture.env.storage().persistent().set(
+            &key,
+            &Reputation {
+                completed_contracts: 0,
+                total_rating: i128::MAX,
+                last_rating: 0,
+            },
+        );
+    });
+
+    let comment = String::from_str(&fixture.env, "great work");
+    super::assert_contract_error(
+        fixture
+            .escrow()
+            .try_issue_reputation(&fixture.escrow_id, &fixture.client, &5u32, &comment),
+        Error::PotentialOverflow,
+    );
+}


### PR DESCRIPTION
## Summary

Closes #870

- Extracted the duplicated `funded_amount - released_amount - refunded_amount` expression (previously raw, repeated across 6 call sites in `lib.rs`/`finalize.rs`) into a single checked helper, `amount_validation::checked_available_balance`, and switched every call site to use it: `release_milestone`, `refund_unreleased_milestones`, `cancel_contract`, `get_contract_summary`, `get_refundable_balance`, `finalize::summarize_contract`, and `dispute::resolution_payouts` (which had its own inline copy of the same logic).
- Hardened the remaining raw arithmetic found in `release_milestone`/`refund_unreleased_milestones`/`issue_reputation` with `checked_add`/`checked_sub`: protocol-fee accrual (`accumulated_fees + protocol_fee`), the accounting-invariant sum, net-amount computation (`gross_amount - protocol_fee`), the refund accumulation loop (`total_refund_amount += milestone.amount`), the reputation counters (`completed_contracts`, `total_rating`), and the pending-reputation-credit counter.
- All of this is defense-in-depth: every public entrypoint already caps a single milestone amount at `MAX_SINGLE_AMOUNT_STROOPS` (1e13) and the milestone count at `MAX_MILESTONES` (10), so a single contract can never organically reach i128 extremes through the public API today. The fix ensures that if those bounds ever change, or accounting state is otherwise corrupted, the contract fails closed with a typed error instead of silently wrapping — which is the real risk, since `overflow-checks` is off by default in a release/wasm build (unlike `cargo test`'s debug profile, which panics on overflow instead of wrapping).
- Added `contracts/escrow/src/test/overflow_saturation.rs` (new, registered in `test/mod.rs`) with 13 tests exercising i128 extremes, sums near `i128::MAX`, and subtraction near zero across every hardened call site, asserting the correct typed error (`PotentialOverflow` / `AccountingInvariantViolated`) where rejection is expected, and correct non-wrapping results where the operation should succeed.
- Added 1 test to `amount_validation.rs`'s existing test module directly covering `checked_available_balance` at the same set of edge cases.

## Test plan

- [x] `cargo fmt` — clean, no diff.
- [x] `cargo clippy --all-targets -- -D warnings` — introduces **zero** new warnings. (This repo's `main` currently has 88 pre-existing clippy errors under `-D warnings`, identical in count and location on a clean checkout; unrelated to this change.)
- [x] `cargo test` — the new/changed tests are green with no regressions. Full test output for the new module:

```
running 13 tests
test test::overflow_saturation::calculate_protocol_fee_rejects_overflowing_product - should panic ... ok
test test::overflow_saturation::calculate_protocol_fee_handles_full_rate_without_overflow ... ok
test test::overflow_saturation::get_refundable_balance_rejects_corrupted_state_at_extreme_values ... ok
test test::overflow_saturation::get_refundable_balance_is_zero_at_exact_consumption ... ok
test test::overflow_saturation::cancel_contract_rejects_corrupted_state_at_extreme_values ... ok
test test::overflow_saturation::refund_unreleased_milestones_conserves_sum_near_i128_max ... ok
test test::overflow_saturation::get_contract_summary_rejects_corrupted_state_at_extreme_values ... ok
test test::overflow_saturation::issue_reputation_rejects_overflowing_completed_contracts_counter ... ok
test test::overflow_saturation::refund_unreleased_milestones_rejects_overflowing_milestone_sum ... ok
test test::overflow_saturation::get_refundable_balance_handles_i128_max_funded_amount ... ok
test test::overflow_saturation::release_milestone_rejects_when_fee_accrual_would_overflow ... ok
test test::overflow_saturation::issue_reputation_rejects_overflowing_total_rating ... ok
test test::overflow_saturation::release_milestone_succeeds_when_funded_amount_is_near_i128_max ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 339 filtered out; finished in 2.12s
```

```
running 7 tests
test amount_validation::tests::test_safe_arithmetic ... ok
test amount_validation::tests::test_validate_amount_array ... ok
test amount_validation::tests::test_validate_milestone_amounts ... ok
test amount_validation::tests::test_validate_single_amount ... ok
test amount_validation::tests::test_checked_available_balance_extremes ... ok
test amount_validation::tests::test_validate_contract_total ... ok
test amount_validation::tests::test_validate_deposit_amount ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 345 filtered out; finished in 0.45s
```

Full-suite run (`cargo test`): **164 passed; 181 failed** on this branch vs **150 passed; 181 failed** on a clean `main` checkout in the same local environment — i.e. the failure count is byte-for-byte identical (same 181 tests, same error codes) and this branch adds exactly 14 new passing tests (13 in `overflow_saturation.rs` + 1 in `amount_validation.rs`), zero regressions. The 181 pre-existing failures are a local Windows/mingw environment issue (`register_stellar_asset_contract` in this toolchain/SDK combination rejects `deposit_funds` with `SettlementTokenNotConfigured` for most fixture-funded tests), reproduced identically on a clean `main` stash before any of this branch's changes, and unrelated to this PR — this repo's CI runs on Linux where that native-Windows-toolchain issue doesn't apply.

Note: to run natively on Windows at all in this environment, `[lib] crate-type` had to be temporarily reduced to `["rlib"]` (dropping `cdylib`) locally, because linking the native `cdylib` artifact on this machine's mingw `ld` hits `error: export ordinal too large` — also reproduced identically on clean `main`. That change was never committed; `Cargo.toml` is untouched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)