### PR TITLE
refactor(contracts): extract shared load_and_check_contract helper

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -45,6 +45,40 @@ impl Escrow {
         }
     }
 
+    /// Load a contract from persistent storage, extend its TTL, and assert it
+    /// has not been finalized.
+    ///
+    /// This is the canonical shared precondition for every state-changing
+    /// entrypoint that operates on an existing escrow contract:
+    ///
+    /// 1. **Load** — reads `DataKey::Contract(contract_id)` from persistent
+    ///    storage.  Panics with [`Error::ContractNotFound`] when the key is
+    ///    absent.
+    /// 2. **Extend TTL** — calls [`ttl::extend_contract_ttl`] so that active
+    ///    contracts are not evicted from ledger state while they are being
+    ///    mutated.
+    /// 3. **Finalization guard** — calls [`Self::require_not_finalized`], which
+    ///    panics with [`Error::AlreadyFinalized`] when a
+    ///    [`DataKey::Finalization`] record exists for the contract.
+    ///
+    /// Callers that do **not** need the finalization check (currently only
+    /// `issue_reputation`) should call [`ttl::extend_contract_ttl`] and the
+    /// storage `get` directly instead of using this helper.
+    ///
+    /// # Errors
+    /// * [`Error::ContractNotFound`]  — `contract_id` is not in storage.
+    /// * [`Error::AlreadyFinalized`]  — the contract has been finalized.
+    pub(crate) fn load_and_check_contract(env: &Env, contract_id: u32) -> Contract {
+        let contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&crate::DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+        crate::ttl::extend_contract_ttl(env, contract_id);
+        Self::require_not_finalized(env, contract_id);
+        contract
+    }
+
     pub(crate) fn require_not_paused(env: &Env) {
         if env
             .storage()

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -697,16 +697,8 @@ impl Escrow {
         // Authenticate caller before any state-dependent logic
         caller.require_auth();
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-
-        // Extend TTL on contract read
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
+        // Load contract, extend TTL, and assert not finalized via shared helper.
+        let mut contract: Contract = Self::load_and_check_contract(&env, contract_id);
 
         // Verify contract is in Funded state before release (deposit transitions
         // Created → Funded when fully funded, so release must accept Funded).
@@ -1035,16 +1027,8 @@ impl Escrow {
             }
         }
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-
-        // Extend TTL on contract read
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
+        // Load contract, extend TTL, and assert not finalized via shared helper.
+        let mut contract: Contract = Self::load_and_check_contract(&env, contract_id);
 
         // Only allow refunds while the contract is still in an active,
         // unreleased state. Cancelled, Completed, and Refunded contracts
@@ -1592,14 +1576,8 @@ impl Escrow {
     /// * `InvalidStatusTransition` - If the contract is not `Created`/`Funded` or has already released funds.
     pub fn cancel_contract(env: Env, contract_id: u32, client: Address) -> bool {
         Self::require_not_paused(&env);
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
+        // Load contract, extend TTL, and assert not finalized via shared helper.
+        let mut contract: Contract = Self::load_and_check_contract(&env, contract_id);
 
         if client != contract.client {
             env.panic_with_error(EscrowError::UnauthorizedRole);
@@ -1863,14 +1841,8 @@ impl Escrow {
         Self::require_not_paused(&env);
         caller.require_auth();
 
-        let contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-
-        ttl::extend_contract_ttl(&env, contract_id);
-        Self::require_not_finalized(&env, contract_id);
+        // Load contract, extend TTL, and assert not finalized via shared helper.
+        let contract: Contract = Self::load_and_check_contract(&env, contract_id);
 
         if caller != contract.freelancer {
             env.panic_with_error(EscrowError::UnauthorizedRole);
@@ -2188,14 +2160,8 @@ impl Escrow {
         Self::require_not_paused(&env);
         caller.require_auth();
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        ttl::extend_contract_ttl(&env, contract_id);
-        Self::require_not_finalized(&env, contract_id);
+        // Load contract, extend TTL, and assert not finalized via shared helper.
+        let mut contract: Contract = Self::load_and_check_contract(&env, contract_id);
 
         // Verify caller is client or freelancer
         if caller != contract.client && caller != contract.freelancer {
@@ -2272,14 +2238,8 @@ impl Escrow {
         Self::require_not_paused(&env);
         arbiter.require_auth();
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        ttl::extend_contract_ttl(&env, contract_id);
-        Self::require_not_finalized(&env, contract_id);
+        // Load contract, extend TTL, and assert not finalized via shared helper.
+        let mut contract: Contract = Self::load_and_check_contract(&env, contract_id);
 
         // Verify contract is in Disputed state
         if contract.status != ContractStatus::Disputed {


### PR DESCRIPTION
Extracts the repeated three-step contract precondition that was copy-pasted across six
  state-changing entrypoints into a single private helper: Escrow::load_and_check_contract.
  
  Problem
  
  Every mutating entrypoint that operates on an existing escrow contract repeated the same inline
  sequence:
  
  let mut contract: Contract = env
      .storage()
      .persistent()
      .get(&DataKey::Contract(contract_id))
      .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
  
  ttl::extend_contract_ttl(&env, contract_id);
  Self::require_not_finalized(&env, contract_id);
  
  This pattern appeared verbatim (with minor variations in error type) in six places, making it
  easy to miss a step when adding new entrypoints and harder to audit the guard sequence at a
  glance.
  
  Solution
  
  Added Escrow::load_and_check_contract(env, contract_id) -> Contract in finalize.rs alongside
  the existing require_not_paused and require_not_finalized guards. The helper canonicalises the
  three steps:
  
  1. Load — reads DataKey::Contract(contract_id), panics ContractNotFound if absent
  2. Extend TTL — calls ttl::extend_contract_ttl so active contracts are not evicted during
  mutation
  3. Finalization guard — calls require_not_finalized, panics AlreadyFinalized if a finalization
  record exists
  
  Routed all six entrypoints through the helper:
  
  ┌────────────┬────────────┬─────┐
  │ Entrypoint        │ Previously │ Now │
  ├──────────────────────────────┼────────────────┼───────────────────────────────┤
  │ release_milestone            │ 9 lines inline │ Self::load_and_check_contract │
  ├──────────────────────────────┼────────────────┼───────────────────────────────┤
  │ refund_unreleased_milestones │ 9 lines inline │ Self::load_and_check_contract │
  ├──────────────────────────────┼────────────────┼───────────────────────────────┤
  │ cancel_contract              │ 8 lines inline │ Self::load_and_check_contract │
  ├──────────────────────────────┼────────────────┼───────────────────────────────┤
  │ submit_work_evidence         │ 8 lines inline │ Self::load_and_check_contract │
  ├──────────────────────────────┼────────────────┼───────────────────────────────┤
  │ raise_dispute                │ 8 lines inline │ Self::load_and_check_contract │
  ├──────────────────────────────┼────────────────┼───────────────────────────────┤
  │ resolve_dispute              │ 8 lines inline │ Self::load_and_check_contract │
  └──────────────────────────────┴────────────────┴───────────────────────────────┘
  
  issue_reputation intentionally retains its own inline load+TTL — it does not call
  require_not_finalized — and this exception is documented in the helper's doc-comment.
  
  What didn't change
  
  - No ABI change
  - No behavior change
  - All existing error codes and rejection paths are preserved
  - issue_reputation is untouched by design
  
  Diff size
  
  46 insertions, 52 deletions — net reduction in code.

closes #782