### PR TITLE
fix: read real reputation_issued flag in ContractSummary snapshot

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -105,13 +105,19 @@ impl Escrow {
             });
         }
 
+        let reputation_issued = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&DataKey::ReputationIssued(contract_id))
+            .unwrap_or(false);
+
         ContractSummary {
             schema_version: 1,
             client: contract.client.clone(),
             freelancer: contract.freelancer.clone(),
             arbiter: contract.arbiter.clone(),
             status: contract.status,
-            reputation_issued: contract.reputation_issued,
+            reputation_issued,
             total_amount,
             funded_amount: contract.funded_amount,
             released_amount: contract.released_amount,

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -328,3 +328,30 @@ fn get_average_rating_fractional_average_is_preserved() {
     // total_rating=3, completed_contracts=2 → 3 * 10_000 / 2 = 15_000
     assert_eq!(client.get_average_rating(&freelancer_addr), Some(15_000));
 }
+
+#[test]
+fn finalize_reflects_reputation_issued_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    
+    // Contract 1: Finalize WITHOUT issuing reputation
+    let (client_addr1, _freelancer_addr1, contract_id1) = complete_contract(&env, &client);
+    let summary1 = client.get_contract_summary(&contract_id1);
+    assert_eq!(summary1.reputation_issued, false);
+    
+    assert!(client.finalize_contract(&contract_id1, &client_addr1));
+    let final_record1 = client.get_finalization_record(&contract_id1).unwrap();
+    assert_eq!(final_record1.summary.reputation_issued, false);
+
+    // Contract 2: Finalize AFTER issuing reputation
+    let (client_addr2, _freelancer_addr2, contract_id2) = complete_contract(&env, &client);
+    assert!(client.issue_reputation(&contract_id2, &client_addr2, &5, &valid_comment(&env)));
+    
+    let summary2 = client.get_contract_summary(&contract_id2);
+    assert_eq!(summary2.reputation_issued, true);
+    
+    assert!(client.finalize_contract(&contract_id2, &client_addr2));
+    let final_record2 = client.get_finalization_record(&contract_id2).unwrap();
+    assert_eq!(final_record2.summary.reputation_issued, true);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -14,6 +14,9 @@ pub struct MilestoneSummary {
     pub refunded: bool,
 }
 
+/// A point-in-time snapshot of the contract state.
+/// This structure is used for both indexing (`get_contract_summary`) and
+/// the immutable close metadata stored at finalization.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractSummary {
@@ -22,6 +25,8 @@ pub struct ContractSummary {
     pub freelancer: Address,
     pub arbiter: Option<Address>,
     pub status: ContractStatus,
+    /// Indicates whether reputation has been issued for this contract.
+    /// This is determined by reading the `DataKey::ReputationIssued` storage entry.
     pub reputation_issued: bool,
     pub total_amount: i128,
     pub funded_amount: i128,

--- a/docs/escrow/README.md
+++ b/docs/escrow/README.md
@@ -111,7 +111,8 @@ but serve different purposes and must not be conflated:
 milestones vector. Its `schema_version` tracks the limits ABI only.
 `ContractSummary` is the per-contract snapshot used by `get_contract_summary`
 and embedded in `FinalizationRecord`; its schema version tracks per-contract
-data.
+data. Note that `reputation_issued` in `ContractSummary` tracks whether a rating
+was given for the contract by reading the storage-backed `DataKey::ReputationIssued`.
 
 Indexers discovering limits should call `get_bounds()`. Indexers snapshotting
 contract state should call `get_contract_summary()`.


### PR DESCRIPTION
The Problem: summarize_contract in contracts/escrow/src/finalize.rs was hardcoding reputation_issued: false instead of reading DataKey::ReputationIssued(contract_id). Because of this, the immutable close record written by finalize_contract always incorrectly claimed that reputation was not issued for completed contracts that had already received a rating.

The Solution:

Updated summarize_contract to fetch the real flag from storage using DataKey::ReputationIssued(contract_id).
Added NatSpec doc comments (///) to the ContractSummary struct and the reputation_issued field in contracts/escrow/src/types.rs.
Documented the exact field semantics in docs/escrow/README.md.
Wrote comprehensive tests in contracts/escrow/src/test/reputation.rs verifying that finalize_contract accurately persists reputation_issued as both false and true respectively.
closes #691 