### PR TITLE
feat(reputation): add versioned migration path for reputation storage (#1012)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -56,6 +56,7 @@ mod approvals;
 mod deposit;
 mod finalize;
 mod migration;
+mod reputation_migration;
 mod ttl;
 mod types;
 mod utils;
@@ -83,7 +84,7 @@ pub use types::{
     Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
     DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
     MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
-    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION, REPUTATION_STORAGE_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -1776,9 +1777,7 @@ impl Escrow {
     }
 
     pub fn get_reputation(env: Env, address: Address) -> Option<types::Reputation> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Reputation(address))
+        reputation_migration::read_reputation_with_migration(&env, &address)
     }
 
     /// Returns the freelancer's average rating scaled to basis points (×10 000),
@@ -1820,6 +1819,40 @@ impl Escrow {
             .persistent()
             .get(&DataKey::PendingReputationCredits(address))
             .unwrap_or(0)
+    }
+
+    /// Migrate the reputation storage record for `address` to the current schema version.
+    ///
+    /// This entrypoint is idempotent: calling it on an already-current record is a
+    /// safe no-op and returns `false`. When a v1 (legacy) record is detected the
+    /// migration writes a [`DataKey::ReputationStorageVersion`] marker alongside the
+    /// existing data and returns `true`. All field values are preserved exactly.
+    ///
+    /// # When to call
+    ///
+    /// Existing records written before versioning was introduced are transparently
+    /// upgraded on every `get_reputation` read via the migration-on-read path, so
+    /// most callers never need to call this directly. This explicit entrypoint is
+    /// intended for operators who want to eagerly migrate a known address (e.g. as
+    /// part of a deployment runbook) and receive a clear success/no-op signal.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` — The freelancer address whose reputation record should be migrated.
+    ///
+    /// # Returns
+    ///
+    /// `true` if a migration was performed; `false` if the record was already at
+    /// [`REPUTATION_STORAGE_VERSION`] or no record existed (no migration needed).
+    ///
+    /// # Security
+    ///
+    /// This is a permissionless read-equivalent: it does not transfer funds,
+    /// change authorizations, or mutate business state beyond writing the version
+    /// marker. Pause and emergency checks are intentionally omitted so operators
+    /// can still migrate records during an incident pause.
+    pub fn migrate_reputation_storage(env: Env, address: Address) -> bool {
+        reputation_migration::migrate_reputation_storage_impl(&env, &address)
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/escrow/src/reputation_migration.rs
+++ b/contracts/escrow/src/reputation_migration.rs
@@ -1,0 +1,125 @@
+//! Versioned migration path for reputation storage.
+//!
+//! ## Storage schema versions
+//!
+//! | Version | Key written | Description |
+//! |---------|-------------|-------------|
+//! | v1 (absent) | — | Original layout. Only [`DataKey::Reputation(address)`] is present. No version marker is stored. This is the "legacy" state: any address whose [`DataKey::ReputationStorageVersion`] is missing is considered v1. |
+//! | v2 (current) | [`DataKey::ReputationStorageVersion(address)`] = `2` | Same [`Reputation`] struct, but a version marker is written alongside it. The marker allows future migrations to distinguish "freshly written by a v2-aware build" from "written before versioning existed". |
+//!
+//! ## Migration semantics
+//!
+//! * **No-op for current version**: if the version marker already equals
+//!   [`REPUTATION_STORAGE_VERSION`] (`2`), `migrate_reputation_storage_impl`
+//!   returns `false` immediately without touching storage.
+//! * **No-op when absent**: if no reputation record exists for the address,
+//!   there is nothing to migrate — returns `false` and leaves storage untouched.
+//! * **v1 → v2**: reads the existing [`Reputation`] value, re-writes it to
+//!   refresh its TTL, then writes the version marker. All field values are
+//!   preserved exactly.
+//! * **Migration-on-read** ([`read_reputation_with_migration`]): called from
+//!   `get_reputation` so every read transparently upgrades legacy records.
+//!
+//! ## Append-only error codes
+//!
+//! No new `EscrowError` variants are required; the function returns `false`
+//! for the no-op path and `true` for an actual migration, keeping the ABI
+//! minimal.
+
+use crate::{
+    ttl::{PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS},
+    DataKey, Reputation, REPUTATION_STORAGE_VERSION,
+};
+use soroban_sdk::{Address, Env};
+
+// ── Version helpers ──────────────────────────────────────────────────────────
+
+/// Read the stored schema version for `address`.
+/// Returns `1` when the version key is absent (pre-versioning layout).
+pub(crate) fn read_reputation_version(env: &Env, address: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get::<_, u32>(&DataKey::ReputationStorageVersion(address.clone()))
+        .unwrap_or(1)
+}
+
+/// Persist the current schema version marker for `address` with the standard
+/// persistent TTL, then bump it via the threshold policy.
+fn write_reputation_version(env: &Env, address: &Address) {
+    let key = DataKey::ReputationStorageVersion(address.clone());
+    env.storage()
+        .persistent()
+        .set(&key, &REPUTATION_STORAGE_VERSION);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+}
+
+// ── Core migration ───────────────────────────────────────────────────────────
+
+/// Upgrade the reputation record for `address` from any older schema to the
+/// current version.
+///
+/// Returns `true` when an actual migration was performed, `false` when the
+/// record was already at the current version (no-op) or when no record exists
+/// for the address (nothing to migrate).
+///
+/// # Behaviour by version
+///
+/// * **v1 → v2 (record present)**: reads the existing [`Reputation`] value,
+///   re-writes it to refresh its TTL, then writes the version marker. All
+///   field values are preserved exactly.
+/// * **v1 (no record)**: returns `false` immediately without touching storage.
+///   An address with no reputation history has nothing to migrate.
+/// * **v2 (current)**: returns `false` immediately; storage is untouched.
+pub(crate) fn migrate_reputation_storage_impl(env: &Env, address: &Address) -> bool {
+    let current_version = read_reputation_version(env, address);
+
+    if current_version >= REPUTATION_STORAGE_VERSION {
+        // Already at current version — nothing to do.
+        return false;
+    }
+
+    // v1 → v2: preserve the existing reputation record, then write the marker.
+    //
+    // If there is no reputation record for this address at all, there is nothing
+    // to migrate — return false and leave storage completely untouched.
+    let rep_key = DataKey::Reputation(address.clone());
+    let rep: Reputation = match env.storage().persistent().get(&rep_key) {
+        Some(r) => r,
+        None => return false,
+    };
+
+    // Re-write the reputation record to refresh its TTL alongside the version marker.
+    env.storage().persistent().set(&rep_key, &rep);
+    env.storage().persistent().extend_ttl(
+        &rep_key,
+        PERSISTENT_BUMP_THRESHOLD,
+        PERSISTENT_TTL_LEDGERS,
+    );
+
+    write_reputation_version(env, address);
+
+    true
+}
+
+// ── Migration-on-read ────────────────────────────────────────────────────────
+
+/// Read the [`Reputation`] for `address`, transparently migrating a legacy v1
+/// record to v2 before returning it.
+///
+/// Returns `None` when no reputation record exists (neither v1 nor v2). The
+/// migration step is a no-op for absent records, so `None` is returned cleanly.
+///
+/// This is the canonical read path used by `get_reputation` so callers always
+/// observe up-to-date versioned records without needing an explicit migration
+/// call.
+pub(crate) fn read_reputation_with_migration(env: &Env, address: &Address) -> Option<Reputation> {
+    // Attempt a silent migration first; this is a no-op for current-version
+    // records and also a no-op for absent records.
+    migrate_reputation_storage_impl(env, address);
+
+    env.storage()
+        .persistent()
+        .get(&DataKey::Reputation(address.clone()))
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -24,6 +24,7 @@ mod refund;
 mod release;
 mod release_authorization;
 mod reputation;
+mod reputation_migration;
 mod security;
 mod ttl_tests;
 

--- a/contracts/escrow/src/test/reputation_migration.rs
+++ b/contracts/escrow/src/test/reputation_migration.rs
@@ -1,0 +1,477 @@
+//! Tests for the versioned reputation storage migration path (issue #1012).
+//!
+//! Coverage matrix
+//! ───────────────
+//! | Scenario | Test |
+//! |----------|------|
+//! | v1 (legacy) record migrates to v2, data preserved | [`migration_v1_to_v2_preserves_data`] |
+//! | v1 record with zero values migrates cleanly | [`migration_v1_zero_values_migrates`] |
+//! | v2 (current) record is a no-op, returns false | [`migration_current_version_is_noop`] |
+//! | Absent record (never written) is a no-op, storage untouched | [`migration_absent_record_is_noop`] |
+//! | migration-on-read via get_reputation upgrades v1 in place | [`get_reputation_transparently_migrates_v1`] |
+//! | get_reputation on absent address returns None | [`get_reputation_absent_returns_none`] |
+//! | multiple migrate calls are idempotent | [`migrate_is_idempotent`] |
+//! | migrate_reputation_storage public entrypoint returns true on migration | [`public_entrypoint_returns_true_on_migration`] |
+//! | public entrypoint returns false for already-current record | [`public_entrypoint_returns_false_on_noop`] |
+//! | version marker is written with correct value after migration | [`version_marker_written_correctly`] |
+//! | reputation issued after migration is still readable | [`issue_reputation_after_migration_readable`] |
+//! | public entrypoint on unknown address does not panic | [`public_entrypoint_unknown_address_does_not_panic`] |
+
+use crate::{
+    reputation_migration::{migrate_reputation_storage_impl, read_reputation_version},
+    DataKey, Reputation, REPUTATION_STORAGE_VERSION,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use super::register_client;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Write a bare v1 reputation record directly into persistent storage, bypassing
+/// the version marker, to simulate legacy on-chain state.
+fn write_v1_reputation(env: &Env, escrow_addr: &Address, address: &Address, rep: &Reputation) {
+    env.as_contract(escrow_addr, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reputation(address.clone()), rep);
+        // Intentionally do NOT write ReputationStorageVersion — this is the v1 layout.
+    });
+}
+
+/// Read the version marker directly from persistent storage (None = never written).
+fn read_version_direct(env: &Env, escrow_addr: &Address, address: &Address) -> Option<u32> {
+    env.as_contract(escrow_addr, || {
+        env.storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::ReputationStorageVersion(address.clone()))
+    })
+}
+
+/// Read the reputation record directly from persistent storage.
+fn read_reputation_direct(
+    env: &Env,
+    escrow_addr: &Address,
+    address: &Address,
+) -> Option<Reputation> {
+    env.as_contract(escrow_addr, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Reputation(address.clone()))
+    })
+}
+
+fn valid_comment(env: &Env) -> String {
+    String::from_str(env, "Great work!")
+}
+
+// ── Migration correctness ────────────────────────────────────────────────────
+
+/// A v1 record (no version marker) is upgraded to v2 and all field values are
+/// preserved exactly.
+#[test]
+fn migration_v1_to_v2_preserves_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let original = Reputation {
+        completed_contracts: 7,
+        total_rating: 31,
+        last_rating: 4,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &original);
+
+    // Confirm pre-migration state: no version marker, record is present.
+    assert_eq!(read_version_direct(&env, &escrow_addr, &freelancer), None);
+
+    let migrated = env.as_contract(&escrow_addr, || {
+        migrate_reputation_storage_impl(&env, &freelancer)
+    });
+    assert!(
+        migrated,
+        "expected migration to report true for a v1 record"
+    );
+
+    // Post-migration: version marker must equal the current version.
+    assert_eq!(
+        read_version_direct(&env, &escrow_addr, &freelancer),
+        Some(REPUTATION_STORAGE_VERSION)
+    );
+
+    // Data preserved exactly.
+    let after = read_reputation_direct(&env, &escrow_addr, &freelancer)
+        .expect("reputation record must be present after migration");
+    assert_eq!(after.completed_contracts, 7);
+    assert_eq!(after.total_rating, 31);
+    assert_eq!(after.last_rating, 4);
+}
+
+/// A v1 record with all-zero fields migrates cleanly; the version marker is
+/// written and the zero-value record is preserved.
+#[test]
+fn migration_v1_zero_values_migrates() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let zeroed = Reputation {
+        completed_contracts: 0,
+        total_rating: 0,
+        last_rating: 0,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &zeroed);
+
+    let migrated = env.as_contract(&escrow_addr, || {
+        migrate_reputation_storage_impl(&env, &freelancer)
+    });
+    assert!(migrated);
+
+    env.as_contract(&escrow_addr, || {
+        assert_eq!(
+            read_reputation_version(&env, &freelancer),
+            REPUTATION_STORAGE_VERSION
+        );
+    });
+
+    // Zero-value record must still be present after migration.
+    let after = read_reputation_direct(&env, &escrow_addr, &freelancer);
+    assert!(after.is_some());
+    let after = after.unwrap();
+    assert_eq!(after.completed_contracts, 0);
+    assert_eq!(after.total_rating, 0);
+    assert_eq!(after.last_rating, 0);
+}
+
+/// Calling migration on a record that already has the current version marker
+/// returns false without touching storage.
+#[test]
+fn migration_current_version_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let rep = Reputation {
+        completed_contracts: 3,
+        total_rating: 13,
+        last_rating: 5,
+    };
+    // Write at v1, migrate to v2.
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &rep);
+    let first = env.as_contract(&escrow_addr, || {
+        migrate_reputation_storage_impl(&env, &freelancer)
+    });
+    assert!(first);
+
+    // Second call must be a no-op.
+    let second = env.as_contract(&escrow_addr, || {
+        migrate_reputation_storage_impl(&env, &freelancer)
+    });
+    assert!(!second, "second migration on a v2 record must return false");
+
+    // Data still intact after no-op.
+    let after = read_reputation_direct(&env, &escrow_addr, &freelancer).unwrap();
+    assert_eq!(after.completed_contracts, 3);
+    assert_eq!(after.total_rating, 13);
+    assert_eq!(after.last_rating, 5);
+}
+
+/// An address that has never had a reputation record written: migration returns
+/// false and leaves storage completely untouched (no record, no version marker).
+#[test]
+fn migration_absent_record_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let unknown = Address::generate(&env);
+
+    // Confirm no record exists before migration attempt.
+    assert_eq!(
+        read_reputation_direct(&env, &escrow_addr, &unknown),
+        None,
+        "no record should exist before migration"
+    );
+
+    let result = env.as_contract(&escrow_addr, || {
+        migrate_reputation_storage_impl(&env, &unknown)
+    });
+
+    // Migration of an absent record must return false.
+    assert!(!result, "migration of an absent record must return false");
+
+    // Storage must remain completely untouched.
+    assert_eq!(
+        read_reputation_direct(&env, &escrow_addr, &unknown),
+        None,
+        "absent record must remain None after migration"
+    );
+
+    // Version marker must also remain absent.
+    assert_eq!(
+        read_version_direct(&env, &escrow_addr, &unknown),
+        None,
+        "no version marker must be written for an absent record"
+    );
+}
+
+/// Multiple successive migration calls are idempotent: only the first
+/// returns true; subsequent calls all return false.
+#[test]
+fn migrate_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let rep = Reputation {
+        completed_contracts: 2,
+        total_rating: 9,
+        last_rating: 5,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &rep);
+
+    env.as_contract(&escrow_addr, || {
+        assert!(migrate_reputation_storage_impl(&env, &freelancer));
+        assert!(!migrate_reputation_storage_impl(&env, &freelancer));
+        assert!(!migrate_reputation_storage_impl(&env, &freelancer));
+    });
+
+    // Data still intact.
+    let after = read_reputation_direct(&env, &escrow_addr, &freelancer).unwrap();
+    assert_eq!(after.completed_contracts, 2);
+    assert_eq!(after.total_rating, 9);
+    assert_eq!(after.last_rating, 5);
+}
+
+// ── Migration-on-read ────────────────────────────────────────────────────────
+
+/// `get_reputation` transparently migrates a v1 record so callers always see
+/// versioned data without an explicit migration call.
+#[test]
+fn get_reputation_transparently_migrates_v1() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let original = Reputation {
+        completed_contracts: 5,
+        total_rating: 22,
+        last_rating: 4,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &original);
+
+    // Confirm no version marker before the read.
+    assert_eq!(read_version_direct(&env, &escrow_addr, &freelancer), None);
+
+    // get_reputation should trigger migration silently.
+    let result = escrow_client.get_reputation(&freelancer);
+    assert!(result.is_some(), "expected a reputation record");
+    let rep = result.unwrap();
+    assert_eq!(rep.completed_contracts, 5);
+    assert_eq!(rep.total_rating, 22);
+    assert_eq!(rep.last_rating, 4);
+
+    // Version marker must now be present.
+    assert_eq!(
+        read_version_direct(&env, &escrow_addr, &freelancer),
+        Some(REPUTATION_STORAGE_VERSION),
+        "get_reputation must leave a version marker after silent migration"
+    );
+}
+
+/// `get_reputation` returns `None` for an address that has never had reputation written.
+#[test]
+fn get_reputation_absent_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let unknown = Address::generate(&env);
+
+    assert!(escrow_client.get_reputation(&unknown).is_none());
+}
+
+// ── Public entrypoint ─────────────────────────────────────────────────────────
+
+/// The public `migrate_reputation_storage` entrypoint returns `true` when it
+/// upgrades a legacy v1 record.
+#[test]
+fn public_entrypoint_returns_true_on_migration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let rep = Reputation {
+        completed_contracts: 1,
+        total_rating: 5,
+        last_rating: 5,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &rep);
+
+    let result = escrow_client.migrate_reputation_storage(&freelancer);
+    assert!(
+        result,
+        "entrypoint must return true when migrating a v1 record"
+    );
+
+    // Record preserved.
+    let after = escrow_client
+        .get_reputation(&freelancer)
+        .expect("record must exist after migration");
+    assert_eq!(after.completed_contracts, 1);
+    assert_eq!(after.total_rating, 5);
+    assert_eq!(after.last_rating, 5);
+}
+
+/// The public `migrate_reputation_storage` entrypoint returns `false` when the
+/// record is already at the current version.
+#[test]
+fn public_entrypoint_returns_false_on_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let rep = Reputation {
+        completed_contracts: 2,
+        total_rating: 8,
+        last_rating: 4,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &rep);
+
+    // First call migrates.
+    assert!(escrow_client.migrate_reputation_storage(&freelancer));
+    // Second call is a no-op.
+    assert!(!escrow_client.migrate_reputation_storage(&freelancer));
+}
+
+/// After migration the version marker equals `REPUTATION_STORAGE_VERSION`.
+#[test]
+fn version_marker_written_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+
+    let rep = Reputation {
+        completed_contracts: 10,
+        total_rating: 45,
+        last_rating: 5,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &rep);
+
+    escrow_client.migrate_reputation_storage(&freelancer);
+
+    assert_eq!(
+        read_version_direct(&env, &escrow_addr, &freelancer),
+        Some(REPUTATION_STORAGE_VERSION),
+        "version marker must equal REPUTATION_STORAGE_VERSION after migration"
+    );
+}
+
+/// Reputation written via `issue_reputation` after an explicit migration is
+/// readable and the version marker remains current.
+///
+/// We set up contract state directly (bypassing `deposit_funds` which requires a
+/// SAC token) because this test targets the migration + reputation storage
+/// interaction, not the full escrow payment flow.
+#[test]
+fn issue_reputation_after_migration_readable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let escrow_addr = escrow_client.address.clone();
+    let freelancer = Address::generate(&env);
+    let client_addr = Address::generate(&env);
+
+    // Seed a v1 reputation record simulating prior on-chain state.
+    let old_rep = Reputation {
+        completed_contracts: 1,
+        total_rating: 3,
+        last_rating: 3,
+    };
+    write_v1_reputation(&env, &escrow_addr, &freelancer, &old_rep);
+
+    // Migrate explicitly via the public entrypoint.
+    assert!(escrow_client.migrate_reputation_storage(&freelancer));
+
+    // Verify version marker is now present.
+    assert_eq!(
+        read_version_direct(&env, &escrow_addr, &freelancer),
+        Some(REPUTATION_STORAGE_VERSION)
+    );
+
+    // Inject a completed contract and pending credit directly into storage so
+    // issue_reputation can execute without needing a full SAC funding flow.
+    let contract_id: u32 = env.as_contract(&escrow_addr, || {
+        let cid: u32 = 9999;
+        let contract = crate::Contract {
+            client: client_addr.clone(),
+            freelancer: freelancer.clone(),
+            arbiter: None,
+            status: crate::ContractStatus::Completed,
+            total_deposited: 1_000,
+            funded_amount: 1_000,
+            released_amount: 1_000,
+            refunded_amount: 0,
+            release_authorization: crate::ReleaseAuthorization::ClientOnly,
+            reputation_issued: false,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(cid), &contract);
+        env.storage().persistent().set(
+            &DataKey::PendingReputationCredits(freelancer.clone()),
+            &1_i128,
+        );
+        cid
+    });
+
+    // issue_reputation must succeed on a previously migrated record.
+    assert!(escrow_client.issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env)));
+
+    // The resulting record must combine the migrated history with the new issuance.
+    let rep = escrow_client
+        .get_reputation(&freelancer)
+        .expect("reputation record must exist after issue_reputation");
+    // completed_contracts: 1 (v1 seed) + 1 (new issuance) = 2
+    assert_eq!(rep.completed_contracts, 2);
+    assert_eq!(rep.last_rating, 5);
+    // total_rating: 3 (v1 seed) + 5 (new issuance) = 8
+    assert_eq!(rep.total_rating, 8);
+
+    // Version marker must still equal the current version.
+    assert_eq!(
+        read_version_direct(&env, &escrow_addr, &freelancer),
+        Some(REPUTATION_STORAGE_VERSION)
+    );
+}
+
+/// The public entrypoint is callable on an unknown address and returns `false`
+/// without panicking (absent record is a no-op).
+#[test]
+fn public_entrypoint_unknown_address_does_not_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_client = register_client(&env);
+    let unknown = Address::generate(&env);
+
+    // Must not panic and must return false (no record to migrate).
+    let result = escrow_client.migrate_reputation_storage(&unknown);
+    assert!(
+        !result,
+        "absent record must return false from public entrypoint"
+    );
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -5,6 +5,17 @@ use soroban_sdk::{contracterror, contracttype, Address, String, Vec};
 #[allow(dead_code)]
 pub const CONTRACT_SUMMARY_SCHEMA_VERSION: u32 = 1;
 
+/// Current reputation storage schema version.
+///
+/// Increment this constant whenever the [`Reputation`] struct gains or removes
+/// fields, so the migration path can detect and upgrade stale on-chain layouts.
+///
+/// | Version | Description |
+/// |---------|-------------|
+/// | 1 (absent) | Original three-field layout: `completed_contracts`, `total_rating`, `last_rating`. |
+/// | 2 (current) | Same fields plus explicit `schema_version` marker written to storage. |
+pub const REPUTATION_STORAGE_VERSION: u32 = 2;
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MilestoneSummary {
@@ -74,6 +85,10 @@ pub enum DataKey {
     PendingReputationCredits(Address),
     Reputation(Address),
     ReputationComment(u32),
+    /// Monotonically-increasing schema version for reputation storage.
+    /// Absent means v1 (original layout). Present value equals
+    /// [`REPUTATION_STORAGE_VERSION`].
+    ReputationStorageVersion(Address),
     // Client migration
     PendingClientMigration(u32),
     // Protocol / governance


### PR DESCRIPTION
## Summary

Closes #1012

Adds a versioned migration path for reputation storage so schema changes do not corrupt existing on-chain data.

## Changes

### `contracts/escrow/src/types.rs`
- Added `DataKey::ReputationStorageVersion(Address)` — per-address schema version key
- Added `REPUTATION_STORAGE_VERSION = 2` constant with doc table of all schema versions

### `contracts/escrow/src/reputation_migration.rs` (new)
- `read_reputation_version` — reads stored version marker; returns 1 when absent (pre-versioning layout)
- `migrate_reputation_storage_impl` — upgrades v1→v2: re-writes the existing `Reputation` record to refresh its TTL and stamps the version marker; no-op when record is absent or already at current version; returns `bool` indicating whether a migration occurred
- `read_reputation_with_migration` — migration-on-read wrapper used by `get_reputation`

### `contracts/escrow/src/lib.rs`
- Declares `mod reputation_migration`
- Re-exports `REPUTATION_STORAGE_VERSION`
- `get_reputation` updated to use `read_reputation_with_migration` — every read transparently upgrades legacy records
- New public entrypoint `migrate_reputation_storage(env, address) -> bool` for operators who want to eagerly migrate a known address

### `contracts/escrow/src/test/reputation_migration.rs` (new)
12 tests covering all required paths:

| Test | Scenario |
|------|----------|
| `migration_v1_to_v2_preserves_data` | v1→v2 migration, all field values preserved |
| `migration_v1_zero_values_migrates` | v1 record with zero values migrates cleanly |
| `migration_current_version_is_noop` | already-current record returns false |
| `migration_absent_record_is_noop` | absent record returns false, no storage written |
| `migrate_is_idempotent` | first call true, all subsequent calls false |
| `get_reputation_transparently_migrates_v1` | migration-on-read via `get_reputation` |
| `get_reputation_absent_returns_none` | absent address returns None |
| `public_entrypoint_returns_true_on_migration` | public entrypoint v1→v2 |
| `public_entrypoint_returns_false_on_noop` | public entrypoint no-op |
| `version_marker_written_correctly` | version marker equals `REPUTATION_STORAGE_VERSION` |
| `issue_reputation_after_migration_readable` | history combined after migration + new issuance |
| `public_entrypoint_unknown_address_does_not_panic` | no panic on unknown address |

### `contracts/escrow/src/test/mod.rs`
- Registered `mod reputation_migration`

## Test output

```
running 12 tests
test test::reputation_migration::get_reputation_absent_returns_none ... ok
test test::reputation_migration::get_reputation_transparently_migrates_v1 ... ok
test test::reputation_migration::issue_reputation_after_migration_readable ... ok
test test::reputation_migration::migrate_is_idempotent ... ok
test test::reputation_migration::migration_absent_record_is_noop ... ok
test test::reputation_migration::migration_current_version_is_noop ... ok
test test::reputation_migration::migration_v1_to_v2_preserves_data ... ok
test test::reputation_migration::migration_v1_zero_values_migrates ... ok
test test::reputation_migration::public_entrypoint_returns_false_on_noop ... ok
test test::reputation_migration::public_entrypoint_returns_true_on_migration ... ok
test test::reputation_migration::public_entrypoint_unknown_address_does_not_panic ... ok
test test::reputation_migration::version_marker_written_correctly ... ok

test result: ok. 12 passed; 0 failed; 0 ignored
```

`cargo fmt --all -- --check` passes. `cargo build --workspace` passes with no new warnings.

## Security notes

- `migrate_reputation_storage` is permissionless and intentionally omits the pause gate so operators can migrate records during an incident pause. It cannot transfer funds, change authorization, or mutate business state — it only stamps a storage version marker.
- Migration of an absent record is a strict no-op: no storage is written, preventing phantom reputation records from appearing.
- Append-only error codes: no new `EscrowError` variants added; the entrypoint returns a plain `bool`.