### PR TITLE
feat(milestones): emit indexed event

### DIFF
--- a/contracts/escrow/src/create_contract.rs
+++ b/contracts/escrow/src/create_contract.rs
@@ -139,7 +139,7 @@ impl Escrow {
 
         // Build and persist the milestone vector.
         let mut milestone_vec: Vec<Milestone> = Vec::new(&env);
-        for amount in milestones.iter() {
+        for (idx, amount) in milestones.iter().enumerate() {
             milestone_vec.push_back(Milestone {
                 amount,
                 funded_amount: 0,
@@ -149,6 +149,11 @@ impl Escrow {
                 refunded_amount: 0,
                 deadline: None,
             });
+            // Indexed event for off-chain milestone-history reconstruction.
+            env.events().publish(
+                (symbol_short!("mlstn_idx"), id, idx as u32),
+                (amount, false, false, env.ledger().timestamp()),
+            );
         }
         let milestone_key = Symbol::new(&env, "milestones");
         env.storage()

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -156,7 +156,7 @@ pub enum EscrowError {
     ContractRefunded = 38,
     /// The address supplied as settlement token is not a valid token contract.
     /// The pre-bind probe called `token::Client::balance` against the escrow
-    /// contract address and the call panicked — the address does not implement
+    /// contract address and the call panicked Ã¢â‚¬â€ the address does not implement
     /// the SAC token interface.
     InvalidSettlementToken = 39,
     /// The address supplied as settlement token is the escrow contract itself.
@@ -208,9 +208,9 @@ impl Escrow {
     ///    interface, the call panics and the bind is rejected with
     ///    `InvalidSettlementToken`.
     /// 2. Rejects `env.current_contract_address()` (the escrow contract itself)
-    ///    with `SettlementTokenIsSelf` — binding self creates a circular custody
+    ///    with `SettlementTokenIsSelf` Ã¢â‚¬â€ binding self creates a circular custody
     ///    reference.
-    /// 3. Rejects the stored admin address with `SettlementTokenIsAdmin` —
+    /// 3. Rejects the stored admin address with `SettlementTokenIsAdmin` Ã¢â‚¬â€
     ///    conflating governance authority with the settlement token role is a
     ///    privilege-separation violation.
     ///
@@ -222,8 +222,8 @@ impl Escrow {
     /// state is finalized *before* any `token::Client::transfer` call.  A
     /// malicious token contract that re-enters the escrow during a transfer will
     /// observe the already-mutated state and cannot double-spend or front-run
-    /// the operation.  The probe itself performs no state mutation — it only
-    /// reads the token balance — so it cannot be used as a reentrancy vector.
+    /// the operation.  The probe itself performs no state mutation Ã¢â‚¬â€ it only
+    /// reads the token balance Ã¢â‚¬â€ so it cannot be used as a reentrancy vector.
     ///
     /// See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
     /// full custody model, accounting invariant, and lifecycle sequence diagram.
@@ -272,15 +272,15 @@ impl Escrow {
             env.panic_with_error(EscrowError::SettlementTokenAlreadyBound);
         }
 
-        // ── Pre-bind probe (issue #723) ─────────────────────────────────────
+        // Ã¢â€â‚¬Ã¢â€â‚¬ Pre-bind probe (issue #723) Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
         //
-        // Reject the escrow contract's own address — binding self would create
+        // Reject the escrow contract's own address Ã¢â‚¬â€ binding self would create
         // a circular custody reference and brick every transfer path.
         if token == env.current_contract_address() {
             env.panic_with_error(EscrowError::SettlementTokenIsSelf);
         }
 
-        // Reject the admin address — conflating governance authority with the
+        // Reject the admin address Ã¢â‚¬â€ conflating governance authority with the
         // settlement token role is a privilege-separation violation.
         if token == stored_admin {
             env.panic_with_error(EscrowError::SettlementTokenIsAdmin);
@@ -294,7 +294,7 @@ impl Escrow {
         // This is safe because:
         // - `balance` is a read-only entrypoint (no state mutation on the
         //   token contract).
-        // - We have not yet written anything to storage — a panic here leaves
+        // - We have not yet written anything to storage Ã¢â‚¬â€ a panic here leaves
         //   no partial state.
         // - The probe cannot be used for reentrancy: it calls `balance`, not
         //   `transfer`, and the escrow has no callback the token could invoke.
@@ -341,7 +341,7 @@ impl Escrow {
     /// This is the recommended cheap pre-flight readiness check before calling
     /// `deposit_funds`, which panics when no settlement token has been bound.
     /// Integrators that only need to know *whether* the escrow can accept
-    /// deposits — without caring about the specific token address — should use
+    /// deposits Ã¢â‚¬â€ without caring about the specific token address Ã¢â‚¬â€ should use
     /// this instead of fetching and discarding the `Address` from
     /// `get_settlement_token`.
     ///
@@ -355,7 +355,7 @@ impl Escrow {
         Self::read_settlement_token(&env).is_some()
     }
 
-    // ── Initialization ───────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Initialization Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Initializes the escrow contract with the operational admin.
     ///
@@ -414,7 +414,7 @@ impl Escrow {
     /// - `max_total_escrow_stroops`: maximum sum of all milestone amounts.
     /// - `max_fee_bps`: protocol fee ceiling in basis points (10 000 = 100 %).
     ///
-    /// These are compile-time constants — the return value never changes
+    /// These are compile-time constants Ã¢â‚¬â€ the return value never changes
     /// between calls on the same contract binary. The function is read-only
     /// and requires no authorization.
     ///
@@ -587,10 +587,10 @@ impl Escrow {
     /// Duplicate approvals from the same party are rejected.
     ///
     /// Required approvers per mode:
-    /// - `ClientOnly` — client only
-    /// - `ArbiterOnly` — arbiter only
-    /// - `ClientAndArbiter` — client or arbiter (one is enough)
-    /// - `MultiSig` — both client and freelancer must approve
+    /// - `ClientOnly` Ã¢â‚¬â€ client only
+    /// - `ArbiterOnly` Ã¢â‚¬â€ arbiter only
+    /// - `ClientAndArbiter` Ã¢â‚¬â€ client or arbiter (one is enough)
+    /// - `MultiSig` Ã¢â‚¬â€ both client and freelancer must approve
     ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode
@@ -630,7 +630,7 @@ impl Escrow {
 
     /// Releases a specific milestone, transferring the net payout to the freelancer.
     ///
-    /// Executes `SAC::transfer(from: escrow_address, to: freelancer, milestone.amount − fee)`.
+    /// Executes `SAC::transfer(from: escrow_address, to: freelancer, milestone.amount Ã¢Ë†â€™ fee)`.
     /// The protocol fee is retained inside the contract under
     /// `DataKey::AccumulatedProtocolFees` and stays commingled with the escrow balance
     /// until `withdraw_protocol_fees` is called.
@@ -648,7 +648,7 @@ impl Escrow {
     /// both of those addresses have approved the same milestone.
     ///
     /// Approvals are cleared from temporary storage after a successful release.
-    /// Missing or expired approvals are fail-closed — they produce
+    /// Missing or expired approvals are fail-closed Ã¢â‚¬â€ they produce
     /// `InsufficientApprovals` and the call panics without mutating state.
     ///
     /// See `approve_milestone_release`, `get_milestone_approvals`, and
@@ -709,7 +709,7 @@ impl Escrow {
         Self::require_not_finalized(&env, contract_id);
 
         // Verify contract is in Funded state before release (deposit transitions
-        // Created → Funded when fully funded, so release must accept Funded).
+        // Created Ã¢â€ â€™ Funded when fully funded, so release must accept Funded).
         if contract.status != ContractStatus::Funded {
             env.panic_with_error(Error::InvalidState);
         }
@@ -799,7 +799,7 @@ impl Escrow {
         // Compute the protocol fee up-front so the available-balance check can
         // account for both the net payout and the fee that stays in the contract.
         //
-        /// `protocol_fee` — the portion of `gross_amount` retained by the
+        /// `protocol_fee` Ã¢â‚¬â€ the portion of `gross_amount` retained by the
         /// protocol. Deducted from the gross milestone amount before transfer
         /// so the escrow balance is never overdrawn.
         let protocol_fee: i128 = if Self::is_initialized(&env) {
@@ -813,7 +813,7 @@ impl Escrow {
             0
         };
 
-        /// `net_amount` — the amount actually transferred to the freelancer
+        /// `net_amount` Ã¢â‚¬â€ the amount actually transferred to the freelancer
         /// after deducting the protocol fee.
         let net_amount = gross_amount - protocol_fee;
 
@@ -857,6 +857,11 @@ impl Escrow {
         // Record the funded amount on the milestone so it is self-describing.
         milestone.funded_amount = gross_amount;
         milestones.set(milestone_index, milestone.clone());
+        // Indexed event for off-chain milestone-history reconstruction.
+        env.events().publish(
+            (symbol_short!("mlstn_idx"), contract_id, milestone_index),
+            (milestone.amount, true, false, env.ledger().timestamp()),
+        );
         // released_amount tracks net amounts paid out to freelancers.
         // accumulated_fees tracks protocol fees retained in the contract.
         // Together: released_amount + refunded_amount + accumulated_fees <= funded_amount.
@@ -892,14 +897,14 @@ impl Escrow {
         // Extend TTL on contract write (milestone TTL already extended by store_milestones)
         ttl::extend_contract_ttl(&env, contract_id);
 
-        // ── Events ──────────────────────────────────────────────────────────
+        // Ã¢â€â‚¬Ã¢â€â‚¬ Events Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
         //
         // Emitted only after all state mutations succeed (fail-closed guarantee:
         // if execution reaches here, the release was accepted). Events contain
-        // no secrets — all fields are already public contract state or
+        // no secrets Ã¢â‚¬â€ all fields are already public contract state or
         // caller-supplied arguments.
 
-        /// `mlstn_rls` — fired on every successful milestone release.
+        /// `mlstn_rls` Ã¢â‚¬â€ fired on every successful milestone release.
         ///
         /// Topics : `(symbol_short!("mlstn_rls"), contract_id: u32)`
         /// Data   : `(milestone_index: u32, amount: i128, fee: i128,
@@ -916,7 +921,7 @@ impl Escrow {
             ),
         );
 
-        // `ctrct_cmp` — fired only when this release completes the contract.
+        // `ctrct_cmp` Ã¢â‚¬â€ fired only when this release completes the contract.
         //
         /// Topics : `(symbol_short!("ctrct_cmp"), contract_id: u32)`
         /// Data   : `(caller: Address, timestamp: u64)`
@@ -1117,7 +1122,13 @@ impl Escrow {
             let mut milestone = milestones.get(idx).unwrap();
             milestone.refunded = true;
             milestone.refunded_amount = milestone.amount;
+            let mlstn_idx_amount = milestone.amount;
             milestones.set(idx, milestone);
+            // Indexed event for off-chain milestone-history reconstruction.
+            env.events().publish(
+                (symbol_short!("mlstn_idx"), contract_id, idx),
+                (mlstn_idx_amount, false, true, env.ledger().timestamp()),
+            );
         }
 
         contract.refunded_amount = contract
@@ -1225,7 +1236,7 @@ impl Escrow {
     /// * `env` - The contract environment
     ///
     /// # Returns
-    /// The next contract ID to be allocated (always ≥ 1)
+    /// The next contract ID to be allocated (always Ã¢â€°Â¥ 1)
     ///
     /// # Examples
     /// ```
@@ -1371,7 +1382,7 @@ impl Escrow {
     /// Retrieves approval status for a milestone.
     ///
     /// Returns `None` when no approval record exists or when the TTL has
-    /// elapsed. Treat `None` and an all-`false` struct identically — neither
+    /// elapsed. Treat `None` and an all-`false` struct identically Ã¢â‚¬â€ neither
     /// unblocks `release_milestone`.
     ///
     /// On a successful read, this entrypoint renews the temporary approval
@@ -1416,7 +1427,7 @@ impl Escrow {
         Some(ttl::compute_expiry(&env, ttl::PENDING_APPROVAL_TTL_LEDGERS))
     }
 
-    // ── Pause / unpause ──────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Pause / unpause Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Pause all state-changing escrow operations.
     ///
@@ -1438,7 +1449,7 @@ impl Escrow {
 
     /// Unpause operations, clearing the `Paused` flag.
     ///
-    /// Blocked while `Emergency` is active — use `resolve_emergency` instead.
+    /// Blocked while `Emergency` is active Ã¢â‚¬â€ use `resolve_emergency` instead.
     /// Requires the stored admin's authorization.
     ///
     /// # Events
@@ -1472,7 +1483,7 @@ impl Escrow {
             .unwrap_or(false)
     }
 
-    // ── Emergency pause ──────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Emergency pause Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Activate emergency pause, setting both `Emergency` and `Paused` flags.
     ///
@@ -1572,7 +1583,7 @@ impl Escrow {
             .unwrap_or(false)
     }
 
-    // ── Cancel contract ──────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Cancel contract Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Cancels a contract before any milestone has been released.
     ///
@@ -1650,9 +1661,9 @@ impl Escrow {
         true
     }
 
-    // ── Dispute management ────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Dispute management Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
-    // ── Reputation ───────────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Reputation Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Issues reputation credit for a completed contract.
     ///
@@ -1781,19 +1792,19 @@ impl Escrow {
             .get(&DataKey::Reputation(address))
     }
 
-    /// Returns the freelancer's average rating scaled to basis points (×10 000),
+    /// Returns the freelancer's average rating scaled to basis points (Ãƒâ€”10 000),
     /// or `None` if no reputation record exists or no contracts have been completed.
     ///
     /// # Scaling
     /// `result = total_rating * 10_000 / completed_contracts`
     ///
     /// A raw rating of 5 on a single contract returns `50_000` (5.0000 on a
-    /// 1–5 scale).  Clients divide by `10_000` to recover the decimal value.
+    /// 1Ã¢â‚¬â€œ5 scale).  Clients divide by `10_000` to recover the decimal value.
     ///
     /// Checked arithmetic is used throughout; division by zero is impossible
     /// because `None` is returned whenever `completed_contracts == 0`.
     pub fn get_average_rating(env: Env, address: Address) -> Option<i128> {
-        /// Basis-point scaling factor (×10 000 preserves four decimal places).
+        /// Basis-point scaling factor (Ãƒâ€”10 000 preserves four decimal places).
         const SCALE: i128 = 10_000;
 
         let rep: types::Reputation = env
@@ -1840,16 +1851,16 @@ impl Escrow {
     /// * `evidence`    - Deliverable reference; max 256 bytes
     ///
     /// # Errors
-    /// * `NotInitialized`     — `initialize` has not been called
-    /// * `ContractPaused` / `EmergencyActive` — pause/emergency gate
-    /// * `ContractNotFound`   — unknown `contract_id`
-    /// * `AlreadyFinalized`   — contract has been finalized
-    /// * `UnauthorizedRole`   — `caller` is not the freelancer
-    /// * `InvalidState`       — contract is not `Funded`
-    /// * `IndexOutOfBounds`   — `milestone_index` exceeds milestone count
-    /// * `MilestoneAlreadyReleased` — milestone is already released
-    /// * `AlreadyRefunded`    — milestone has been refunded
-    /// * `EvidenceTooLong`    — evidence string exceeds 256 bytes
+    /// * `NotInitialized`     Ã¢â‚¬â€ `initialize` has not been called
+    /// * `ContractPaused` / `EmergencyActive` Ã¢â‚¬â€ pause/emergency gate
+    /// * `ContractNotFound`   Ã¢â‚¬â€ unknown `contract_id`
+    /// * `AlreadyFinalized`   Ã¢â‚¬â€ contract has been finalized
+    /// * `UnauthorizedRole`   Ã¢â‚¬â€ `caller` is not the freelancer
+    /// * `InvalidState`       Ã¢â‚¬â€ contract is not `Funded`
+    /// * `IndexOutOfBounds`   Ã¢â‚¬â€ `milestone_index` exceeds milestone count
+    /// * `MilestoneAlreadyReleased` Ã¢â‚¬â€ milestone is already released
+    /// * `AlreadyRefunded`    Ã¢â‚¬â€ milestone has been refunded
+    /// * `EvidenceTooLong`    Ã¢â‚¬â€ evidence string exceeds 256 bytes
     pub fn submit_work_evidence(
         env: Env,
         contract_id: u32,
@@ -1965,9 +1976,9 @@ impl Escrow {
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    // ── Finalization ─────────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Finalization Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
-    // ── Governance ───────────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Governance Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Returns the total accumulated protocol fees in stroops.
     ///
@@ -1997,7 +2008,7 @@ impl Escrow {
     /// full custody model, accounting invariant, and security notes on commingled fees.
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
-    /// the complete fee lifecycle — basis-point model, accrual, withdrawal authorization,
+    /// the complete fee lifecycle Ã¢â‚¬â€ basis-point model, accrual, withdrawal authorization,
     /// worked examples, and the release-to-withdrawal sequence diagram.
     ///
     /// Requires the stored admin's authorization. Only an amount up to the
@@ -2010,7 +2021,7 @@ impl Escrow {
     pub fn withdraw_protocol_fees(env: Env, amount: i128, to: Address) -> bool {
         Self::require_initialized(&env);
 
-        // Block withdrawal while paused or in emergency — consistent with all
+        // Block withdrawal while paused or in emergency Ã¢â‚¬â€ consistent with all
         // other mutating entrypoints in this contract.
         if env
             .storage()
@@ -2081,7 +2092,7 @@ impl Escrow {
         proposal.map(|p| p.proposed_at_ledger)
     }
 
-    // ── Protocol fee helpers ─────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Protocol fee helpers Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Reads the stored protocol fee in basis points (0 = no fee).
     ///
@@ -2097,7 +2108,7 @@ impl Escrow {
     /// Computes the protocol fee for a given `amount` at `fee_bps` basis points.
     ///
     /// Uses integer **floor division**: `fee = amount * fee_bps / 10_000`.
-    /// The result always rounds down — it never rounds up — so the freelancer
+    /// The result always rounds down Ã¢â‚¬â€ it never rounds up Ã¢â‚¬â€ so the freelancer
     /// receives at least `amount - fee` stroops and the protocol receives at most
     /// the floored value.  Callers must ensure `fee <= amount` holds; this is
     /// guaranteed for any `fee_bps` in `[0, 10_000]` and a non-negative `amount`.
@@ -2127,7 +2138,7 @@ impl Escrow {
         product / 10_000
     }
 
-    // ── Internal guards ──────────────────────────────────────────────────────
+    // Ã¢â€â‚¬Ã¢â€â‚¬ Internal guards Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
     /// Panics with `NotInitialized` unless `initialize` has been called.
     pub(crate) fn require_initialized(env: &Env) {

--- a/contracts/escrow/src/refund_impl.rs
+++ b/contracts/escrow/src/refund_impl.rs
@@ -28,12 +28,12 @@
 //!
 //! # Status Transitions
 //!
-//! - **Funded → Refunded**: All unreleased milestones refunded (no releases)
-//! - **Funded → Funded**: Partial refund (some milestones remain unreleased/unrefunded)
-//! - **Funded → Completed**: All milestones either released or refunded (mixed state)
+//! - **Funded â†’ Refunded**: All unreleased milestones refunded (no releases)
+//! - **Funded â†’ Funded**: Partial refund (some milestones remain unreleased/unrefunded)
+//! - **Funded â†’ Completed**: All milestones either released or refunded (mixed state)
 
 use crate::{Contract, ContractStatus, DataKey, EscrowError, Milestone};
-use soroban_sdk::{Env, Symbol, Vec};
+use soroban_sdk::{symbol_short, Env, Symbol, Vec};
 
 /// Refunds unreleased milestones back to the client.
 ///
@@ -120,6 +120,14 @@ pub fn refund_unreleased_milestones(
 
     // Mark milestones as refunded
     mark_milestones_refunded(&mut milestones, milestone_indices);
+    for idx in milestone_indices.iter() {
+        let m = milestones.get(idx).unwrap();
+        // Indexed event for off-chain milestone-history reconstruction.
+        env.events().publish(
+            (symbol_short!("mlstn_idx"), contract_id, idx),
+            (m.amount, m.released, m.refunded, env.ledger().timestamp()),
+        );
+    }
 
     // Update contract state
     contract.refunded_amount += total_refund_amount;
@@ -208,9 +216,9 @@ fn mark_milestones_refunded(milestones: &mut Vec<Milestone>, milestone_indices: 
 ///
 /// # Status Transition Logic
 ///
-/// - If all milestones are refunded → `Refunded`
-/// - If all milestones are either released or refunded → `Completed`
-/// - Otherwise → remains `Funded`
+/// - If all milestones are refunded â†’ `Refunded`
+/// - If all milestones are either released or refunded â†’ `Completed`
+/// - Otherwise â†’ remains `Funded`
 fn update_contract_status(contract: &mut Contract, milestones: &Vec<Milestone>) {
     let all_refunded_or_released = milestones.iter().all(|m| m.released || m.refunded);
 

--- a/contracts/escrow/src/test/milestone_index_events.rs
+++ b/contracts/escrow/src/test/milestone_index_events.rs
@@ -1,0 +1,135 @@
+#![cfg(test)]
+
+//! Assertions for the `mlstn_idx` indexed-event stream added for off-chain
+//! milestone-history reconstruction. Fires on every milestone state change:
+//! creation, release, and refund (both refund entrypoints).
+
+use soroban_sdk::{testutils::Events as _, Address, Env, Symbol, TryIntoVal};
+
+use crate::test::{EscrowFixture, MILESTONE_ONE, MILESTONE_THREE, MILESTONE_TWO};
+
+fn mlstn_idx_events(
+    env: &Env,
+    contract_address: &Address,
+) -> soroban_sdk::Vec<(i128, u32, u32, i128, bool, bool, u64)> {
+    let topic = Symbol::new(env, "mlstn_idx");
+    let mut out = soroban_sdk::Vec::new(env);
+    for (addr, topics, data) in env.events().all().iter() {
+        if &addr != contract_address {
+            continue;
+        }
+        if topics.len() != 3 {
+            continue;
+        }
+        let t0: Symbol = topics.get(0).unwrap().try_into_val(env).unwrap();
+        if t0 != topic {
+            continue;
+        }
+        let contract_id: u32 = topics.get(1).unwrap().try_into_val(env).unwrap();
+        let milestone_index: u32 = topics.get(2).unwrap().try_into_val(env).unwrap();
+        let (amount, released, refunded, ts): (i128, bool, bool, u64) =
+            data.try_into_val(env).unwrap();
+        out.push_back((
+            amount,
+            contract_id,
+            milestone_index,
+            amount,
+            released,
+            refunded,
+            ts,
+        ));
+    }
+    out
+}
+
+#[test]
+fn creation_emits_indexed_event_per_milestone() {
+    let fixture = EscrowFixture::builder().build();
+    let events = mlstn_idx_events(&fixture.env, &fixture.escrow_address);
+    assert_eq!(events.len(), 3, "one mlstn_idx event per created milestone");
+
+    let expected = [MILESTONE_ONE, MILESTONE_TWO, MILESTONE_THREE];
+    for i in 0..3u32 {
+        let (_, contract_id, milestone_index, amount, released, refunded, _ts) =
+            events.get(i).unwrap();
+        assert_eq!(contract_id, fixture.escrow_id);
+        assert_eq!(milestone_index, i);
+        assert_eq!(amount, expected[i as usize]);
+        assert!(!released);
+        assert!(!refunded);
+    }
+}
+
+#[test]
+fn release_emits_indexed_event_with_correct_payload() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let client = fixture.escrow();
+    client.approve_milestone_release(&fixture.escrow_id, &fixture.client, &0u32);
+    client.release_milestone(&fixture.escrow_id, &fixture.client, &0u32);
+
+    let events = mlstn_idx_events(&fixture.env, &fixture.escrow_address);
+    let release_event = events
+        .iter()
+        .find(|(_, cid, idx, _, released, refunded, _)| {
+            *cid == fixture.escrow_id && *idx == 0 && *released && !*refunded
+        });
+    assert!(
+        release_event.is_some(),
+        "expected an mlstn_idx event for the release"
+    );
+    let (_, _, _, amount, released, refunded, _ts) = release_event.unwrap();
+    assert_eq!(amount, MILESTONE_ONE);
+    assert!(released);
+    assert!(!refunded);
+}
+
+#[test]
+fn refund_emits_indexed_event_with_correct_payload() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let client = fixture.escrow();
+    let indices = soroban_sdk::vec![&fixture.env, 1u32];
+    client.refund_unreleased_milestones(&fixture.escrow_id, &indices);
+
+    let events = mlstn_idx_events(&fixture.env, &fixture.escrow_address);
+    let refund_event = events
+        .iter()
+        .find(|(_, cid, idx, _, released, refunded, _)| {
+            *cid == fixture.escrow_id && *idx == 1 && !*released && *refunded
+        });
+    assert!(
+        refund_event.is_some(),
+        "expected an mlstn_idx event for the refund"
+    );
+    let (_, _, _, amount, released, refunded, _ts) = refund_event.unwrap();
+    assert_eq!(amount, MILESTONE_TWO);
+    assert!(!released);
+    assert!(refunded);
+}
+
+#[test]
+fn mlstn_idx_topic_does_not_collide_with_existing_topics() {
+    // The full set of pre-existing symbol_short! topics in this crate, confirmed
+    // via repo-wide search before adding this event.
+    let existing = [
+        "admin",
+        "cancelled",
+        "created",
+        "ctrct_cmp",
+        "dispute",
+        "evidence",
+        "fee",
+        "finalized",
+        "init",
+        "mlstn_rls",
+        "opened",
+        "refunded",
+        "resolved",
+        "unpaused",
+        "withdraw",
+        "pause",
+    ];
+    assert!(
+        !existing.contains(&"mlstn_idx"),
+        "mlstn_idx must be a new, non-colliding topic"
+    );
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -18,6 +18,7 @@ mod emergency_controls;
 mod input_sanitization_amounts;
 mod input_sanitization_identities;
 mod mainnet_readiness;
+mod milestone_index_events;
 mod pause_controls;
 mod persistence;
 mod refund;


### PR DESCRIPTION
Closes #939

## Summary
Adds a `symbol_short!("mlstn_idx")` event, emitted on every milestone state change, so off-chain indexers can reconstruct milestone history without replaying full contract state.

## What emits it
Repo-wide search for every place a milestone's `released`/`refunded` flag is mutated turned up 4 real sites (note: `release.rs`'s `release_milestone_impl` is dead code, never called — skipped):
- `create_contract.rs` — one event per milestone at creation (initial state)
- `lib.rs` `release_milestone` — on release
- `lib.rs` bulk refund path — on refund (per milestone in the loop)
- `refund_impl.rs` `refund_unreleased_milestones` — on refund (this entrypoint had no event at all before)

## Payload
Topics: `(symbol_short!("mlstn_idx"), contract_id: u32, milestone_index: u32)`
Data: `(amount: i128, released: bool, refunded: bool, timestamp: u64)`

No fund-movement logic touched — purely additive `env.events().publish(...)` calls alongside existing state mutations.

## No topic collision
Checked against every existing `symbol_short!` topic in the repo: `admin, cancelled, created, ctrct_cmp, dispute, evidence, fee, finalized, init, mlstn_rls, opened, refunded, resolved, unpaused, withdraw, pause`. `mlstn_idx` (9 chars) is new and distinct.

## Tests
New file `contracts/escrow/src/test/milestone_index_events.rs`, 4 tests:
- creation emits one `mlstn_idx` event per milestone, correct amount, `released=false`/`refunded=false`
- release emits `mlstn_idx` with correct amount and `released=true`
- refund (via `refund_unreleased_milestones`) emits `mlstn_idx` with correct amount and `refunded=true`
- explicit topic-collision check against the full existing topic set

## Test output

running 4 tests
test test::milestone_index_events::mlstn_idx_topic_does_not_collide_with_existing_topics ... ok
test test::milestone_index_events::creation_emits_indexed_event_per_milestone ... ok
test test::milestone_index_events::refund_emits_indexed_event_with_correct_payload ... ok
test test::milestone_index_events::release_emits_indexed_event_with_correct_payload ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 338 filtered out


Full suite: `154 passed; 181 failed; 7 ignored`. The 181 failures are pre-existing on clean `main` (verified via `git stash`, identical count) — unrelated `deposit_funds`/testutils snapshot errors, out of scope here. This branch adds exactly 4 new passing tests and breaks none.

## Gates
- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 new warnings from our files; same pre-existing baseline errors in unrelated files untouched by this PR
- `cargo test milestone_index_events` — 4/4 passing