### PR TITLE
feat(escrow): add guarded dispute rollback

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -159,6 +159,10 @@ pub fn finalize_contract_impl(env: &Env, contract_id: u32, finalizer: Address) -
         .persistent()
         .set(&Escrow::finalization_key(contract_id), &record);
 
+    if contract.status == ContractStatus::Disputed {
+        crate::rollback::clear_dispute_rollback(env, contract_id);
+    }
+
     env.events().publish(
         (symbol_short!("finalized"), contract_id),
         (finalizer, record.timestamp),

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -17,6 +17,7 @@
 //! | `deposit` | Deposit preflight and post-transfer accounting used by `deposit_funds`. | `DataKey::Contract(contract_id)` and `(DataKey::Contract(contract_id), "milestones")`. |
 //! | `finalize` | Immutable finalization records, finalization guards, and final contract summaries. | `DataKey::Finalization(contract_id)`; reads `Contract(id)`, `(Contract(id), "milestones")`, `Paused`, and `Emergency`. |
 //! | `migration` | Client migration proposals, acceptance checks, cancellation, and pending-migration reads. | Temporary `DataKey::PendingClientMigration(contract_id)`; reads and updates `DataKey::Contract(contract_id)`. |
+//! | `rollback` | Guarded rollback of unchanged, unresolved disputes. | `DataKey::DisputeRollback(contract_id)`; reads and updates `DataKey::Contract(contract_id)` and its milestones. |
 //! | `ttl` | TTL constants plus helpers for temporary and persistent storage renewal. | Extends caller-provided keys, especially `Contract(id)`, `(Contract(id), "milestones")`, `NextContractId`, participant indexes, approvals, and migrations. |
 //! | `types` | Shared Soroban types, error enums, summaries, governance records, dispute records, and the canonical `DataKey` enum. | Declares storage key schema only; does not access storage itself. |
 //! | `utils` | Small deterministic helpers shared by entrypoints, currently ledger timestamp access. | None. |
@@ -56,6 +57,7 @@ mod approvals;
 mod deposit;
 mod finalize;
 mod migration;
+mod rollback;
 mod ttl;
 mod types;
 mod utils;
@@ -530,6 +532,11 @@ impl Escrow {
     /// - `InvalidStatusTransition` unless status is `Completed` or `Disputed`.
     pub fn finalize_contract(env: Env, contract_id: u32, finalizer: Address) -> bool {
         finalize::finalize_contract_impl(&env, contract_id, finalizer)
+    }
+
+    /// Restore an unchanged, unresolved dispute to its pre-dispute status.
+    pub fn rollback_dispute(env: Env, contract_id: u32) -> bool {
+        rollback::rollback_dispute_impl(&env, contract_id)
     }
 
     /// Return immutable close metadata for `contract_id`, if it has been finalized.
@@ -1040,6 +1047,7 @@ impl Escrow {
             .persistent()
             .get(&DataKey::Contract(contract_id))
             .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+        let was_disputed = contract.status == ContractStatus::Disputed;
 
         // Extend TTL on contract read
         ttl::extend_contract_ttl(&env, contract_id);
@@ -1142,6 +1150,10 @@ impl Escrow {
         env.storage()
             .persistent()
             .set(&DataKey::Contract(contract_id), &contract);
+
+        if was_disputed {
+            rollback::clear_dispute_rollback(&env, contract_id);
+        }
 
         // Extend TTL on contract write (milestone TTL already extended by store_milestones)
         ttl::extend_contract_ttl(&env, contract_id);
@@ -2213,6 +2225,9 @@ impl Escrow {
             _ => env.panic_with_error(Error::InvalidState),
         }
 
+        let milestones = ttl::load_milestones(&env, contract_id);
+        rollback::store_dispute_rollback(&env, contract_id, &contract, &milestones);
+
         contract.status = ContractStatus::Disputed;
         env.storage()
             .persistent()
@@ -2310,6 +2325,7 @@ impl Escrow {
         env.storage()
             .persistent()
             .set(&DataKey::Contract(contract_id), &contract);
+        rollback::clear_dispute_rollback(&env, contract_id);
 
         ttl::extend_contract_ttl(&env, contract_id);
 

--- a/contracts/escrow/src/rollback.rs
+++ b/contracts/escrow/src/rollback.rs
@@ -1,0 +1,102 @@
+use crate::ttl::{PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS};
+use crate::{ttl, Contract, ContractStatus, DataKey, Error, Escrow, Milestone};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeRollbackRecord {
+    pub contract: Contract,
+    pub milestones: Vec<Milestone>,
+}
+
+fn rollback_key(contract_id: u32) -> DataKey {
+    DataKey::DisputeRollback(contract_id)
+}
+
+pub(crate) fn store_dispute_rollback(
+    env: &Env,
+    contract_id: u32,
+    contract: &Contract,
+    milestones: &Vec<Milestone>,
+) {
+    let key = rollback_key(contract_id);
+    env.storage().persistent().set(
+        &key,
+        &DisputeRollbackRecord {
+            contract: contract.clone(),
+            milestones: milestones.clone(),
+        },
+    );
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
+}
+
+pub(crate) fn clear_dispute_rollback(env: &Env, contract_id: u32) {
+    env.storage()
+        .persistent()
+        .remove(&rollback_key(contract_id));
+}
+
+pub(crate) fn rollback_dispute_impl(env: &Env, contract_id: u32) -> bool {
+    Escrow::require_initialized(env);
+    Escrow::require_not_paused(env);
+
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+    admin.require_auth();
+
+    let mut contract: Contract = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Contract(contract_id))
+        .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+    Escrow::require_not_finalized(env, contract_id);
+    if contract.status != ContractStatus::Disputed {
+        env.panic_with_error(Error::RollbackNotAllowed);
+    }
+
+    let record: DisputeRollbackRecord = env
+        .storage()
+        .persistent()
+        .get(&rollback_key(contract_id))
+        .unwrap_or_else(|| env.panic_with_error(Error::RollbackNotAllowed));
+
+    if !matches!(
+        record.contract.status,
+        ContractStatus::Funded | ContractStatus::PartiallyFunded
+    ) {
+        env.panic_with_error(Error::RollbackNotAllowed);
+    }
+
+    let mut expected_contract = record.contract.clone();
+    expected_contract.status = ContractStatus::Disputed;
+    let milestones = ttl::load_milestones(env, contract_id);
+    if contract != expected_contract || milestones != record.milestones {
+        env.panic_with_error(Error::RollbackStateChanged);
+    }
+
+    let restored_status = record.contract.status;
+    contract.status = restored_status;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Contract(contract_id), &contract);
+    clear_dispute_rollback(env, contract_id);
+    ttl::extend_contract_and_milestones_ttl(env, contract_id);
+
+    env.events().publish(
+        (symbol_short!("rollback"), contract_id),
+        (
+            admin,
+            ContractStatus::Disputed,
+            restored_status,
+            env.ledger().timestamp(),
+        ),
+    );
+
+    true
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -24,6 +24,7 @@ mod refund;
 mod release;
 mod release_authorization;
 mod reputation;
+mod rollback;
 mod security;
 mod ttl_tests;
 

--- a/contracts/escrow/src/test/rollback.rs
+++ b/contracts/escrow/src/test/rollback.rs
@@ -1,0 +1,306 @@
+use crate::{
+    Contract, ContractStatus, DataKey, DisputeResolution, Error, Escrow, EscrowClient,
+    ReleaseAuthorization,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events},
+    token, vec, Address, Env, Symbol, TryFromVal,
+};
+
+struct RollbackContext {
+    env: Env,
+    escrow_address: Address,
+    admin: Address,
+    client: Address,
+    freelancer: Address,
+    arbiter: Address,
+    contract_id: u32,
+    token: Address,
+}
+
+impl RollbackContext {
+    fn escrow(&self) -> EscrowClient<'_> {
+        EscrowClient::new(&self.env, &self.escrow_address)
+    }
+}
+
+fn setup(deposit: i128) -> RollbackContext {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let client_address = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let escrow_address = env.register(Escrow, ());
+    let escrow = EscrowClient::new(&env, &escrow_address);
+    escrow.initialize(&admin);
+
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    escrow.bind_settlement_token(&admin, &token);
+
+    let contract_id = escrow.create_contract(
+        &client_address,
+        &freelancer,
+        &Some(arbiter.clone()),
+        &vec![&env, 100_i128, 200_i128],
+        &ReleaseAuthorization::ClientOnly,
+    );
+    token::StellarAssetClient::new(&env, &token).mint(&client_address, &300_i128);
+    escrow.deposit_funds(&contract_id, &client_address, &deposit);
+
+    RollbackContext {
+        env,
+        escrow_address,
+        admin,
+        client: client_address,
+        freelancer,
+        arbiter,
+        contract_id,
+        token,
+    }
+}
+
+fn set_status(context: &RollbackContext, status: ContractStatus) {
+    context.env.as_contract(&context.escrow_address, || {
+        let key = DataKey::Contract(context.contract_id);
+        let mut contract: Contract = context.env.storage().persistent().get(&key).unwrap();
+        contract.status = status;
+        context.env.storage().persistent().set(&key, &contract);
+    });
+}
+
+fn has_rollback_record(context: &RollbackContext) -> bool {
+    context.env.as_contract(&context.escrow_address, || {
+        context
+            .env
+            .storage()
+            .persistent()
+            .has(&DataKey::DisputeRollback(context.contract_id))
+    })
+}
+
+fn rollback_event_count(context: &RollbackContext) -> usize {
+    let topic = symbol_short!("rollback");
+    context
+        .env
+        .events()
+        .all()
+        .iter()
+        .filter(|event| {
+            event.0 == context.escrow_address
+                && Symbol::try_from_val(&context.env, &event.1.get(0).unwrap()).ok()
+                    == Some(topic.clone())
+        })
+        .count()
+}
+
+#[test]
+fn rollback_restores_funded_state_without_changing_value() {
+    let context = setup(300);
+    let escrow = context.escrow();
+    let token = token::Client::new(&context.env, &context.token);
+
+    let contract_before = escrow.get_contract(&context.contract_id);
+    let milestones_before = escrow.get_milestones(&context.contract_id);
+    let escrow_balance = token.balance(&context.escrow_address);
+    let client_balance = token.balance(&context.client);
+    let freelancer_balance = token.balance(&context.freelancer);
+
+    escrow.raise_dispute(&context.contract_id, &context.client);
+    assert!(has_rollback_record(&context));
+    assert!(escrow.rollback_dispute(&context.contract_id));
+    let auths = context.env.auths();
+    assert_eq!(auths.len(), 1);
+    assert_eq!(auths[0].0, context.admin);
+
+    assert_eq!(escrow.get_contract(&context.contract_id), contract_before);
+    assert_eq!(
+        escrow.get_milestones(&context.contract_id),
+        milestones_before
+    );
+    assert_eq!(token.balance(&context.escrow_address), escrow_balance);
+    assert_eq!(token.balance(&context.client), client_balance);
+    assert_eq!(token.balance(&context.freelancer), freelancer_balance);
+    assert!(!has_rollback_record(&context));
+}
+
+#[test]
+fn rollback_restores_partially_funded_state() {
+    let context = setup(100);
+    let escrow = context.escrow();
+
+    assert_eq!(
+        escrow.get_contract(&context.contract_id).status,
+        ContractStatus::PartiallyFunded
+    );
+    escrow.raise_dispute(&context.contract_id, &context.freelancer);
+    escrow.rollback_dispute(&context.contract_id);
+
+    assert_eq!(
+        escrow.get_contract(&context.contract_id).status,
+        ContractStatus::PartiallyFunded
+    );
+}
+
+#[test]
+fn rollback_requires_admin_authorization() {
+    let context = setup(300);
+    let escrow = context.escrow();
+    escrow.raise_dispute(&context.contract_id, &context.client);
+    context.env.mock_auths(&[]);
+
+    assert!(escrow.try_rollback_dispute(&context.contract_id).is_err());
+    assert_eq!(
+        escrow.get_contract(&context.contract_id).status,
+        ContractStatus::Disputed
+    );
+    assert!(has_rollback_record(&context));
+}
+
+#[test]
+fn rollback_rejects_missing_contract_and_non_disputed_states() {
+    let context = setup(300);
+    let escrow = context.escrow();
+
+    super::assert_contract_error(
+        escrow.try_rollback_dispute(&999_u32),
+        Error::ContractNotFound,
+    );
+
+    for status in [
+        ContractStatus::Created,
+        ContractStatus::Funded,
+        ContractStatus::Completed,
+        ContractStatus::Cancelled,
+        ContractStatus::Refunded,
+    ] {
+        set_status(&context, status);
+        super::assert_contract_error(
+            escrow.try_rollback_dispute(&context.contract_id),
+            Error::RollbackNotAllowed,
+        );
+    }
+}
+
+#[test]
+fn rollback_rejects_changed_state() {
+    let context = setup(300);
+    let escrow = context.escrow();
+    escrow.raise_dispute(&context.contract_id, &context.client);
+
+    context.env.as_contract(&context.escrow_address, || {
+        let key = DataKey::Contract(context.contract_id);
+        let mut contract: Contract = context.env.storage().persistent().get(&key).unwrap();
+        contract.refunded_amount = 1;
+        context.env.storage().persistent().set(&key, &contract);
+    });
+
+    super::assert_contract_error(
+        escrow.try_rollback_dispute(&context.contract_id),
+        Error::RollbackStateChanged,
+    );
+    assert_eq!(rollback_event_count(&context), 0);
+}
+
+#[test]
+fn refund_closes_rollback_window() {
+    let context = setup(300);
+    let escrow = context.escrow();
+    escrow.raise_dispute(&context.contract_id, &context.client);
+    escrow.refund_unreleased_milestones(&context.contract_id, &vec![&context.env, 0_u32]);
+
+    assert!(!has_rollback_record(&context));
+    super::assert_contract_error(
+        escrow.try_rollback_dispute(&context.contract_id),
+        Error::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn resolution_and_finalization_close_rollback_window() {
+    let resolved = setup(300);
+    let resolved_escrow = resolved.escrow();
+    resolved_escrow.raise_dispute(&resolved.contract_id, &resolved.client);
+    resolved_escrow.resolve_dispute(
+        &resolved.contract_id,
+        &resolved.arbiter,
+        &DisputeResolution::FullRefund,
+    );
+    assert!(!has_rollback_record(&resolved));
+    super::assert_contract_error(
+        resolved_escrow.try_rollback_dispute(&resolved.contract_id),
+        Error::RollbackNotAllowed,
+    );
+
+    let finalized = setup(300);
+    let finalized_escrow = finalized.escrow();
+    finalized_escrow.raise_dispute(&finalized.contract_id, &finalized.client);
+    finalized_escrow.finalize_contract(&finalized.contract_id, &finalized.client);
+    assert!(!has_rollback_record(&finalized));
+    super::assert_contract_error(
+        finalized_escrow.try_rollback_dispute(&finalized.contract_id),
+        Error::AlreadyFinalized,
+    );
+}
+
+#[test]
+fn rollback_is_single_use_and_emits_expected_event() {
+    let context = setup(300);
+    let escrow = context.escrow();
+    escrow.raise_dispute(&context.contract_id, &context.client);
+    escrow.rollback_dispute(&context.contract_id);
+
+    let topic = symbol_short!("rollback");
+    let event = context
+        .env
+        .events()
+        .all()
+        .iter()
+        .find(|event| {
+            event.0 == context.escrow_address
+                && Symbol::try_from_val(&context.env, &event.1.get(0).unwrap()).ok()
+                    == Some(topic.clone())
+        })
+        .unwrap();
+    assert_eq!(event.1.len(), 2);
+    assert_eq!(
+        u32::try_from_val(&context.env, &event.1.get(1).unwrap()).unwrap(),
+        context.contract_id
+    );
+    let data =
+        <(Address, ContractStatus, ContractStatus, u64)>::try_from_val(&context.env, &event.2)
+            .unwrap();
+    assert_eq!(
+        data,
+        (
+            context.admin.clone(),
+            ContractStatus::Disputed,
+            ContractStatus::Funded,
+            context.env.ledger().timestamp(),
+        )
+    );
+    assert_eq!(rollback_event_count(&context), 1);
+
+    super::assert_contract_error(
+        escrow.try_rollback_dispute(&context.contract_id),
+        Error::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn pause_blocks_rollback() {
+    let context = setup(300);
+    let escrow = context.escrow();
+    escrow.raise_dispute(&context.contract_id, &context.client);
+    escrow.pause();
+
+    super::assert_contract_error(
+        escrow.try_rollback_dispute(&context.contract_id),
+        Error::ContractPaused,
+    );
+    assert!(has_rollback_record(&context));
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -90,6 +90,7 @@ pub enum DataKey {
     Finalization(u32),
     // Settlement token
     SettlementToken,
+    DisputeRollback(u32),
 }
 
 /// Canonical contract error type for all entrypoint-facing errors.
@@ -193,6 +194,10 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// No safe rollback is available for the contract's current state.
+    RollbackNotAllowed = 54,
+    /// Contract or milestone state changed after the rollback point was recorded.
+    RollbackStateChanged = 55,
 }
 
 /// Contract lifecycle states

--- a/docs/escrow/abi-reference.md
+++ b/docs/escrow/abi-reference.md
@@ -285,6 +285,15 @@ The list intentionally omits planned or reserved entrypoints that are not implem
 - Events: `("dispute", "resolved")`
 - Errors: `ContractPaused`, `EmergencyActive`, `ContractNotFound`, `UnauthorizedRole`, `InvalidStatusTransition`, `InvalidDisputeSplit`, `AccountingInvariantViolated`, `PotentialOverflow`, `AlreadyFinalized`
 
+### rollback_dispute
+
+- Signature: `rollback_dispute(env: Env, contract_id: u32) -> bool`
+- Kind: Mutating
+- Auth: Stored admin `require_auth()`
+- Semantics: Restores an unresolved dispute to its recorded `Funded` or `PartiallyFunded` status only when the contract and milestones are unchanged since the dispute opened. Refund, resolution, or finalization permanently closes the rollback window.
+- Events: `("rollback", contract_id)` with `(admin, Disputed, restored_status, timestamp)`
+- Errors: `ContractPaused`, `EmergencyActive`, `ContractNotFound`, `AlreadyFinalized`, `RollbackNotAllowed`, `RollbackStateChanged`
+
 ### issue_reputation
 
 - Signature: `issue_reputation(env: Env, contract_id: u32, caller: Address, rating: u32, comment: String) -> bool`


### PR DESCRIPTION
## Summary

- Add an admin-authorized rollback for unresolved escrow disputes.
- Restore only the exact pre-dispute `Funded` or `PartiallyFunded` status.
- Snapshot the contract and milestones when a dispute is raised, then reject rollback if either state changes.
- Close the rollback window after refunds, dispute resolution, finalization, or a successful rollback.
- Emit a rollback event and return typed errors for unavailable or changed rollback state.
- Document the new entrypoint in the escrow ABI reference.

## Safety

The rollback does not move tokens or reconstruct financial state. It only restores the recorded pre-dispute status when the contract and milestone state still match the dispute snapshot. Existing disputes without a snapshot fail closed.

## Testing

Focused rollback tests:

```text
running 9 tests
.........
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 340 filtered out
```

The tests cover:

- Successful rollback to `Funded` and `PartiallyFunded`
- Stored admin authorization and non-admin rejection
- Rejection outside `Disputed`
- Rejection after contract or milestone state changes
- Rollback closure after refunds, resolution, and finalization
- Replay rejection
- Event payload
- Pause enforcement
- Contract, milestone, and token balance preservation

Coverage for `contracts/escrow/src/rollback.rs`:

```text
Lines:   76 / 79   (96.20%)
Regions: 102 / 107 (95.33%)
```

Additional checks:

```text
cargo fmt --all -- --check                         PASS
cargo build --workspace --release                  PASS
git diff --check                                   PASS
cargo test --workspace                             BASELINE FAILURE
cargo clippy --workspace --all-targets -- -D warnings  BASELINE FAILURE
```

The full workspace test run reports 159 passed, 181 failed, and 7 ignored. The failures reproduce on the current upstream commit and are primarily existing `SettlementTokenNotConfigured` failures in unrelated tests. Clippy also reports existing warnings in untouched files. The new rollback module and its focused tests introduce no Clippy errors.

Closes #999
