### PR TITLE
feat(storage): admin-configurable storage limit

### DIFF
--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -252,4 +252,71 @@ impl Escrow {
     pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
         env.storage().persistent().get(&DataKey::GovernedParameters)
     }
+
+    /// Set the admin-configurable per-contract storage limit (in bytes).
+    ///
+    /// Admin-gated: the stored admin (under [`DataKey::Admin`]) must authorize the
+    /// call and the contract must be initialized.
+    ///
+    /// The `new_limit` must be within the range `[MIN_STORAGE_LIMIT,
+    /// MAX_STORAGE_LIMIT]` (1 – 1 000 000 bytes inclusive).  Values outside this
+    /// range are rejected with [`Error::StorageLimitOutOfRange`].  The default
+    /// value — applied whenever no admin has overridden the limit — is
+    /// `DEFAULT_STORAGE_LIMIT` (64 KB = 65 536 bytes), which preserves the
+    /// behaviour that existed before this entrypoint was introduced.
+    ///
+    /// # Errors
+    /// * [`Error::NotInitialized`] — `initialize` has not been called.
+    /// * [`Error::UnauthorizedRole`] — `admin` is not the stored admin.
+    /// * [`Error::StorageLimitOutOfRange`] — `new_limit < MIN_STORAGE_LIMIT` or
+    ///   `new_limit > MAX_STORAGE_LIMIT`.
+    ///
+    /// # Events
+    /// `(Symbol("storage_limit"),)` → `(old_limit, new_limit, admin, timestamp)`
+    pub fn set_storage_limit(env: Env, admin: Address, new_limit: u32) -> bool {
+        Self::require_initialized(&env);
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+
+        if admin != stored_admin {
+            env.panic_with_error(Error::UnauthorizedRole);
+        }
+        admin.require_auth();
+
+        if new_limit < crate::MIN_STORAGE_LIMIT || new_limit > crate::MAX_STORAGE_LIMIT {
+            env.panic_with_error(Error::StorageLimitOutOfRange);
+        }
+
+        let old_limit: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StorageLimit)
+            .unwrap_or(crate::DEFAULT_STORAGE_LIMIT);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::StorageLimit, &new_limit);
+
+        env.events().publish(
+            (Symbol::new(&env, "storage_limit"),),
+            (old_limit, new_limit, admin, env.ledger().timestamp()),
+        );
+
+        true
+    }
+
+    /// Return the current per-contract storage limit in bytes.
+    ///
+    /// Returns [`DEFAULT_STORAGE_LIMIT`] when no admin has overridden the value.
+    /// Read-only and auth-free.
+    pub fn get_storage_limit(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::StorageLimit)
+            .unwrap_or(crate::DEFAULT_STORAGE_LIMIT)
+    }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -91,6 +91,17 @@ pub const MAX_MILESTONES: u32 = 10;
 pub const MAX_SINGLE_AMOUNT_STROOPS: i128 = crate::amount_validation::MAX_SINGLE_AMOUNT_STROOPS;
 pub const MAX_TOTAL_ESCROW_STROOPS: i128 = MAX_SINGLE_AMOUNT_STROOPS;
 
+// ── Admin-configurable storage limit constants ─────────────────────────────
+/// Minimum value accepted by [`Escrow::set_storage_limit`] (1 byte).
+pub const MIN_STORAGE_LIMIT: u32 = 1;
+/// Maximum value accepted by [`Escrow::set_storage_limit`] (1 000 000 bytes).
+pub const MAX_STORAGE_LIMIT: u32 = 1_000_000;
+/// Default storage limit (65 536 bytes = 64 KiB) when no admin override is set.
+///
+/// Preserves pre-#901 behaviour for deployments that have not called
+/// [`Escrow::set_storage_limit`].
+pub const DEFAULT_STORAGE_LIMIT: u32 = 65_536;
+
 #[contract]
 pub struct Escrow;
 

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -25,6 +25,7 @@ mod release;
 mod release_authorization;
 mod reputation;
 mod security;
+mod storage_limit;
 mod ttl_tests;
 
 // --- Shared constants ---

--- a/contracts/escrow/src/test/storage_limit.rs
+++ b/contracts/escrow/src/test/storage_limit.rs
@@ -1,0 +1,301 @@
+//! Tests for the admin-configurable storage limit (#901).
+//!
+//! Coverage matrix
+//! ───────────────
+//! * `get_storage_limit` returns `DEFAULT_STORAGE_LIMIT` before any admin call.
+//! * `set_storage_limit` persists the value and `get_storage_limit` reflects it.
+//! * In-bounds boundary values (MIN, MAX, DEFAULT) are accepted.
+//! * Zero → `StorageLimitOutOfRange`.
+//! * One above maximum → `StorageLimitOutOfRange`.
+//! * Non-admin caller → `UnauthorizedRole`.
+//! * Uninitialized contract → `NotInitialized`.
+//! * Multiple sequential calls: last write wins.
+//! * Event is emitted with the `"storage_limit"` topic.
+//! * `get_storage_limit` is auth-free (no mock needed).
+
+use super::assert_contract_error;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, Symbol, TryFromVal,
+};
+
+use crate::{
+    Error, Escrow, EscrowClient, DEFAULT_STORAGE_LIMIT, MAX_STORAGE_LIMIT, MIN_STORAGE_LIMIT,
+};
+
+// ── Shared fixture ────────────────────────────────────────────────────────────
+
+struct Ctx {
+    env: Env,
+    client_addr: Address,
+    admin: Address,
+}
+
+impl Ctx {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(Escrow, ());
+        let admin = Address::generate(&env);
+        let client = EscrowClient::new(&env, &contract_id);
+        client.initialize(&admin);
+        Ctx {
+            env,
+            client_addr: contract_id,
+            admin,
+        }
+    }
+
+    fn escrow(&self) -> EscrowClient<'_> {
+        EscrowClient::new(&self.env, &self.client_addr)
+    }
+}
+
+// ── Default value ─────────────────────────────────────────────────────────────
+
+#[test]
+fn get_storage_limit_returns_default_before_any_set() {
+    let ctx = Ctx::new();
+    assert_eq!(ctx.escrow().get_storage_limit(), DEFAULT_STORAGE_LIMIT);
+}
+
+// ── Happy-path set / get ──────────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_persists_and_get_reflects_it() {
+    let ctx = Ctx::new();
+    let new_limit: u32 = 128_000;
+    assert!(ctx.escrow().set_storage_limit(&ctx.admin, &new_limit));
+    assert_eq!(ctx.escrow().get_storage_limit(), new_limit);
+}
+
+#[test]
+fn set_storage_limit_min_boundary_accepted() {
+    let ctx = Ctx::new();
+    assert!(ctx
+        .escrow()
+        .set_storage_limit(&ctx.admin, &MIN_STORAGE_LIMIT));
+    assert_eq!(ctx.escrow().get_storage_limit(), MIN_STORAGE_LIMIT);
+}
+
+#[test]
+fn set_storage_limit_max_boundary_accepted() {
+    let ctx = Ctx::new();
+    assert!(ctx
+        .escrow()
+        .set_storage_limit(&ctx.admin, &MAX_STORAGE_LIMIT));
+    assert_eq!(ctx.escrow().get_storage_limit(), MAX_STORAGE_LIMIT);
+}
+
+#[test]
+fn set_storage_limit_default_value_accepted() {
+    let ctx = Ctx::new();
+    // Explicit set to default must succeed (it's in-range)
+    assert!(ctx
+        .escrow()
+        .set_storage_limit(&ctx.admin, &DEFAULT_STORAGE_LIMIT));
+    assert_eq!(ctx.escrow().get_storage_limit(), DEFAULT_STORAGE_LIMIT);
+}
+
+// ── Rejection: out-of-range ───────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_rejects_zero() {
+    let ctx = Ctx::new();
+    let result = ctx.escrow().try_set_storage_limit(&ctx.admin, &0u32);
+    assert_contract_error(result, Error::StorageLimitOutOfRange);
+}
+
+#[test]
+fn set_storage_limit_rejects_one_above_max() {
+    let ctx = Ctx::new();
+    let over_max = MAX_STORAGE_LIMIT + 1;
+    let result = ctx.escrow().try_set_storage_limit(&ctx.admin, &over_max);
+    assert_contract_error(result, Error::StorageLimitOutOfRange);
+}
+
+#[test]
+fn set_storage_limit_rejects_u32_max() {
+    let ctx = Ctx::new();
+    let result = ctx.escrow().try_set_storage_limit(&ctx.admin, &u32::MAX);
+    assert_contract_error(result, Error::StorageLimitOutOfRange);
+}
+
+// ── Rejection: wrong caller ───────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_rejects_non_admin() {
+    let ctx = Ctx::new();
+    let impostor = Address::generate(&ctx.env);
+    let result = ctx
+        .escrow()
+        .try_set_storage_limit(&impostor, &DEFAULT_STORAGE_LIMIT);
+    assert_contract_error(result, Error::UnauthorizedRole);
+}
+
+// ── Rejection: uninitialized ──────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_rejects_when_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+    // Contract is NOT initialized — no `client.initialize(...)` call
+
+    let admin = Address::generate(&env);
+    let result = client.try_set_storage_limit(&admin, &DEFAULT_STORAGE_LIMIT);
+    assert_contract_error(result, Error::NotInitialized);
+}
+
+// ── Multiple sequential calls ─────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_last_write_wins() {
+    let ctx = Ctx::new();
+    ctx.escrow().set_storage_limit(&ctx.admin, &10_000u32);
+    assert_eq!(ctx.escrow().get_storage_limit(), 10_000);
+
+    ctx.escrow().set_storage_limit(&ctx.admin, &20_000u32);
+    assert_eq!(ctx.escrow().get_storage_limit(), 20_000);
+
+    ctx.escrow()
+        .set_storage_limit(&ctx.admin, &MIN_STORAGE_LIMIT);
+    assert_eq!(ctx.escrow().get_storage_limit(), MIN_STORAGE_LIMIT);
+}
+
+#[test]
+fn set_storage_limit_same_value_twice_succeeds() {
+    let ctx = Ctx::new();
+    ctx.escrow().set_storage_limit(&ctx.admin, &50_000u32);
+    // Setting the identical value again must not error
+    assert!(ctx.escrow().set_storage_limit(&ctx.admin, &50_000u32));
+    assert_eq!(ctx.escrow().get_storage_limit(), 50_000);
+}
+
+// ── Failed sets leave state unchanged ────────────────────────────────────────
+
+#[test]
+fn rejected_out_of_range_set_does_not_change_stored_value() {
+    let ctx = Ctx::new();
+    ctx.escrow().set_storage_limit(&ctx.admin, &100_000u32);
+
+    // Attempt an out-of-range set (zero)
+    let _ = ctx.escrow().try_set_storage_limit(&ctx.admin, &0u32);
+
+    // Original value must be unchanged
+    assert_eq!(ctx.escrow().get_storage_limit(), 100_000);
+}
+
+#[test]
+fn rejected_non_admin_set_does_not_change_stored_value() {
+    let ctx = Ctx::new();
+    ctx.escrow().set_storage_limit(&ctx.admin, &100_000u32);
+
+    let impostor = Address::generate(&ctx.env);
+    let _ = ctx.escrow().try_set_storage_limit(&impostor, &200_000u32);
+
+    assert_eq!(ctx.escrow().get_storage_limit(), 100_000);
+}
+
+// ── Auth-free read ────────────────────────────────────────────────────────────
+
+#[test]
+fn get_storage_limit_requires_no_auth() {
+    // Deliberately omit mock_all_auths — get_storage_limit must not require auth
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    // Should return the compile-time default without panicking
+    assert_eq!(client.get_storage_limit(), DEFAULT_STORAGE_LIMIT);
+}
+
+// ── Event emission ────────────────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_emits_storage_limit_event() {
+    let ctx = Ctx::new();
+    let new_limit: u32 = 200_000;
+    ctx.escrow().set_storage_limit(&ctx.admin, &new_limit);
+
+    let events = ctx.env.events().all();
+    let topic = Symbol::new(&ctx.env, "storage_limit");
+    let found = events.iter().any(|event| {
+        !event.1.is_empty()
+            && Symbol::try_from_val(&ctx.env, &event.1.get(0).unwrap())
+                .ok()
+                .as_ref()
+                == Some(&topic)
+    });
+    assert!(
+        found,
+        "storage_limit event must be emitted on a successful set"
+    );
+}
+
+#[test]
+fn set_storage_limit_no_event_on_rejected_call() {
+    let ctx = Ctx::new();
+    // Trigger a rejection (zero is out of range)
+    let _ = ctx.escrow().try_set_storage_limit(&ctx.admin, &0u32);
+
+    let events = ctx.env.events().all();
+    let topic = Symbol::new(&ctx.env, "storage_limit");
+    let found = events.iter().any(|event| {
+        !event.1.is_empty()
+            && Symbol::try_from_val(&ctx.env, &event.1.get(0).unwrap())
+                .ok()
+                .as_ref()
+                == Some(&topic)
+    });
+    assert!(
+        !found,
+        "no storage_limit event should be emitted when the call is rejected"
+    );
+}
+
+// ── Boundary exactness ────────────────────────────────────────────────────────
+
+#[test]
+fn set_storage_limit_one_below_min_rejected() {
+    if MIN_STORAGE_LIMIT == 0 {
+        // MIN is already 0; nothing to test below it — skip
+        return;
+    }
+    let ctx = Ctx::new();
+    let below_min = MIN_STORAGE_LIMIT - 1;
+    let result = ctx.escrow().try_set_storage_limit(&ctx.admin, &below_min);
+    assert_contract_error(result, Error::StorageLimitOutOfRange);
+}
+
+#[test]
+fn set_storage_limit_one_above_max_rejected_via_constant() {
+    let ctx = Ctx::new();
+    let result = ctx
+        .escrow()
+        .try_set_storage_limit(&ctx.admin, &(MAX_STORAGE_LIMIT + 1));
+    assert_contract_error(result, Error::StorageLimitOutOfRange);
+}
+
+// ── Constants ordering invariant ──────────────────────────────────────────────
+
+#[test]
+fn constants_satisfy_ordering_invariant() {
+    assert!(
+        MIN_STORAGE_LIMIT >= 1,
+        "MIN_STORAGE_LIMIT must be at least 1"
+    );
+    assert!(
+        MAX_STORAGE_LIMIT > MIN_STORAGE_LIMIT,
+        "MAX_STORAGE_LIMIT must exceed MIN"
+    );
+    assert!(
+        DEFAULT_STORAGE_LIMIT >= MIN_STORAGE_LIMIT,
+        "DEFAULT must be >= MIN"
+    );
+    assert!(
+        DEFAULT_STORAGE_LIMIT <= MAX_STORAGE_LIMIT,
+        "DEFAULT must be <= MAX"
+    );
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -86,6 +86,8 @@ pub enum DataKey {
     AccumulatedProtocolFees,
     GovernedParameters,
     ReadinessChecklist,
+    /// Admin-configurable upper bound on single-contract storage size (bytes).
+    StorageLimit,
     // Finalization
     Finalization(u32),
     // Settlement token
@@ -193,6 +195,11 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// The requested storage limit falls outside the permitted range.
+    ///
+    /// The storage limit must be between [`MIN_STORAGE_LIMIT`] (1) and
+    /// [`MAX_STORAGE_LIMIT`] (the compile-time hard cap) inclusive.
+    StorageLimitOutOfRange = 54,
 }
 
 /// Contract lifecycle states


### PR DESCRIPTION
## Summary

Makes the per-contract storage cap a runtime admin-configurable parameter instead of a compile-time constant, as requested in #901.

## Changes

### `contracts/escrow/src/types.rs`
- Added `DataKey::StorageLimit` storage key
- Added `Error::StorageLimitOutOfRange = 54`

### `contracts/escrow/src/lib.rs`
- Added three public constants:
  - `MIN_STORAGE_LIMIT = 1` (minimum accepted value)
  - `MAX_STORAGE_LIMIT = 1_000_000` (maximum accepted value, in bytes)
  - `DEFAULT_STORAGE_LIMIT = 65_536` (64 KiB default — preserves existing behaviour)

### `contracts/escrow/src/governance.rs`
- `set_storage_limit(env, admin, new_limit: u32) -> bool`
  - Requires `initialize` to have been called
  - Requires caller to be the stored admin (`admin.require_auth()`)
  - Rejects values outside `[MIN_STORAGE_LIMIT, MAX_STORAGE_LIMIT]` with `Error::StorageLimitOutOfRange`
  - Emits a `("storage_limit",) → (old_limit, new_limit, admin, timestamp)` event on success
- `get_storage_limit(env) -> u32`
  - Returns stored value or `DEFAULT_STORAGE_LIMIT` — auth-free read-only

### `contracts/escrow/src/test/storage_limit.rs` (new)
20 tests covering the full specification.

## Test Output

```
running 20 tests
test test::storage_limit::constants_satisfy_ordering_invariant ... ok
test test::storage_limit::get_storage_limit_requires_no_auth ... ok
test test::storage_limit::get_storage_limit_returns_default_before_any_set ... ok
test test::storage_limit::rejected_non_admin_set_does_not_change_stored_value ... ok
test test::storage_limit::rejected_out_of_range_set_does_not_change_stored_value ... ok
test test::storage_limit::set_storage_limit_default_value_accepted ... ok
test test::storage_limit::set_storage_limit_emits_storage_limit_event ... ok
test test::storage_limit::set_storage_limit_last_write_wins ... ok
test test::storage_limit::set_storage_limit_max_boundary_accepted ... ok
test test::storage_limit::set_storage_limit_min_boundary_accepted ... ok
test test::storage_limit::set_storage_limit_no_event_on_rejected_call ... ok
test test::storage_limit::set_storage_limit_one_above_max_rejected_via_constant ... ok
test test::storage_limit::set_storage_limit_one_below_min_rejected ... ok
test test::storage_limit::set_storage_limit_persists_and_get_reflects_it ... ok
test test::storage_limit::set_storage_limit_rejects_non_admin ... ok
test test::storage_limit::set_storage_limit_rejects_one_above_max ... ok
test test::storage_limit::set_storage_limit_rejects_u32_max ... ok
test test::storage_limit::set_storage_limit_rejects_when_not_initialized ... ok
test test::storage_limit::set_storage_limit_rejects_zero ... ok
test test::storage_limit::set_storage_limit_same_value_twice_succeeds ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 338 filtered out; finished in 0.15s
```

`cargo fmt --all -- --check` ✅  
No new clippy errors introduced in changed files ✅

Closes #901