### PR TITLE
Add pause guard for mutating escrow entrypoints

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -255,6 +255,7 @@ impl Escrow {
     /// configuration.
     pub fn bind_settlement_token(env: Env, admin: Address, token: Address) -> bool {
         Self::require_initialized(&env);
+        Self::require_not_paused(&env);
         let stored_admin: Address = env
             .storage()
             .persistent()
@@ -2009,17 +2010,7 @@ impl Escrow {
     /// * `to` - The destination address for the withdrawn fees
     pub fn withdraw_protocol_fees(env: Env, amount: i128, to: Address) -> bool {
         Self::require_initialized(&env);
-
-        // Block withdrawal while paused or in emergency — consistent with all
-        // other mutating entrypoints in this contract.
-        if env
-            .storage()
-            .persistent()
-            .get::<_, bool>(&DataKey::Paused)
-            .unwrap_or(false)
-        {
-            env.panic_with_error(EscrowError::ContractPaused);
-        }
+        Self::require_not_paused(&env);
 
         let admin: Address = env
             .storage()

--- a/contracts/escrow/src/test/pause_controls.rs
+++ b/contracts/escrow/src/test/pause_controls.rs
@@ -63,6 +63,57 @@ fn pause_then_unpause_toggles_state() {
     assert!(!client.is_paused());
 }
 
+#[test]
+fn pause_blocks_bind_settlement_token() {
+    let (env, contract_id, admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+    client.pause();
+
+    let token = env.register_stellar_asset_contract(admin.clone());
+    super::assert_contract_error(
+        client.try_bind_settlement_token(&admin, &token),
+        Error::ContractPaused,
+    );
+}
+
+#[test]
+fn unpause_restores_bind_settlement_token() {
+    let (env, contract_id, admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+    client.pause();
+    client.unpause();
+
+    let token = env.register_stellar_asset_contract(admin.clone());
+    assert!(client.bind_settlement_token(&admin, &token));
+}
+
+#[test]
+fn pause_blocks_withdraw_protocol_fees() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+    client.pause();
+
+    let treasury = Address::generate(&env);
+    super::assert_contract_error(
+        client.try_withdraw_protocol_fees(&100_i128, &treasury),
+        Error::ContractPaused,
+    );
+}
+
+#[test]
+fn unpause_restores_withdraw_protocol_fees() {
+    let (env, contract_id, _admin) = setup_initialized();
+    let client = EscrowClient::new(&env, &contract_id);
+    client.pause();
+    client.unpause();
+
+    let treasury = Address::generate(&env);
+    super::assert_contract_error(
+        client.try_withdraw_protocol_fees(&0_i128, &treasury),
+        EscrowError::AmountMustBePositive,
+    );
+}
+
 // --- create_contract ---
 
 #[test]


### PR DESCRIPTION
closes #1064 
#1064 Add a pause-aware guard to escrow
Repo Avatar
[Talenttrust/Talenttrust-Contracts](https://github.com/Talenttrust/Talenttrust-Contracts)
Pause-guard escrow
Description
escrow entrypoints may run while the contract is paused. This issue adds a pause-aware guard where appropriate.

Requirements and context
Repository scope: Talenttrust/Talenttrust-Contracts only.
Reject mutating escrow entrypoints while paused with the typed error; allow read-only ones.
Reuse the existing pause check.
Cover paused-rejected and unpaused-allowed in tests.
Suggested execution
Fork the repo and create a branch
git checkout -b feature/escrow-42-pauseguard
Implement changes
Write code in: the relevant module.
Write comprehensive tests in: cover the new behaviour and edge cases.
Test and commit
Test and commit
Run cargo fmt, cargo clippy --all-targets -- -D warnings, and cargo test.
Cover edge cases: paused rejects writes, unpaused allows, reads allowed.
Include the full test output in the PR description.
Example commit message
feat(escrow): add pause-aware guard

Guidelines
Minimum 95 percent test coverage for impacted modules.
Clear, reviewer-focused documentation.
Timeframe: 96 hours.
Community & contribution rewards
💬 Join the TalentTrust community on Discord: [https://discord.gg/WqnGpcPx](https://www.drips.network/external/https%3A%2F%2Fdiscord.gg%2FWqnGpcPx)
⭐ This is a GrantFox OSS / Official Campaign task and may be rewarded. When your PR is merged you'll be prompted to rate the project — a 5-star rating is much appreciated.