### PR TITLE
implimented

### DIFF
--- a/contracts/escrow/src/create_contract.rs
+++ b/contracts/escrow/src/create_contract.rs
@@ -1,6 +1,7 @@
 use crate::{
     amount_validation, ttl, Contract, ContractStatus, DataKey, Error, Escrow, EscrowArgs,
-    EscrowClient, EscrowError, GovernedParameters, Milestone, ReleaseAuthorization, MAX_MILESTONES,
+    EscrowClient, EscrowError, GovernedParameters, Milestone, ReleaseAuthorization,
+    SimulateCreateContractOutcome, MAX_MILESTONES,
 };
 use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol, Vec};
 
@@ -171,6 +172,153 @@ impl Escrow {
         );
 
         id
+    }
+
+    /// Simulates contract creation without writing to storage or emitting events.
+    ///
+    /// This is a read-only variant of [`create_contract`](Self::create_contract) that
+    /// performs all the same validation checks but returns the projected outcome without:
+    /// - Mutating storage
+    /// - Emitting events
+    /// - Incrementing the contract ID counter
+    ///
+    /// The simulated contract ID is based on the current `NextContractId` value at the
+    /// time of the call. If validation fails, the function panics with the same error
+    /// as the real `create_contract` would.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `client` - The address of the client funding the contract
+    /// * `freelancer` - The address of the freelancer performing the work
+    /// * `arbiter` - Optional arbiter address for dispute resolution
+    /// * `milestones` - Vector of milestone amounts (in stroops)
+    /// * `release_authorization` - Authorization mode for milestone releases
+    ///
+    /// # Returns
+    /// A [`SimulateCreateContractOutcome`] containing the projected contract details,
+    /// including the simulated contract ID and all input parameters.
+    ///
+    /// # Errors
+    /// Same as [`create_contract`](Self::create_contract):
+    /// * `InvalidParticipant`   - If client and freelancer are the same address
+    /// * `EmptyMilestones`      - If no milestones are provided
+    /// * `InvalidMilestoneAmount` - If any milestone amount is <= 0
+    /// * `MissingArbiter`       - If arbiter is required but not provided
+    /// * `InvalidArbiter`       - If arbiter is same as client or freelancer
+    /// * `TooManyMilestones`    - If the number of milestones exceeds `MAX_MILESTONES`
+    /// * `TotalCapExceeded`     - If the sum of milestone amounts exceeds the governed cap
+    ///
+    /// # Notes
+    /// - The simulated contract ID is **not** consumed; `create_contract` will still
+    ///   use the same ID (or the next available one if contract creation occurs after simulation).
+    /// - The `client` address **does not** require authorization for this read-only operation.
+    /// - All participant validation (distinct client/freelancer, valid arbiter) is performed.
+    /// - All milestone validation (non-empty, positive amounts, within cap) is performed.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let outcome = escrow.simulate_create_contract(
+    ///     &env,
+    ///     &client,
+    ///     &freelancer,
+    ///     &None,
+    ///     &milestones,
+    ///     &ReleaseAuthorization::ClientOnly,
+    /// );
+    /// // outcome.contract_id is the ID that would be assigned
+    /// // No storage has been modified
+    /// ```
+    pub fn simulate_create_contract(
+        env: Env,
+        client: Address,
+        freelancer: Address,
+        arbiter: Option<Address>,
+        milestones: Vec<i128>,
+        release_authorization: ReleaseAuthorization,
+    ) -> SimulateCreateContractOutcome {
+        // Validate that client and freelancer are distinct participants.
+        if client == freelancer {
+            env.panic_with_error(EscrowError::InvalidParticipant);
+        }
+
+        // Validate arbiter requirement based on release authorization mode.
+        match release_authorization {
+            ReleaseAuthorization::ArbiterOnly | ReleaseAuthorization::ClientAndArbiter
+                if arbiter.is_none() =>
+            {
+                env.panic_with_error(EscrowError::MissingArbiter);
+            }
+            _ => {}
+        }
+
+        // Validate arbiter is distinct from both client and freelancer.
+        if let Some(ref arb) = arbiter {
+            if arb == &client || arb == &freelancer {
+                env.panic_with_error(EscrowError::InvalidArbiter);
+            }
+        }
+
+        // Validate at least one milestone is specified.
+        if milestones.is_empty() {
+            env.panic_with_error(EscrowError::EmptyMilestones);
+        }
+
+        // Enforce maximum number of milestones.
+        if milestones.len() > MAX_MILESTONES {
+            env.panic_with_error(EscrowError::TooManyMilestones);
+        }
+
+        // Retrieve governed parameters for total escrow cap; allow any total if unset.
+        let max_total = env
+            .storage()
+            .persistent()
+            .get::<_, GovernedParameters>(&DataKey::GovernedParameters)
+            .map(|params| params.max_escrow_total_stroops)
+            .unwrap_or(i128::MAX);
+
+        // Validate milestone amounts and enforce the total cap via the canonical helper.
+        let mut native_milestones = [0_i128; MAX_MILESTONES as usize];
+        let len = milestones.len() as usize;
+        for i in 0..len {
+            native_milestones[i] = milestones.get(i as u32).unwrap();
+        }
+        match amount_validation::validate_milestone_amounts(&native_milestones[..len], max_total) {
+            Ok(_) => (),
+            Err(err) => match err {
+                EscrowError::InvalidMilestoneAmount => {
+                    env.panic_with_error(EscrowError::InvalidMilestoneAmount)
+                }
+                EscrowError::TotalCapExceeded => {
+                    env.panic_with_error(EscrowError::TotalCapExceeded)
+                }
+                _ => env.panic_with_error(EscrowError::InvalidMilestoneAmount),
+            },
+        }
+
+        // Get the next contract ID (read-only, no state mutation)
+        let simulated_id: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextContractId)
+            .unwrap_or(1);
+
+        // Calculate total amount (sum of all milestones)
+        let mut total_amount: i128 = 0;
+        for milestone_amount in milestones.iter() {
+            total_amount = total_amount
+                .checked_add(milestone_amount)
+                .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+        }
+
+        SimulateCreateContractOutcome {
+            contract_id: simulated_id,
+            client,
+            freelancer,
+            arbiter,
+            release_authorization,
+            milestones,
+            total_amount,
+        }
     }
 }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -83,7 +83,7 @@ pub use types::{
     Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
     DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
     MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
-    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    SimulateCreateContractOutcome, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -1244,6 +1244,56 @@ impl Escrow {
             .persistent()
             .get(&DataKey::NextContractId)
             .unwrap_or(1)
+    }
+
+    /// Simulates contract creation without writing to storage or emitting events.
+    ///
+    /// This is a read-only variant of `create_contract` that performs all the same
+    /// validation checks but returns the projected outcome without:
+    /// - Mutating storage
+    /// - Emitting events
+    /// - Incrementing the contract ID counter
+    /// - Requiring caller authorization
+    ///
+    /// The simulated contract ID is based on the current `NextContractId` value at the
+    /// time of the call. If validation fails, the function panics with the same error
+    /// as the real `create_contract` would.
+    ///
+    /// # Use cases
+    /// - Clients can preview what contract ID and outcomes would result from their parameters
+    /// - Off-chain indexers can validate contract parameters before submitting transactions
+    /// - Testing and debugging contract creation logic
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `client` - The address of the client funding the contract
+    /// * `freelancer` - The address of the freelancer performing the work
+    /// * `arbiter` - Optional arbiter address for dispute resolution
+    /// * `milestones` - Vector of milestone amounts (in stroops)
+    /// * `release_authorization` - Authorization mode for milestone releases
+    ///
+    /// # Returns
+    /// A [`SimulateCreateContractOutcome`] containing the projected contract details,
+    /// including the simulated contract ID and all input parameters.
+    ///
+    /// # Errors
+    /// Same as `create_contract`:
+    /// * `InvalidParticipant`   - If client and freelancer are the same address
+    /// * `EmptyMilestones`      - If no milestones are provided
+    /// * `InvalidMilestoneAmount` - If any milestone amount is <= 0
+    /// * `MissingArbiter`       - If arbiter is required but not provided
+    /// * `InvalidArbiter`       - If arbiter is same as client or freelancer
+    /// * `TooManyMilestones`    - If the number of milestones exceeds `MAX_MILESTONES`
+    /// * `TotalCapExceeded`     - If the sum of milestone amounts exceeds the governed cap
+    pub fn simulate_create_contract(
+        env: Env,
+        client: Address,
+        freelancer: Address,
+        arbiter: Option<Address>,
+        milestones: soroban_sdk::Vec<i128>,
+        release_authorization: ReleaseAuthorization,
+    ) -> SimulateCreateContractOutcome {
+        Self::simulate_create_contract(env, client, freelancer, arbiter, milestones, release_authorization)
     }
 
     /// Returns a structured summary of the contract and its milestones.

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -25,6 +25,7 @@ mod release;
 mod release_authorization;
 mod reputation;
 mod security;
+mod simulate_create_contract;
 mod ttl_tests;
 
 // --- Shared constants ---

--- a/contracts/escrow/src/test/simulate_create_contract.rs
+++ b/contracts/escrow/src/test/simulate_create_contract.rs
@@ -1,0 +1,533 @@
+/// Comprehensive tests for `simulate_create_contract` dry-run functionality.
+///
+/// These tests ensure that:
+/// 1. Simulate returns the projected outcome matching what `create_contract` would produce
+/// 2. Simulate performs all validation checks identical to `create_contract`
+/// 3. Simulate makes no storage mutations
+/// 4. Simulate requires no authorization
+/// 5. Edge cases and error conditions are handled correctly
+use soroban_sdk::vec;
+
+use crate::{ContractStatus, ReleaseAuthorization, SimulateCreateContractOutcome};
+
+use super::{create_client, setup};
+
+/// Test that simulate returns the projected contract ID and parameters.
+///
+/// # Security
+/// - Validates contract ID prediction
+/// - Ensures all parameters are correctly returned
+/// - Verifies total amount calculation
+#[test]
+fn simulate_returns_projected_outcome() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128];
+
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Verify outcome contains correct values
+    assert_eq!(outcome.contract_id, 1);
+    assert_eq!(outcome.client, client_addr);
+    assert_eq!(outcome.freelancer, freelancer_addr);
+    assert_eq!(outcome.arbiter, None);
+    assert_eq!(outcome.release_authorization, ReleaseAuthorization::ClientOnly);
+    assert_eq!(outcome.milestones.len(), 2);
+    assert_eq!(outcome.milestones.get(0).unwrap(), 200_0000000_i128);
+    assert_eq!(outcome.milestones.get(1).unwrap(), 400_0000000_i128);
+    assert_eq!(outcome.total_amount, 600_0000000_i128);
+}
+
+/// Test that simulate doesn't mutate storage (contract not created).
+///
+/// # Security
+/// - Ensures storage remains unmodified after simulate
+/// - Validates no contract record is persisted
+/// - Verifies contract ID counter is not incremented
+#[test]
+fn simulate_does_not_mutate_storage() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    // Call simulate
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Verify contract was NOT actually created
+    assert!(!client.contract_exists(&outcome.contract_id));
+
+    // Verify next contract ID is still 1 (not incremented to 2)
+    assert_eq!(client.get_next_contract_id(), 1);
+
+    // Simulate another call - should get the same contract ID
+    let outcome2 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    assert_eq!(outcome2.contract_id, 1);
+}
+
+/// Test that simulate matches create_contract outcome.
+///
+/// # Security
+/// - Ensures simulate outcome matches real contract creation
+/// - Validates consistency between dry-run and actual operations
+#[test]
+fn simulate_outcome_matches_create_contract() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 200_0000000_i128, 400_0000000_i128, 300_0000000_i128];
+
+    // Get simulated outcome
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Create the actual contract
+    let contract_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Verify IDs match
+    assert_eq!(outcome.contract_id, contract_id);
+
+    // Verify contract was created
+    assert!(client.contract_exists(&contract_id));
+
+    // Verify contract details match outcome
+    let contract = client.get_contract(&contract_id);
+    assert_eq!(contract.client, outcome.client);
+    assert_eq!(contract.freelancer, outcome.freelancer);
+    assert_eq!(contract.arbiter, outcome.arbiter);
+    assert_eq!(contract.release_authorization, outcome.release_authorization);
+
+    // Verify milestones match
+    let stored_milestones = client.get_milestones(&contract_id);
+    assert_eq!(stored_milestones.len(), outcome.milestones.len());
+    for i in 0..stored_milestones.len() {
+        assert_eq!(
+            stored_milestones.get(i).unwrap().amount,
+            outcome.milestones.get(i as u32).unwrap()
+        );
+    }
+
+    // Verify total amount matches
+    let total: i128 = stored_milestones
+        .iter()
+        .fold(0_i128, |sum, m| sum + m.amount);
+    assert_eq!(total, outcome.total_amount);
+}
+
+/// Test that simulate validates empty milestones.
+///
+/// # Security
+/// - Prevents invalid contract simulation
+/// - Validates input sanitization
+#[test]
+#[should_panic]
+fn simulate_rejects_empty_milestones() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+/// Test that simulate validates zero-amount milestones.
+///
+/// # Security
+/// - Prevents dust attacks during simulation
+/// - Validates milestone amount constraints
+#[test]
+#[should_panic]
+fn simulate_rejects_zero_amount_milestone() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 0_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+/// Test that simulate rejects negative milestone amounts.
+///
+/// # Security
+/// - Prevents negative amount attacks
+/// - Validates amount sign
+#[test]
+#[should_panic]
+fn simulate_rejects_negative_milestone() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, -100_0000000_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+/// Test that simulate validates same client and freelancer.
+///
+/// # Security
+/// - Prevents self-dealing during simulation
+/// - Validates participant uniqueness
+#[test]
+#[should_panic]
+fn simulate_rejects_same_participants() {
+    let (env, client_addr, _) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &client_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+/// Test that simulate validates too many milestones.
+///
+/// # Security
+/// - Enforces milestone count limits during simulation
+/// - Prevents resource exhaustion
+#[test]
+#[should_panic]
+fn simulate_rejects_too_many_milestones() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+
+    // Create more milestones than allowed
+    let mut milestones = vec![&env];
+    for _ in 0..11 {
+        milestones.push_back(100_0000000_i128);
+    }
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+}
+
+/// Test that simulate validates arbiter requirement for ArbiterOnly mode.
+///
+/// # Security
+/// - Ensures arbiter is present when required
+/// - Validates authorization mode constraints
+#[test]
+#[should_panic]
+fn simulate_requires_arbiter_for_arbiter_only() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+}
+
+/// Test that simulate validates arbiter requirement for ClientAndArbiter mode.
+///
+/// # Security
+/// - Ensures arbiter is present when required
+/// - Validates authorization mode constraints
+#[test]
+#[should_panic]
+fn simulate_requires_arbiter_for_client_and_arbiter() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+}
+
+/// Test that simulate validates arbiter is not the client.
+///
+/// # Security
+/// - Prevents role confusion with arbiter=client
+/// - Validates participant distinctness
+#[test]
+#[should_panic]
+fn simulate_rejects_arbiter_as_client() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(client_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+}
+
+/// Test that simulate validates arbiter is not the freelancer.
+///
+/// # Security
+/// - Prevents role confusion with arbiter=freelancer
+/// - Validates participant distinctness
+#[test]
+#[should_panic]
+fn simulate_rejects_arbiter_as_freelancer() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(freelancer_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+}
+
+/// Test that simulate works with arbiter addresses.
+///
+/// # Security
+/// - Validates arbiter handling in outcome
+/// - Ensures arbiter is correctly included in projection
+#[test]
+fn simulate_with_arbiter() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let arbiter_addr = soroban_sdk::Address::generate(&env);
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+
+    assert_eq!(outcome.arbiter, Some(arbiter_addr));
+    assert_eq!(outcome.client, client_addr);
+    assert_eq!(outcome.freelancer, freelancer_addr);
+}
+
+/// Test that simulate returns correct total with multiple milestones.
+///
+/// # Security
+/// - Validates correct arithmetic in total calculation
+/// - Ensures all milestones are included in sum
+#[test]
+fn simulate_calculates_total_correctly() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![
+        &env,
+        100_0000000_i128,
+        200_0000000_i128,
+        150_0000000_i128,
+        50_0000000_i128,
+    ];
+
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    assert_eq!(outcome.total_amount, 500_0000000_i128);
+    assert_eq!(outcome.milestones.len(), 4);
+}
+
+/// Test that simulate requires no caller authorization.
+///
+/// # Security
+/// - Validates read-only nature of simulate
+/// - Ensures no auth required for dry-run
+#[test]
+fn simulate_requires_no_authorization() {
+    let (env, client_addr, freelancer_addr) = setup();
+    // Create a client without auto-mocking auth
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    // This should not panic due to missing authorization
+    // (simulate doesn't require auth)
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    assert_eq!(outcome.contract_id, 1);
+}
+
+/// Test that simulate with all release authorization modes.
+///
+/// # Security
+/// - Validates all release authorization modes are correctly projected
+/// - Ensures mode is correctly included in outcome
+#[test]
+fn simulate_with_all_authorization_modes() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let arbiter_addr = soroban_sdk::Address::generate(&env);
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    // Test ClientOnly
+    let outcome1 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert_eq!(outcome1.release_authorization, ReleaseAuthorization::ClientOnly);
+
+    // Test ArbiterOnly (with arbiter)
+    let outcome2 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ArbiterOnly,
+    );
+    assert_eq!(outcome2.release_authorization, ReleaseAuthorization::ArbiterOnly);
+
+    // Test ClientAndArbiter (with arbiter)
+    let outcome3 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientAndArbiter,
+    );
+    assert_eq!(outcome3.release_authorization, ReleaseAuthorization::ClientAndArbiter);
+
+    // Test MultiSig (no arbiter required)
+    let outcome4 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::MultiSig,
+    );
+    assert_eq!(outcome4.release_authorization, ReleaseAuthorization::MultiSig);
+}
+
+/// Test that simulate increments contract ID for each call (reflects counter).
+///
+/// # Security
+/// - Ensures contract IDs would be unique
+/// - Validates proper ID allocation sequencing
+#[test]
+fn simulate_reflects_current_contract_id() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    let milestones = vec![&env, 100_0000000_i128];
+
+    // First simulate should show ID 1
+    let outcome1 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert_eq!(outcome1.contract_id, 1);
+
+    // Create a real contract to increment counter
+    client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Second simulate should now show ID 2
+    let outcome2 = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert_eq!(outcome2.contract_id, 2);
+}
+
+/// Test edge case with maximum milestone amount.
+///
+/// # Security
+/// - Validates handling of maximum amounts
+/// - Ensures total calculation doesn't overflow with max values
+#[test]
+fn simulate_with_large_amounts() {
+    let (env, client_addr, freelancer_addr) = setup();
+    let client = create_client(&env);
+    // Use large but valid amounts
+    let milestones = vec![&env, 1_000_000_000_000_i128, 2_000_000_000_000_i128];
+
+    let outcome = client.simulate_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    assert_eq!(outcome.total_amount, 3_000_000_000_000_i128);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -52,6 +52,36 @@ pub struct ContractBounds {
     pub max_fee_bps: u32,
 }
 
+/// Simulated outcome of creating a contract without actually writing to storage.
+///
+/// This type is returned by `simulate_create_contract` and represents the
+/// projected state that would result from a contract creation. The operation
+/// performs all validation checks but makes no storage writes or events.
+///
+/// # Read-only guarantee
+/// - No storage mutations
+/// - No events emitted
+/// - All validation from `create_contract` is applied
+/// - Outcome matches what `create_contract` would produce
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulateCreateContractOutcome {
+    /// The contract ID that would be assigned
+    pub contract_id: u32,
+    /// The client address
+    pub client: Address,
+    /// The freelancer address
+    pub freelancer: Address,
+    /// The optional arbiter address
+    pub arbiter: Option<Address>,
+    /// The release authorization mode
+    pub release_authorization: ReleaseAuthorization,
+    /// The milestone amounts (in stroops)
+    pub milestones: Vec<i128>,
+    /// Total escrow amount across all milestones
+    pub total_amount: i128,
+}
+
 // ── Core contract state ──────────────────────────────────────────────────────
 
 // ─── Storage keys ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1041 


 Add a read-only contracts simulation that returns the projected outcome without writing storage or emitting events.
- Keep it consistent with the real entrypoint's checks.
- Cover matching outcomes in tests.