### PR TITLE
feat: add simulate_deposit_funds entrypoint for dry-run settlement preview

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -83,7 +83,7 @@ pub use types::{
     Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
     DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
     MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
-    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    SimulateDepositResult, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -513,6 +513,72 @@ impl Escrow {
         token_client.transfer(&caller, &env.current_contract_address(), &amount);
 
         deposit::apply_validated_deposit(&env, contract_id, caller, validated)
+    }
+
+    /// Simulate a deposit without mutating state or moving tokens.
+    ///
+    /// Runs the same preflight validation as [`deposit_funds`](Self::deposit_funds)
+    /// — initialization check, pause guard, deposit validation, settlement-token
+    /// configuration — and returns the projected [`SimulateDepositResult`] that a
+    /// real deposit would produce, but without executing the SAC transfer, writing
+    /// storage, or emitting events.
+    ///
+    /// Because the simulation never calls into the token contract, it does **not**
+    /// require the caller's authorization (no `require_auth`). This makes it a cheap
+    /// read-only pre-flight that callers can invoke to preview the deposit outcome
+    /// before committing to the actual transaction.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    /// * `caller` - The address of the caller
+    /// * `amount` - The amount to simulate depositing (in stroops)
+    ///
+    /// # Returns
+    /// A [`SimulateDepositResult`] with the projected funded amounts and status
+    ///
+    /// # Errors
+    /// Returns the same errors as [`deposit_funds`](Self::deposit_funds):
+    /// * `NotInitialized` if `initialize` has not been called
+    /// * `ContractPaused` if the contract is paused
+    /// * `AmountMustBePositive` if amount is ≤ 0
+    /// * `ContractNotFound` if the contract doesn't exist
+    /// * `UnauthorizedRole` if `caller` is not the client
+    /// * `InvalidState` if the contract is not in `Created` or `PartiallyFunded` state
+    /// * `InvalidDepositAmount` if the deposit would exceed the total milestone amount
+    /// * `SettlementTokenNotConfigured` if no settlement token has been bound
+    pub fn simulate_deposit_funds(
+        env: Env,
+        contract_id: u32,
+        caller: Address,
+        amount: i128,
+    ) -> SimulateDepositResult {
+        Self::require_initialized(&env);
+        Self::require_not_paused(&env);
+
+        // Validate all the same preconditions as the real deposit path.
+        let validated = deposit::validate_deposit(&env, contract_id, &caller, amount);
+
+        // Check settlement-token configuration (same guard as deposit_funds).
+        let _token = Self::read_settlement_token(&env)
+            .unwrap_or_else(|| env.panic_with_error(Error::SettlementTokenNotConfigured));
+
+        // Project the contract status that would result from the deposit.
+        let projected_status = {
+            let total = validated.total_amount;
+            if validated.new_funded_amount == total {
+                ContractStatus::Funded
+            } else {
+                ContractStatus::PartiallyFunded
+            }
+        };
+
+        SimulateDepositResult {
+            current_funded_amount: validated.contract.funded_amount,
+            new_funded_amount: validated.new_funded_amount,
+            projected_status,
+            total_milestone_amount: validated.total_amount,
+        }
     }
 
     /// Finalize an escrow contract by writing immutable close metadata.

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -25,6 +25,7 @@ mod release;
 mod release_authorization;
 mod reputation;
 mod security;
+mod simulate_deposit;
 mod ttl_tests;
 
 // --- Shared constants ---

--- a/contracts/escrow/src/test/simulate_deposit.rs
+++ b/contracts/escrow/src/test/simulate_deposit.rs
@@ -1,0 +1,379 @@
+//! Tests for `simulate_deposit_funds` – a read-only preview of the deposit
+//! outcome that runs the same validation as the real `deposit_funds` entrypoint
+//! without executing the SAC transfer, writing storage, or emitting events.
+//!
+//! Coverage matrix:
+//!
+//! | Path                          | Positive cases | Negative cases |
+//! |-------------------------------|---------------|----------------|
+//! | `simulate_deposit_funds`      | matches real full deposit | unbound token rejected |
+//! |                               | matches real partial deposit | non-client rejected |
+//! |                               | idempotent (no state mutation) | non-positive amount rejected |
+//! |                               | projected status correct | cancelled contract rejected |
+//! |                               | — | refunded contract rejected |
+//! |                               | — | invalid-state (Funded) rejected |
+//! |                               | — | over-funding rejected |
+//! |                               | — | not-initialized rejected |
+//! |                               | — | paused rejected |
+//! | State mutation                | simulation does not change contract state | — |
+//! |                               | simulation does not move tokens | — |
+//!
+//! Run locally with `cargo test -p escrow --lib simulate_deposit`.
+
+#![cfg(test)]
+#![allow(deprecated)]
+
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec as SorobanVec,
+};
+
+use super::{
+    assert_contract_error, total_milestone_amount, MILESTONE_ONE, MILESTONE_THREE, MILESTONE_TWO,
+};
+use crate::{ContractStatus, Error, EscrowError, ReleaseAuthorization};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Register the escrow contract, an SAC, initialize, bind settlement token.
+fn setup_bound(env: &Env) -> (crate::EscrowClient<'_>, Address, Address) {
+    let contract_id = env.register(crate::Escrow, ());
+    let client = crate::EscrowClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+
+    let sac = env.register_stellar_asset_contract(admin.clone());
+
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(&admin);
+    client.bind_settlement_token(&admin, &sac);
+
+    (client, sac, admin)
+}
+
+/// Mint `amount` SAC tokens to `holder` via the SAC admin client.
+fn mint_to(env: &Env, sac: &Address, holder: &Address, amount: i128) {
+    StellarAssetClient::new(env, sac).mint(holder, &amount);
+}
+
+/// Create a 3-milestone contract and return (client_addr, freelancer_addr, contract_id).
+fn create_contract(env: &Env, client: &crate::EscrowClient<'_>) -> (Address, Address, u32) {
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+    let milestones = SorobanVec::from_slice(env, &[MILESTONE_ONE, MILESTONE_TWO, MILESTONE_THREE]);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    (client_addr, freelancer_addr, id)
+}
+
+// ─── Positive cases ──────────────────────────────────────────────────────────
+
+/// Simulating a full deposit must return the same projected outcome that a real
+/// deposit produces (funded_amount and status).
+#[test]
+fn simulate_matches_real_full_deposit() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    // Simulate the deposit first.
+    let simulated = client.simulate_deposit_funds(&id, &client_addr, &total);
+    assert_eq!(simulated.current_funded_amount, 0);
+    assert_eq!(simulated.new_funded_amount, total);
+    assert_eq!(simulated.projected_status, ContractStatus::Funded);
+    assert_eq!(simulated.total_milestone_amount, total);
+
+    // Now execute the real deposit.
+    mint_to(&env, &sac, &client_addr, total);
+    assert!(client.deposit_funds(&id, &client_addr, &total));
+
+    // The real contract state must match the simulated projection.
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.funded_amount, simulated.new_funded_amount);
+    assert_eq!(contract.status, simulated.projected_status);
+}
+
+/// Simulating a partial deposit must return PartiallyFunded when the amount
+/// is less than the total milestone sum.
+#[test]
+fn simulate_partial_deposit_returns_partially_funded() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+    let partial = total / 2;
+
+    mint_to(&env, &sac, &client_addr, total);
+    // Partially fund the contract so we're in PartiallyFunded state.
+    assert!(client.deposit_funds(&id, &client_addr, &partial));
+
+    // Simulate a second deposit that would bring it to full.
+    let remainder = total - partial;
+    let simulated = client.simulate_deposit_funds(&id, &client_addr, &remainder);
+    assert_eq!(simulated.current_funded_amount, partial);
+    assert_eq!(simulated.new_funded_amount, total);
+    assert_eq!(simulated.projected_status, ContractStatus::Funded);
+    assert_eq!(simulated.total_milestone_amount, total);
+
+    // Execute the real remainder deposit and verify.
+    assert!(client.deposit_funds(&id, &client_addr, &remainder));
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.funded_amount, simulated.new_funded_amount);
+    assert_eq!(contract.status, simulated.projected_status);
+}
+
+/// Simulating a deposit when already partially funded must project the correct
+/// PartiallyFunded status if the new amount does not reach the total.
+#[test]
+fn simulate_from_partially_funded_stays_partial() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+    let partial = total / 2;
+    let small_deposit = 100_0000000;
+
+    mint_to(&env, &sac, &client_addr, total + small_deposit);
+    assert!(client.deposit_funds(&id, &client_addr, &partial));
+
+    let simulated = client.simulate_deposit_funds(&id, &client_addr, &small_deposit);
+    assert_eq!(simulated.current_funded_amount, partial);
+    assert_eq!(simulated.new_funded_amount, partial + small_deposit);
+    assert_eq!(simulated.projected_status, ContractStatus::PartiallyFunded);
+    assert_eq!(simulated.total_milestone_amount, total);
+}
+
+/// Multiple simulate calls must return the same result because the simulation
+/// never mutates state.
+#[test]
+fn simulate_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    let first = client.simulate_deposit_funds(&id, &client_addr, &total);
+    let second = client.simulate_deposit_funds(&id, &client_addr, &total);
+    assert_eq!(first, second);
+
+    // Verify no state change occurred.
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.funded_amount, 0);
+    assert_eq!(contract.status, ContractStatus::Created);
+}
+
+// ─── No state mutation ───────────────────────────────────────────────────────
+
+/// After a simulate call, token balances and contract state must be untouched.
+#[test]
+fn simulate_does_not_mutate_state() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    mint_to(&env, &sac, &client_addr, total);
+
+    // Record balances before simulation.
+    let token = TokenClient::new(&env, &sac);
+    let before_client = token.balance(&client_addr);
+    let before_escrow = token.balance(&client.address);
+    let before_contract = client.get_contract(&id);
+
+    // Run the simulation.
+    let _simulated = client.simulate_deposit_funds(&id, &client_addr, &total);
+
+    // Assert no tokens moved.
+    assert_eq!(token.balance(&client_addr), before_client);
+    assert_eq!(token.balance(&client.address), before_escrow);
+
+    // Assert no contract state changed.
+    let after_contract = client.get_contract(&id);
+    assert_eq!(after_contract.funded_amount, before_contract.funded_amount);
+    assert_eq!(after_contract.status, before_contract.status);
+    assert_eq!(
+        after_contract.total_deposited,
+        before_contract.total_deposited
+    );
+}
+
+// ─── Negative cases ─────────────────────────────────────────────────────────
+
+/// Simulate must reject when no settlement token has been bound.
+#[test]
+fn simulate_rejects_unbound_token() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register(crate::Escrow, ());
+    let client = crate::EscrowClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &super::default_milestones(&env),
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &client_addr, &100_i128),
+        crate::Error::SettlementTokenNotConfigured,
+    );
+
+    // State must be unchanged.
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.funded_amount, 0);
+    assert_eq!(contract.status, ContractStatus::Created);
+}
+
+/// Simulate must reject when the caller is not the contract's client.
+#[test]
+fn simulate_rejects_non_client() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _sac, _admin) = setup_bound(&env);
+    let (_client_addr, freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &freelancer_addr, &total),
+        Error::UnauthorizedRole,
+    );
+}
+
+/// Simulate must reject non-positive amounts (same as real deposit).
+#[test]
+fn simulate_rejects_non_positive_amounts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+
+    for amount in [0_i128, -1_i128] {
+        assert_contract_error(
+            client.try_simulate_deposit_funds(&id, &client_addr, &amount),
+            Error::AmountMustBePositive,
+        );
+    }
+}
+
+/// Simulate must reject deposits on a cancelled contract.
+#[test]
+fn simulate_rejects_cancelled_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+
+    // Cancel the contract (needs to be in Created state, no funds).
+    assert!(client.cancel_contract(&id, &client_addr));
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &client_addr, &100_i128),
+        EscrowError::ContractCancelled,
+    );
+}
+
+/// Simulate must reject deposits on a refunded contract.
+#[test]
+fn simulate_rejects_refunded_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    // Fund and then refund.
+    mint_to(&env, &sac, &client_addr, total);
+    assert!(client.deposit_funds(&id, &client_addr, &total));
+    let indices = SorobanVec::from_slice(&env, &[0u32, 1, 2]);
+    assert_eq!(client.refund_unreleased_milestones(&id, &indices), total);
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &client_addr, &100_i128),
+        EscrowError::ContractRefunded,
+    );
+}
+
+/// Simulate must reject when the contract is already fully funded (Funded state).
+#[test]
+fn simulate_rejects_funded_contract() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    mint_to(&env, &sac, &client_addr, total);
+    assert!(client.deposit_funds(&id, &client_addr, &total));
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &client_addr, &1_i128),
+        Error::InvalidState,
+    );
+}
+
+/// Simulate must reject deposits that would exceed the total milestone amount.
+#[test]
+fn simulate_rejects_overfunding() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let total = total_milestone_amount();
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &client_addr, &(total + 1)),
+        Error::InvalidDepositAmount,
+    );
+}
+
+/// Simulate must reject when the contract has not been initialized.
+#[test]
+fn simulate_rejects_uninitialized() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register(crate::Escrow, ());
+    let client = crate::EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let _sac = env.register_stellar_asset_contract(admin.clone());
+    // Note: not calling initialize.
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&0u32, &admin, &100_i128),
+        crate::Error::NotInitialized,
+    );
+}
+
+/// Simulate must reject when the contract is paused.
+#[test]
+fn simulate_rejects_paused() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (client, _sac, _admin) = setup_bound(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+
+    // Pause the contract.
+    assert!(client.pause());
+
+    assert_contract_error(
+        client.try_simulate_deposit_funds(&id, &client_addr, &100_i128),
+        Error::ContractPaused,
+    );
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -272,6 +272,28 @@ pub enum DepositMode {
     Incremental = 1,
 }
 
+// ── Simulation result types ───────────────────────────────────────────────────
+
+/// Result of a simulated deposit operation.
+///
+/// Returned by [`simulate_deposit_funds`](crate::Escrow::simulate_deposit_funds)
+/// to let callers preview the state transition that a real `deposit_funds`
+/// call would produce, without executing any token transfer or writing storage.
+///
+/// All amounts are in stroops.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulateDepositResult {
+    /// The `funded_amount` on the contract before the simulated deposit.
+    pub current_funded_amount: i128,
+    /// The `funded_amount` that would result after the deposit.
+    pub new_funded_amount: i128,
+    /// The contract status that would result after the deposit.
+    pub projected_status: ContractStatus,
+    /// The sum of all milestone amounts for the contract.
+    pub total_milestone_amount: i128,
+}
+
 // ── Governance / readiness ───────────────────────────────────────────────────
 
 /// Readiness checklist stored under [`DataKey::ReadinessChecklist`].


### PR DESCRIPTION
Add a read-only `simulate_deposit_funds` entrypoint that lets callers preview the outcome of a deposit operation without executing the SAC transfer, writing storage, or emitting events.

The simulation runs the same preflight validation as `deposit_funds`: initialization guard, pause check, deposit validation (caller role, contract state, amount bounds, over-funding), and settlement-token configuration check. On success it returns a `SimulateDepositResult` with the projected `funded_amount` and contract status.

Changes:
- `types.rs`: Add `SimulateDepositResult` struct
- `lib.rs`: Add `simulate_deposit_funds` entrypoint + re-export type
- `test/mod.rs`: Register new test module
- `test/simulate_deposit.rs`: 14 tests covering positive cases, no-state-mutation guarantees, and all negative paths matching the real entrypoint's error behaviour

Close #1066