### PR TITLE
Return concrete defaults from get_governed_parameters instead of None

### DIFF
--- a/contracts/escrow/src/create_contract.rs
+++ b/contracts/escrow/src/create_contract.rs
@@ -1,6 +1,6 @@
 use crate::{
     amount_validation, ttl, Contract, ContractStatus, DataKey, Error, Escrow, EscrowArgs,
-    EscrowClient, EscrowError, GovernedParameters, Milestone, ReleaseAuthorization, MAX_MILESTONES,
+    EscrowClient, EscrowError, Milestone, ReleaseAuthorization, MAX_MILESTONES,
 };
 use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol, Vec};
 
@@ -85,13 +85,9 @@ impl Escrow {
             env.panic_with_error(EscrowError::TooManyMilestones);
         }
 
-        // Retrieve governed parameters for total escrow cap; allow any total if unset.
-        let max_total = env
-            .storage()
-            .persistent()
-            .get::<_, GovernedParameters>(&DataKey::GovernedParameters)
-            .map(|params| params.max_escrow_total_stroops)
-            .unwrap_or(i128::MAX);
+        // Retrieve governed parameters for total escrow cap; returns defaults
+        // (i128::MAX) when `set_governed_params` has never been called.
+        let max_total = Self::get_governed_parameters(env.clone()).max_escrow_total_stroops;
 
         // Validate milestone amounts and enforce the total cap via the canonical helper.
         let mut native_milestones = [0_i128; MAX_MILESTONES as usize];

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -249,7 +249,42 @@ impl Escrow {
     }
 
     /// Retrieve the current governed parameters.
-    pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
-        env.storage().persistent().get(&DataKey::GovernedParameters)
+    ///
+    /// Returns a [`GovernedParameters`] value populated from storage when
+    /// `set_governed_params` has been called, or from the same default
+    /// constants the enforcement code uses when storage is empty.
+    ///
+    /// The defaults match what the enforcement paths apply when no
+    /// governance parameters have been configured:
+    /// - `protocol_fee_bps`: `0` (no protocol fee withheld on release)
+    /// - `max_escrow_total_stroops`: `i128::MAX` (no effective cap)
+    ///
+    /// Callers that need to distinguish "governance has not written" from
+    /// "governance wrote values that happen to match defaults" should use
+    /// [`is_governed_params_set`](Self::is_governed_params_set) which
+    /// checks whether `set_governed_params` has ever succeeded.
+    pub fn get_governed_parameters(env: Env) -> GovernedParameters {
+        env.storage()
+            .persistent()
+            .get::<_, GovernedParameters>(&DataKey::GovernedParameters)
+            .unwrap_or(GovernedParameters {
+                protocol_fee_bps: 0,
+                max_escrow_total_stroops: i128::MAX,
+            })
+    }
+
+    /// Returns `true` if `set_governed_params` has ever been called
+    /// successfully, `false` otherwise.
+    ///
+    /// This lets integrators distinguish between "governance wrote defaults"
+    /// and "governance has not written anything yet". The underlying flag
+    /// is the `governed_params_set` field of the [`ReadinessChecklist`]
+    /// stored under [`DataKey::ReadinessChecklist`].
+    pub fn is_governed_params_set(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get::<_, crate::ReadinessChecklist>(&DataKey::ReadinessChecklist)
+            .map(|c| c.governed_params_set)
+            .unwrap_or(false)
     }
 }

--- a/contracts/escrow/src/test/mainnet_readiness.rs
+++ b/contracts/escrow/src/test/mainnet_readiness.rs
@@ -71,7 +71,7 @@ fn set_governed_params_sets_governed_params() {
         "governed_params_set must be true after set_governed_params()"
     );
 
-    let params = client.get_governed_parameters().unwrap();
+    let params = client.get_governed_parameters();
     assert_eq!(params.protocol_fee_bps, 1000);
     assert_eq!(params.max_escrow_total_stroops, 500_000_000_000_i128);
 }
@@ -255,6 +255,81 @@ fn finalized_record_carries_current_schema_version() {
         record.summary.schema_version, CONTRACT_SUMMARY_SCHEMA_VERSION,
         "finalized record must carry the current schema version"
     );
+}
+
+// ── 4.14 ────────────────────────────────────────────────────────────────────
+// Before set_governed_params, get_governed_parameters returns defaults.
+#[test]
+fn get_governed_parameters_returns_defaults_when_unset() {
+    let (env, contract_id) = setup();
+    let client = EscrowClient::new(&env, &contract_id);
+
+    // Without any initialization, get_governed_parameters must return
+    // concrete defaults instead of None.
+    let params = client.get_governed_parameters();
+    assert_eq!(
+        params.protocol_fee_bps, 0,
+        "default protocol_fee_bps should be 0"
+    );
+    assert_eq!(
+        params.max_escrow_total_stroops,
+        i128::MAX,
+        "default max_escrow_total_stroops should be i128::MAX"
+    );
+
+    // The companion flag must report that params have NOT been explicitly set.
+    assert!(
+        !client.is_governed_params_set(),
+        "is_governed_params_set should be false before set_governed_params"
+    );
+}
+
+// ── 4.15 ────────────────────────────────────────────────────────────────────
+// After set_governed_params, get_governed_parameters returns stored values
+// and is_governed_params_set flips to true, even when values match defaults.
+#[test]
+fn set_governed_params_updates_parameters_and_flag() {
+    let (env, contract_id) = setup();
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Before setting: defaults active, flag is false.
+    let before = client.get_governed_parameters();
+    assert_eq!(before.protocol_fee_bps, 0);
+    assert_eq!(before.max_escrow_total_stroops, i128::MAX);
+    assert!(!client.is_governed_params_set());
+
+    // Set governed params to match defaults explicitly.
+    assert!(client.set_governed_params(&admin, &0_u32, &i128::MAX));
+
+    // After setting: values unchanged, but flag is now true.
+    let after = client.get_governed_parameters();
+    assert_eq!(after.protocol_fee_bps, 0);
+    assert_eq!(after.max_escrow_total_stroops, i128::MAX);
+    assert!(
+        client.is_governed_params_set(),
+        "is_governed_params_set should be true after set_governed_params"
+    );
+}
+
+// ── 4.16 ────────────────────────────────────────────────────────────────────
+// Setting governed params to non-default values works correctly.
+#[test]
+fn set_governed_params_to_custom_values() {
+    let (env, contract_id) = setup();
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    assert!(client.set_governed_params(&admin, &250_u32, &1_000_000_000_000_i128));
+
+    let params = client.get_governed_parameters();
+    assert_eq!(params.protocol_fee_bps, 250);
+    assert_eq!(params.max_escrow_total_stroops, 1_000_000_000_000_i128);
+    assert!(client.is_governed_params_set());
 }
 
 /// Confirms that a fresh contract (no successful initialize) still reports

--- a/docs/escrow/abi-reference.md
+++ b/docs/escrow/abi-reference.md
@@ -422,10 +422,19 @@ The list intentionally omits planned or reserved entrypoints that are not implem
 
 ### get_governed_parameters
 
-- Signature: `get_governed_parameters(env: Env) -> Option<GovernedParameters>`
+- Signature: `get_governed_parameters(env: Env) -> GovernedParameters`
 - Kind: Read-only
 - Auth: None
-- Semantics: Returns the stored governance parameters, if present.
+- Semantics: Returns the current governance parameters. When `set_governed_params` has not been called, returns safe defaults (`protocol_fee_bps: 0`, `max_escrow_total_stroops: i128::MAX`) that match the enforcement code's fallback values. Use [`is_governed_params_set`](#is_governed_params_set) to distinguish "unset" from "set to matching defaults".
+- Events: None
+- Errors: None
+
+### is_governed_params_set
+
+- Signature: `is_governed_params_set(env: Env) -> bool`
+- Kind: Read-only
+- Auth: None
+- Semantics: Returns `true` if `set_governed_params` has ever been called successfully, `false` otherwise. This lets integrators distinguish between "governance has not written anything yet" (defaults active, flag is `false`) and "governance wrote values that happen to match defaults" (defaults active, flag is `true`).
 - Events: None
 - Errors: None
 

--- a/tests/abi_reference_doc_test.rs
+++ b/tests/abi_reference_doc_test.rs
@@ -54,6 +54,7 @@ fn abi_reference_document_lists_current_public_entrypoints() {
         "get_governance_admin",
         "set_governed_params",
         "get_governed_parameters",
+        "is_governed_params_set",
     ];
 
     for entrypoint in expected_entrypoints {


### PR DESCRIPTION
## Summary

Changes `get_governed_parameters` to return a concrete `GovernedParameters` value instead of `Option<GovernedParameters>`. When no governance parameters have been explicitly set via `set_governed_params`, the function now returns the same default constants that the enforcement code uses as fallbacks — eliminating the mismatch where integrators would see `None` even though hardcoded limits were actively in effect.

Closes #739

## Motivation

`get_governed_parameters` previously returned `Option<GovernedParameters>` and yielded `None` until `set_governed_params` had been called. Meanwhile, the enforcement paths (`create_contract` for the escrow cap, `get_protocol_fee_bps` for the fee rate) continued to apply hardcoded fallback values:

- `protocol_fee_bps` → `0` (from `get_protocol_fee_bps`'s `unwrap_or(0)`)
- `max_escrow_total_stroops` → `i128::MAX` (from `create_contract`'s `unwrap_or(i128::MAX)`)

Integrators calling `get_governed_parameters` would see `None` even though meaningful limits were actively enforced, misrepresenting the actual on-chain behavior.

## Changes

### `contracts/escrow/src/governance.rs`

**`get_governed_parameters`**
- Return type changed from `Option<GovernedParameters>` to `GovernedParameters`.
- Defaults when storage is empty:
  - `protocol_fee_bps: 0` — matches `get_protocol_fee_bps` default
  - `max_escrow_total_stroops: i128::MAX` — matches `create_contract` fallback
- Updated doc comments explaining the defaults and recommending `is_governed_params_set` for callers that need to distinguish "unset" from "set to matching defaults".

**`is_governed_params_set`** (new)
- Public read-only function returning `bool`.
- Reads the `governed_params_set` field from `ReadinessChecklist`, which is flipped to `true` exclusively by `set_governed_params`.
- Lets integrators distinguish "governance has never written" from "governance wrote values that happen to match defaults".
- Auth-free and read-only — no storage mutation.

### `contracts/escrow/src/create_contract.rs`

- Simplified the escrow-cap retrieval: replaced manual storage read with `unwrap_or(i128::MAX)` with `Self::get_governed_parameters(env.clone()).max_escrow_total_stroops`.
- Removed unused `GovernedParameters` import (no longer needed since we don't directly deserialize from storage).

### `contracts/escrow/src/test/mainnet_readiness.rs`

- **Updated existing test (4.3)**: Removed `.unwrap()` from `client.get_governed_parameters().unwrap()` — the function no longer returns `Option`.

**Added 3 new tests:**
- **4.14 `get_governed_parameters_returns_defaults_when_unset`**: Verifies default values (0 fee, `i128::MAX` cap) + `is_governed_params_set` returns `false` before any governance configuration.
- **4.15 `set_governed_params_updates_parameters_and_flag`**: Verifies that explicitly setting params to match defaults flips `is_governed_params_set` to `true` while values remain identical.
- **4.16 `set_governed_params_to_custom_values`**: Verifies setting custom values (250 bps, 1T stroops) works correctly with both `get_governed_parameters` and `is_governed_params_set`.

### `tests/abi_reference_doc_test.rs`

- Added `"is_governed_params_set"` to the list of expected public entrypoints in the ABI reference doc test.

### `docs/escrow/abi-reference.md`

- Updated `get_governed_parameters` entry: new signature (`GovernedParameters` return type), updated semantics description, and cross-reference to `is_governed_params_set`.
- Added new entry for `is_governed_params_set` with signature, semantics, and guidance for integrators.

## Design Decisions

### Why not keep `Option` and add a separate default getter?

Combining the defaults into a single return value improves the developer experience — callers no longer need to handle the `None` case or know about the fallback constants. The companion boolean provides the discrimination that `Option` previously offered, but only for callers that actually need it.

### Why `is_governed_params_set` instead of a timestamp?

A boolean is sufficient for the stated requirement ("tell whether governance has explicitly written parameters"). A timestamp would add storage overhead and complexity without a clear use case. The `ReadinessChecklist.governed_params_set` flag was already being maintained — this change simply exposes it through a dedicated entrypoint.

### Why not change `set_protocol_fee_bps` to also set the governed params flag?

`set_protocol_fee_bps` is a legacy entrypoint that only writes `ProtocolFeeBps`, not `GovernedParameters`. The new `set_governed_params` is the canonical path that writes both. We keep them separate to maintain backward compatibility.

## Migration Path

### For off-chain callers (indexers, clients)

Before:
```rust
if let Some(params) = contract.get_governed_parameters() {
    // use params
} else {
    // assume defaults
}
```

After:
```rust
let params = contract.get_governed_parameters();
// params always has concrete values

// Optional: check if explicitly set
if contract.is_governed_params_set() {
    // governance has configured these
}
```

## Backward Compatibility

- **Storage format**: No changes. The `GovernedParameters` struct and `DataKey::GovernedParameters` serialization are untouched.
- **ReadinessChecklist**: The `governed_params_set` flag was already being set by `set_governed_params`; this change only exposes it.
- **In-repo callers**: All references to `get_governed_parameters` have been updated (test in `mainnet_readiness.rs`).

## Testing

- Existing tests pass with minor `.unwrap()` adjustments.
- New tests cover the three key states: unset (defaults), set-to-defaults (flag true, values unchanged), and custom values.

## Related

- Implements the requirement from issue #739
- See `docs/escrow/abi-reference.md` for updated entrypoint documentation

Closes #739 
