### PR TITLE
refactor(escrow): extract require_settlement_token helper (#807)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -185,6 +185,21 @@ impl Escrow {
             .persistent()
             .set(&DataKey::SettlementToken, token);
     }
+
+    /// Return a ready-to-use `token::Client` for the bound settlement token.
+    ///
+    /// Panics with `SettlementTokenNotConfigured` when no token has been bound
+    /// yet (i.e. `bind_settlement_token` has not been called). This is the
+    /// single place that enforces the "token must be configured before any
+    /// value-moving operation" precondition; all transfer-bearing entrypoints
+    /// (`deposit_funds`, `release_milestone`, `refund_unreleased_milestones`,
+    /// `cancel_contract`, `withdraw_protocol_fees`) route through here rather
+    /// than repeating the inline fetch-and-panic pattern.
+    pub(crate) fn require_settlement_token(env: &Env) -> token::Client {
+        let addr = Self::read_settlement_token(env)
+            .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
+        token::Client::new(env, &addr)
+    }
 }
 
 #[contractimpl]
@@ -506,10 +521,7 @@ impl Escrow {
         // rejected deposits cannot debit the client and then fail state checks.
         let validated = deposit::validate_deposit(&env, contract_id, &caller, amount);
 
-        let token = Self::read_settlement_token(&env)
-            .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
-
-        let token_client = token::Client::new(&env, &token);
+        let token_client = Self::require_settlement_token(&env);
         token_client.transfer(&caller, &env.current_contract_address(), &amount);
 
         deposit::apply_validated_deposit(&env, contract_id, caller, validated)
@@ -836,9 +848,7 @@ impl Escrow {
         // Transfer the net amount (gross minus fee) to the freelancer.
         // The fee portion remains in the contract's token balance and is
         // tracked separately in AccumulatedProtocolFees.
-        let token = Self::read_settlement_token(&env)
-            .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
-        let token_client = token::Client::new(&env, &token);
+        let token_client = Self::require_settlement_token(&env);
         token_client.transfer(
             &env.current_contract_address(),
             &contract.freelancer,
@@ -1102,10 +1112,7 @@ impl Escrow {
         }
 
         // Transfer tokens from contract to client
-        let token = Self::read_settlement_token(&env)
-            .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
-
-        let token_client = token::Client::new(&env, &token);
+        let token_client = Self::require_settlement_token(&env);
         token_client.transfer(
             &env.current_contract_address(),
             &contract.client,
@@ -1622,9 +1629,7 @@ impl Escrow {
         let refund_amount =
             contract.funded_amount - contract.released_amount - contract.refunded_amount;
         if refund_amount > 0 {
-            let token = Self::read_settlement_token(&env)
-                .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
-            token::Client::new(&env, &token).transfer(
+            Self::require_settlement_token(&env).transfer(
                 &env.current_contract_address(),
                 &client,
                 &refund_amount,
@@ -2043,10 +2048,7 @@ impl Escrow {
             env.panic_with_error(EscrowError::InsufficientAccumulatedFees);
         }
 
-        let token = match Self::read_settlement_token(&env) {
-            Some(t) => t,
-            None => env.panic_with_error(Error::SettlementTokenNotConfigured),
-        };
+        let token_client = Self::require_settlement_token(&env);
 
         let new_accumulated = accumulated - amount;
         env.storage()
@@ -2059,7 +2061,6 @@ impl Escrow {
             ttl::PERSISTENT_TTL_LEDGERS,
         );
 
-        let token_client = soroban_sdk::token::Client::new(&env, &token);
         token_client.transfer(&env.current_contract_address(), &to, &amount);
 
         env.events().publish(


### PR DESCRIPTION
closes #807 
Multiple transfer-bearing entrypoints (deposit_funds, release_milestone, refund_unreleased_milestones, cancel_contract, withdraw_protocol_fees) each repeated the same three-line settlement precondition inline:

    let token = Self::read_settlement_token(&env)
        .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
    let token::Client::new(&env, &token);

This commit extracts that pattern into a single private helper:

    pub(crate) fn require_settlement_token(env: &Env) -> token::Client

All five call sites now route through the helper. Behaviour is unchanged: the same SettlementTokenNotConfigured error is returned on every path that previously panicked inline.

Notable fix: cancel_contract previously used EscrowError::NotInitialized as a fallback for the missing-token case; it now correctly uses Error::SettlementTokenNotConfigured, consistent with every other entrypoint and with the test in sac_custody.rs.

No ABI change: require_settlement_token is pub(crate) and not a contract entrypoint. No public function signatures were modified.