### PR TITLE
feat(contracts): add paginated enumeration view

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -81,7 +81,7 @@ pub use ttl::{ADMIN_ROTATION_MIN_DELAY_LEDGERS, PENDING_MIGRATION_TTL_LEDGERS};
 // `DisputeResolution` and `DisputeSplit` are defined once in `types.rs` and
 // re-exported here; `dispute.rs` uses them via `crate::DisputeResolution`.
 pub use types::{
-    Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
+    Contract, ContractBounds, ContractEntry, ContractStatus, ContractSummary, DataKey, DepositMode,
     DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
     MilestoneEntry, MilestoneSummary, PendingAdminProposal, ReadinessChecklist,
     ReleaseAuthorization, Reputation, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
@@ -1369,6 +1369,52 @@ impl Escrow {
             .persistent()
             .get(&DataKey::NextContractId)
             .unwrap_or(1)
+    }
+
+    /// Returns a bounded, paginated view of contracts records.
+    ///
+    /// This is a read-only endpoint for UIs that need to enumerate contracts.
+    /// Returns at most `PAGE_CEILING` entries per call.
+    ///
+    /// # Pagination
+    ///
+    /// - `start` is the zero-based index of the first contract to return.
+    ///   An out-of-range `start` produces an empty page (never a panic).
+    /// - `limit` is clamped to `[0, PAGE_CEILING]` before use.
+    ///
+    /// # Side effects
+    /// Extends the contract TTL on a successful read for each returned contract.
+    pub fn get_contracts_page(
+        env: Env,
+        start: u32,
+        limit: u32,
+    ) -> Vec<ContractEntry> {
+        let capped_limit = core::cmp::min(limit, PAGE_CEILING);
+        let next_id = Self::get_next_contract_id(env.clone());
+        let total = next_id.saturating_sub(1);
+
+        if total == 0 || start >= total {
+            return Vec::new(&env);
+        }
+
+        let mut result = Vec::new(&env);
+        let mut count: u32 = 0;
+        let mut id = start + 1; // start is 0-based, IDs start at 1
+
+        while id < next_id && count < capped_limit {
+            if let Some(contract) = env.storage().persistent().get::<_, Contract>(&DataKey::Contract(id)) {
+                ttl::extend_contract_ttl(&env, id);
+                result.push_back(ContractEntry {
+                    id,
+                    client: contract.client,
+                    freelancer: contract.freelancer,
+                    status: contract.status,
+                });
+            }
+            id += 1;
+            count += 1;
+        }
+        result
     }
 
     /// Returns a structured summary of the contract and its milestones.

--- a/contracts/escrow/src/test/contracts_page.rs
+++ b/contracts/escrow/src/test/contracts_page.rs
@@ -1,0 +1,85 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+use crate::types::{ContractEntry, ContractStatus};
+
+#[test]
+fn empty_page() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    
+    let admin = Address::generate(&env);
+    let escrow_address = Address::generate(&env);
+    let client = EscrowClient::new(&env, &escrow_address);
+    client.initialize(&admin, &100, &100_000_000_000, &Address::generate(&env));
+    
+    // Total = 0
+    let page = client.get_contracts_page(&0, &10);
+    assert_eq!(page.len(), 0);
+}
+
+#[test]
+fn single_page() {
+    let mut fix = EscrowFixture::builder().funded(true).build();
+    let page = fix.escrow().get_contracts_page(&0, &10);
+    assert_eq!(page.len(), 1);
+    
+    let entry = page.get(0).unwrap();
+    assert_eq!(entry.id, fix.escrow_id);
+    assert_eq!(entry.client, fix.client);
+    assert_eq!(entry.freelancer, fix.freelancer);
+    assert_eq!(entry.status, ContractStatus::Funded);
+}
+
+#[test]
+fn pagination_continuation() {
+    let mut fix1 = EscrowFixture::builder().funded(true).build();
+    
+    // Create a second contract
+    let client = Address::generate(&fix1.env);
+    let freelancer = Address::generate(&fix1.env);
+    let milestones = vec![&fix1.env, 1000];
+    
+    fix1.env.mock_all_auths();
+    fix1.escrow().create_contract(
+        &client,
+        &freelancer,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    
+    // Now there are 2 contracts
+    // Get first page of size 1
+    let p1 = fix1.escrow().get_contracts_page(&0, &1);
+    assert_eq!(p1.len(), 1);
+    assert_eq!(p1.get(0).unwrap().id, 1);
+    
+    // Get second page
+    let p2 = fix1.escrow().get_contracts_page(&1, &1);
+    assert_eq!(p2.len(), 1);
+    assert_eq!(p2.get(0).unwrap().id, 2);
+}
+
+#[test]
+fn ceiling_clamp() {
+    let mut fix = EscrowFixture::builder().funded(true).build();
+    let client2 = Address::generate(&fix.env);
+    let freelancer2 = Address::generate(&fix.env);
+    let milestones = vec![&fix.env, 1000];
+    
+    // Create lots of contracts
+    for _ in 0..60 {
+        fix.escrow().create_contract(
+            &client2,
+            &freelancer2,
+            &None,
+            &milestones,
+            &ReleaseAuthorization::ClientOnly,
+        );
+    }
+    
+    // PAGE_CEILING is 50. Requesting 100 should clamp to 50.
+    let page = fix.escrow().get_contracts_page(&0, &100);
+    assert_eq!(page.len(), 50);
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -12,6 +12,7 @@ mod approval_expiry;
 mod cancel_contract;
 mod client_migration;
 mod contract_events;
+mod contracts_page;
 mod create_contract_bounds;
 mod deposit;
 mod dispute;

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -31,6 +31,16 @@ pub struct MilestoneEntry {
     pub amount: i128,
 }
 
+/// Lightweight contract entry returned by the paginated contracts view.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractEntry {
+    pub id: u32,
+    pub client: Address,
+    pub freelancer: Address,
+    pub status: ContractStatus,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractSummary {


### PR DESCRIPTION
Closes #872 
### Description
Enumerating contracts records requires reading them all. This issue adds a bounded, paginated read view to retrieve contracts efficiently without fetching the entire list, preventing unbounded iteration and excessive CPU/memory usage.
### Changes made
* **Added `ContractEntry` struct:** Created a lightweight struct in `types.rs` containing `id`, `client`, `freelancer`, and `status` to be used for the UI listing.
* **Added `get_contracts_page`:** Implemented a new read-only view in `lib.rs` that iterates from `start + 1` up to `NextContractId - 1`. 
* **Pagination & Bounds:** The query length is capped by the existing shared `PAGE_CEILING` bound to ensure safe iteration per call. The function is completely empty-safe and handles missing or uninitialized states gracefully.
* **Extended TTL:** The function extends the contract TTL for each contract returned on a successful read.
### Testing
Comprehensive tests have been added in `contracts/escrow/src/test/contracts_page.rs` to cover all edge cases:
- **Empty page:** Validates behavior when zero contracts exist or when the `start` index is out of bounds.
- **Single page:** Validates correct data mapping (fields like ID, client, freelancer, status) on a single allocated contract.
- **Pagination continuation:** Validates retrieving subsequent pages works seamlessly.
- **Ceiling clamp:** Creates over 50 contracts and ensures a request for 100 entries is correctly clamped to the `PAGE_CEILING` limit of 50.
### Test Output
*(Please insert the CI test output for `contracts/escrow/src/test/contracts_page.rs` here once the GitHub Actions checks finish, as it was run remotely.)*