### PR TITLE
feat(events): admin-configurable limit

### DIFF
--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -66,6 +66,49 @@ impl Escrow {
             .unwrap_or(0)
     }
 
+    /// Set the maximum events limit for queries or indexing.
+    ///
+    /// Admin-gated: the stored admin (under [`DataKey::Admin`]) must authorize
+    /// the call and the contract must be initialized.
+    ///
+    /// `new_limit` must be within safe bounds (e.g., > 0 and <= 1000).
+    ///
+    /// # Events
+    /// `(Symbol("events_limit"),)` → `(old_limit, new_limit, admin, timestamp)`
+    pub fn set_events_limit(env: Env, new_limit: u32) -> bool {
+        Self::require_initialized(&env);
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+        admin.require_auth();
+
+        if new_limit == 0 || new_limit > 1000 {
+            env.panic_with_error(Error::InvalidEventsLimit);
+        }
+
+        let old_limit: u32 = Self::get_events_limit(env.clone());
+        
+        env.storage()
+            .persistent()
+            .set(&DataKey::EventsLimit, &new_limit);
+
+        env.events().publish(
+            (Symbol::new(&env, "events_limit"),),
+            (old_limit, new_limit, admin, env.ledger().timestamp()),
+        );
+        true
+    }
+
+    /// Returns the current events limit. Default is 100.
+    pub fn get_events_limit(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::EventsLimit)
+            .unwrap_or(100) // Default preserves current behaviour
+    }
+
     // ── Two-step admin transfer ───────────────────────────────────────────────
 
     /// Propose a new governance admin. Stores the proposal with a timelock.

--- a/contracts/escrow/src/test/governance.rs
+++ b/contracts/escrow/src/test/governance.rs
@@ -238,3 +238,28 @@ fn propose_emits_event() {
     });
     assert!(found_proposed, "propose event should be emitted");
 }
+
+#[test]
+fn events_limit_tests() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Default preserves current behaviour
+    assert_eq!(client.get_events_limit(), 100);
+
+    // In-bounds set
+    assert!(client.set_events_limit(&500));
+    assert_eq!(client.get_events_limit(), 500);
+
+    // Over-bounds rejected
+    let result = client.try_set_events_limit(&1001);
+    super::assert_contract_error(result, crate::Error::InvalidEventsLimit);
+
+    // Out-of-bounds zero rejected
+    let result = client.try_set_events_limit(&0);
+    super::assert_contract_error(result, crate::Error::InvalidEventsLimit);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -81,6 +81,7 @@ pub enum DataKey {
     PendingGovernanceAdmin,
     ProtocolParameters,
     ProtocolFeeBps,
+    EventsLimit,
     // Two-step admin transfer: pending admin stored here while proposal awaits acceptance
     PendingAdmin,
     AccumulatedProtocolFees,
@@ -193,6 +194,8 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// The configured events limit is out of allowed range.
+    InvalidEventsLimit = 54,
 }
 
 /// Contract lifecycle states


### PR DESCRIPTION
The events limit is now an admin-configurable parameter with a sane default and bounds.

Closes #906