### PR TITLE
refactor(settlement): name magic numbers

### DIFF
--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -6,6 +6,21 @@
 //! or `Refunded`. The root entrypoints own authentication, token transfer, event
 //! publication, and writes to `DataKey::Contract(contract_id)`.
 
+/// Freelancer's share numerator for the PartialRefund dispute resolution (30%).
+///
+/// When a dispute is resolved with `PartialRefund`, the freelancer receives
+/// `floor(available * PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR / PARTIAL_REFUND_DENOMINATOR)`
+/// stroops and the client receives the remainder.  The current value of `30`
+/// means the freelancer gets 30% of the available escrow balance.
+pub const PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR: i128 = 30;
+
+/// Denominator for the PartialRefund dispute resolution split.
+///
+/// Together with [`PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR`] this defines the
+/// freelancer's share as a percentage.  With `NUMERATOR = 30` and
+/// `DENOMINATOR = 100` the split is 30 % to the freelancer, 70 % to the client.
+pub const PARTIAL_REFUND_DENOMINATOR: i128 = 100;
+
 use soroban_sdk::{contractimpl, symbol_short, Address, Env};
 
 use crate::{
@@ -43,10 +58,10 @@ pub fn resolution_payouts(
     match resolution {
         DisputeResolution::FullRefund => Ok((available, 0)),
         DisputeResolution::PartialRefund => {
-            // freelancer gets floor(available * 30 / 100), client gets remainder
+            // freelancer gets floor(available * NUMERATOR / DENOMINATOR), client gets remainder
             let freelancer_payout = available
-                .checked_mul(30)
-                .and_then(|value| value.checked_div(100))
+                .checked_mul(PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR)
+                .and_then(|value| value.checked_div(PARTIAL_REFUND_DENOMINATOR))
                 .ok_or(Error::PotentialOverflow)?;
             Ok((available - freelancer_payout, freelancer_payout))
         }

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -10,7 +10,7 @@
 use crate::ttl::ADMIN_ROTATION_MIN_DELAY_LEDGERS;
 use crate::{
     DataKey, Error, Escrow, EscrowArgs, EscrowClient, GovernedParameters, PendingAdminProposal,
-    ReadinessChecklist,
+    ReadinessChecklist, MAX_FEE_BPS,
 };
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
@@ -21,7 +21,7 @@ impl Escrow {
     /// Admin-gated: the stored admin (under [`DataKey::Admin`]) must authorize
     /// the call and the contract must be initialized.
     ///
-    /// `new_bps` must be `≤ 10_000` (100%). The fee takes effect immediately for
+    /// `new_bps` must be `≤ MAX_FEE_BPS` (100%). The fee takes effect immediately for
     /// the next `release_milestone` call.
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
@@ -192,7 +192,7 @@ impl Escrow {
 
     /// Set both governance parameters at once and update the readiness checklist.
     ///
-    /// Sets `protocol_fee_bps` (must be `≤ 10_000`) and `max_escrow_total_stroops`
+    /// Sets `protocol_fee_bps` (must be `≤ MAX_FEE_BPS`) and `max_escrow_total_stroops`
     /// atomically. Also flips `ReadinessChecklist::governed_params_set` to `true`.
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
@@ -223,7 +223,7 @@ impl Escrow {
         }
         admin.require_auth();
 
-        if protocol_fee_bps > 10_000 {
+        if protocol_fee_bps > MAX_FEE_BPS {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -91,6 +91,19 @@ pub const MAX_MILESTONES: u32 = 10;
 pub const MAX_SINGLE_AMOUNT_STROOPS: i128 = crate::amount_validation::MAX_SINGLE_AMOUNT_STROOPS;
 pub const MAX_TOTAL_ESCROW_STROOPS: i128 = MAX_SINGLE_AMOUNT_STROOPS;
 
+/// Basis‑point denominator: 10 000 bps ≡ 100 %.
+///
+/// Used throughout the protocol for fee calculations, fee caps, and rating
+/// scaling.  A basis point is 1/100th of one percent, so 10 000 bps = 100 %.
+pub const BASIS_POINT_DENOMINATOR: u32 = 10_000;
+
+/// Maximum configurable protocol fee in basis points (10 000 bps = 100 %).
+///
+/// This is the ceiling enforced by `set_protocol_fee_bps` and
+/// `set_governed_params`.  Any value above this cap is rejected with
+/// `Error::InvalidProtocolParameters`.
+pub const MAX_FEE_BPS: u32 = BASIS_POINT_DENOMINATOR;
+
 #[contract]
 pub struct Escrow;
 
@@ -427,7 +440,7 @@ impl Escrow {
             max_milestones: MAX_MILESTONES,
             max_single_milestone_stroops: MAX_SINGLE_AMOUNT_STROOPS,
             max_total_escrow_stroops: MAX_TOTAL_ESCROW_STROOPS,
-            max_fee_bps: 10_000,
+            max_fee_bps: MAX_FEE_BPS,
         }
     }
 
@@ -1781,20 +1794,23 @@ impl Escrow {
             .get(&DataKey::Reputation(address))
     }
 
-    /// Returns the freelancer's average rating scaled to basis points (×10 000),
-    /// or `None` if no reputation record exists or no contracts have been completed.
+    /// Returns the freelancer's average rating scaled to basis points
+    /// (×`BASIS_POINT_DENOMINATOR`), or `None` if no reputation record exists
+    /// or no contracts have been completed.
     ///
     /// # Scaling
-    /// `result = total_rating * 10_000 / completed_contracts`
+    /// `result = total_rating * BASIS_POINT_DENOMINATOR / completed_contracts`
     ///
     /// A raw rating of 5 on a single contract returns `50_000` (5.0000 on a
-    /// 1–5 scale).  Clients divide by `10_000` to recover the decimal value.
+    /// 1–5 scale).  Clients divide by `BASIS_POINT_DENOMINATOR` to recover the
+    /// decimal value.
     ///
     /// Checked arithmetic is used throughout; division by zero is impossible
     /// because `None` is returned whenever `completed_contracts == 0`.
     pub fn get_average_rating(env: Env, address: Address) -> Option<i128> {
-        /// Basis-point scaling factor (×10 000 preserves four decimal places).
-        const SCALE: i128 = 10_000;
+        /// Basis-point scaling factor (×`BASIS_POINT_DENOMINATOR` preserves
+        /// four decimal places).
+        const SCALE: i128 = BASIS_POINT_DENOMINATOR as i128;
 
         let rep: types::Reputation = env
             .storage()
@@ -2096,15 +2112,16 @@ impl Escrow {
 
     /// Computes the protocol fee for a given `amount` at `fee_bps` basis points.
     ///
-    /// Uses integer **floor division**: `fee = amount * fee_bps / 10_000`.
+    /// Uses integer **floor division**: `fee = amount * fee_bps / BASIS_POINT_DENOMINATOR`.
     /// The result always rounds down — it never rounds up — so the freelancer
     /// receives at least `amount - fee` stroops and the protocol receives at most
     /// the floored value.  Callers must ensure `fee <= amount` holds; this is
-    /// guaranteed for any `fee_bps` in `[0, 10_000]` and a non-negative `amount`.
+    /// guaranteed for any `fee_bps` in `[0, MAX_FEE_BPS]` and a non-negative `amount`.
     ///
     /// # Basis-point unit
-    /// `10_000 bps = 100%`. The maximum configurable rate is `10_000`. A rate of
-    /// `0` is the default and disables fee collection entirely.
+    /// `BASIS_POINT_DENOMINATOR bps = 100%`. The maximum configurable rate is
+    /// `MAX_FEE_BPS`. A rate of `0` is the default and disables fee collection
+    /// entirely.
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
     /// the full formula, rounding rules, worked numeric examples, and the sequence
@@ -2124,7 +2141,7 @@ impl Escrow {
         let product = amount
             .checked_mul(fee_bps as i128)
             .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
-        product / 10_000
+        product / BASIS_POINT_DENOMINATOR as i128
     }
 
     // ── Internal guards ──────────────────────────────────────────────────────

--- a/contracts/escrow/src/protocol_fees_test.rs
+++ b/contracts/escrow/src/protocol_fees_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{Escrow, EscrowClient};
+use crate::{Escrow, EscrowClient, BASIS_POINT_DENOMINATOR, MAX_FEE_BPS};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 // ── Unit tests for calculate_protocol_fee floor-division rounding ─────────
@@ -17,7 +17,7 @@ fn test_calculate_protocol_fee_zero_bps_returns_zero() {
 #[test]
 fn test_calculate_protocol_fee_250_bps_of_round_amount() {
     let env = Env::default();
-    // 1_000_000 * 250 / 10_000 = 25_000 exactly
+    // 1_000_000 * 250 / BASIS_POINT_DENOMINATOR = 25_000 exactly
     let fee = Escrow::calculate_protocol_fee(&env, 1_000_000, 250);
     assert_eq!(fee, 25_000);
     // Net payout must never be negative
@@ -26,7 +26,7 @@ fn test_calculate_protocol_fee_250_bps_of_round_amount() {
 
 /// Verifies floor rounding: an indivisible product rounds DOWN, never up.
 ///
-/// 1_001 * 250 = 250_250; 250_250 / 10_000 = 25 remainder 250 → floor == 25.
+/// 1_001 * 250 = 250_250; 250_250 / BASIS_POINT_DENOMINATOR = 25 remainder 250 → floor == 25.
 #[test]
 fn test_calculate_protocol_fee_floor_rounds_down_on_indivisible_product() {
     let env = Env::default();
@@ -35,9 +35,10 @@ fn test_calculate_protocol_fee_floor_rounds_down_on_indivisible_product() {
     assert!(1_001 - fee >= 0);
 }
 
-/// Verifies that a sub-threshold amount produces a zero fee (amount * bps < 10_000).
+/// Verifies that a sub-threshold amount produces a zero fee
+/// (amount * bps < BASIS_POINT_DENOMINATOR).
 ///
-/// 9 * 1_000 = 9_000; 9_000 / 10_000 = 0 (floors to zero).
+/// 9 * 1_000 = 9_000; 9_000 / BASIS_POINT_DENOMINATOR = 0 (floors to zero).
 #[test]
 fn test_calculate_protocol_fee_sub_threshold_amount_rounds_to_zero() {
     let env = Env::default();
@@ -62,8 +63,8 @@ fn test_calculate_protocol_fee_overflow_guard_fires() {
 fn test_net_payout_never_negative_for_valid_inputs() {
     let env = Env::default();
     let cases: &[(i128, u32)] = &[
-        (1, 10_000),       // maximum fee rate, minimal amount
-        (10_000, 10_000),  // 100% fee rate
+        (1, MAX_FEE_BPS),       // maximum fee rate, minimal amount
+        (MAX_FEE_BPS, MAX_FEE_BPS),  // 100% fee rate
         (50_000, 500),     // 5% fee rate
         (3_333, 1_000),    // 10% fee rate, indivisible
         (1, 1),            // near-zero fee

--- a/contracts/escrow/src/test/create_contract_bounds.rs
+++ b/contracts/escrow/src/test/create_contract_bounds.rs
@@ -6,7 +6,7 @@
 //   2. max_milestones  == MAX_MILESTONES
 //   3. max_single_milestone_stroops == MAX_SINGLE_AMOUNT_STROOPS
 //   4. max_total_escrow_stroops     == MAX_TOTAL_ESCROW_STROOPS
-//   5. max_fee_bps                  == 10_000 (100 %)
+//   5. max_fee_bps                  == MAX_FEE_BPS (100 %)
 //   6. Idempotent — two calls return identical values
 //   7. No auth required (works before initialize)
 //   8. Consistency: max_single == max_total (current policy)
@@ -28,8 +28,8 @@
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
 
 use crate::{
-    ContractBounds, Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_MILESTONES,
-    MAX_SINGLE_AMOUNT_STROOPS, MAX_TOTAL_ESCROW_STROOPS,
+    ContractBounds, Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_FEE_BPS,
+    MAX_MILESTONES, MAX_SINGLE_AMOUNT_STROOPS, MAX_TOTAL_ESCROW_STROOPS,
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -109,15 +109,15 @@ fn get_bounds_max_total_escrow_stroops_equals_constant() {
     );
 }
 
-/// `max_fee_bps` must be 10_000 (100%).
+/// `max_fee_bps` must be `MAX_FEE_BPS` (100%).
 #[test]
-fn get_bounds_max_fee_bps_is_10000() {
+fn get_bounds_max_fee_bps_is_max_fee_bps() {
     let (env, cid) = setup();
     let client = EscrowClient::new(&env, &cid);
     let bounds = client.get_bounds();
     assert_eq!(
-        bounds.max_fee_bps, 10_000,
-        "max_fee_bps must be 10_000 (100 %)"
+        bounds.max_fee_bps, MAX_FEE_BPS,
+        "max_fee_bps must be MAX_FEE_BPS (100 %)"
     );
 }
 
@@ -177,16 +177,16 @@ fn get_bounds_all_fields_are_positive() {
     assert!(bounds.max_fee_bps > 0, "max_fee_bps must be > 0");
 }
 
-/// `max_fee_bps` must not exceed 10_000 — higher values would imply a fee
-/// greater than the payout itself.
+/// `max_fee_bps` must not exceed `MAX_FEE_BPS` — higher values would imply a
+/// fee greater than the payout itself.
 #[test]
-fn get_bounds_fee_bps_does_not_exceed_100_percent() {
+fn get_bounds_fee_bps_does_not_exceed_max_fee_bps() {
     let (env, cid) = setup();
     let client = EscrowClient::new(&env, &cid);
     let bounds = client.get_bounds();
     assert!(
-        bounds.max_fee_bps <= 10_000,
-        "max_fee_bps must not exceed 10_000 (100 %)"
+        bounds.max_fee_bps <= MAX_FEE_BPS,
+        "max_fee_bps must not exceed MAX_FEE_BPS (100 %)"
     );
 }
 

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -30,7 +30,10 @@ use crate::{
 };
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
-use crate::dispute::{final_status_after_resolution, resolution_payouts};
+use crate::dispute::{
+    final_status_after_resolution, resolution_payouts, PARTIAL_REFUND_DENOMINATOR,
+    PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR,
+};
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -336,7 +339,8 @@ fn resolution_payouts_conserves_available_balance() {
         let (client, freelancer) =
             resolution_payouts(&c, &DisputeResolution::PartialRefund).unwrap();
         assert_eq!(client + freelancer, available);
-        let expected_freelancer = (available * 30) / 100;
+        let expected_freelancer =
+            (available * PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR) / PARTIAL_REFUND_DENOMINATOR;
         assert_eq!(freelancer, expected_freelancer);
         assert_eq!(client, available - expected_freelancer);
 

--- a/contracts/escrow/src/test/protocol_fees.rs
+++ b/contracts/escrow/src/test/protocol_fees.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, Address, Env, vec};
-use crate::{Escrow, EscrowClient, DataKey, Error, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, DataKey, Error, ReleaseAuthorization, MAX_FEE_BPS};
 
 #[test]
 fn test_default_fees_are_zero() {
@@ -55,7 +55,7 @@ fn test_get_protocol_fee_bps_after_configuration() {
     assert_eq!(client.get_protocol_fee_bps(), 1000);
 }
 
-/// Test that protocol fee updates accept 0 and 10_000 basis points.
+/// Test that protocol fee updates accept 0 and MAX_FEE_BPS.
 #[test]
 fn test_set_protocol_fee_bps_accepts_boundary_values() {
     let env = Env::default();
@@ -70,8 +70,8 @@ fn test_set_protocol_fee_bps_accepts_boundary_values() {
     assert!(client.set_protocol_fee_bps(&0u32));
     assert_eq!(client.get_protocol_fee_bps(), 0);
 
-    assert!(client.set_protocol_fee_bps(&10_000u32));
-    assert_eq!(client.get_protocol_fee_bps(), 10_000);
+    assert!(client.set_protocol_fee_bps(&MAX_FEE_BPS));
+    assert_eq!(client.get_protocol_fee_bps(), MAX_FEE_BPS);
 }
 
 /// Test that protocol fee updates reject values above 100%.
@@ -87,7 +87,7 @@ fn test_set_protocol_fee_bps_rejects_values_above_100_percent() {
     client.initialize(&admin);
     assert!(client.set_protocol_fee_bps(&0u32));
 
-    let result = client.try_set_protocol_fee_bps(&10_001u32);
+    let result = client.try_set_protocol_fee_bps(&(MAX_FEE_BPS + 1));
     super::assert_contract_error(result, Error::InvalidProtocolParameters);
     assert_eq!(client.get_protocol_fee_bps(), 0);
 }
@@ -121,17 +121,17 @@ fn test_get_accumulated_protocol_fees_after_releases() {
 
     assert_eq!(client.get_accumulated_protocol_fees(), 0);
 
-    // Fee: 1000 * 1000 / 10_000 = 100
+    // Fee: 1000 * 1000 / MAX_FEE_BPS = 100
     client.approve_milestone_release(&id, &client_addr, &0);
     client.release_milestone(&id, &client_addr, &0);
     assert_eq!(client.get_accumulated_protocol_fees(), 100);
 
-    // Fee: 2500 * 1000 / 10_000 = 250
+    // Fee: 2500 * 1000 / MAX_FEE_BPS = 250
     client.approve_milestone_release(&id, &client_addr, &1);
     client.release_milestone(&id, &client_addr, &1);
     assert_eq!(client.get_accumulated_protocol_fees(), 350);
 
-    // Fee: 3333 * 1000 / 10_000 = 333
+    // Fee: 3333 * 1000 / MAX_FEE_BPS = 333
     client.approve_milestone_release(&id, &client_addr, &2);
     client.release_milestone(&id, &client_addr, &2);
     assert_eq!(client.get_accumulated_protocol_fees(), 683);

--- a/contracts/escrow/src/test/sac_custody.rs
+++ b/contracts/escrow/src/test/sac_custody.rs
@@ -32,7 +32,7 @@ use super::{
     assert_contract_error, register_client, total_milestone_amount, MILESTONE_ONE, MILESTONE_THREE,
     MILESTONE_TWO,
 };
-use crate::{ContractStatus, EscrowError, ReleaseAuthorization};
+use crate::{ContractStatus, EscrowError, ReleaseAuthorization, BASIS_POINT_DENOMINATOR};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -522,7 +522,7 @@ fn release_milestone_with_sac_pushes_payout_minus_fee_to_freelancer() {
     // Configure a 10% protocol fee (1000 bps of 10000 total bps).
     client.set_protocol_fee_bps(&1000u32);
     let milestone_amount = MILESTONE_ONE;
-    let fee = milestone_amount * 1000 / 10_000;
+    let fee = milestone_amount * 1000 / BASIS_POINT_DENOMINATOR as i128;
     let payout = milestone_amount - fee;
     client.approve_milestone_release(&id, &client_addr, &0);
     assert!(client.release_milestone(&id, &client_addr, &0));

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -48,7 +48,7 @@ pub struct ContractBounds {
     pub max_single_milestone_stroops: i128,
     /// Maximum total escrow amount for a single contract (in stroops).
     pub max_total_escrow_stroops: i128,
-    /// Maximum protocol fee in basis points (10_000 = 100%).
+    /// Maximum protocol fee in basis points (`MAX_FEE_BPS` = 100%).
     pub max_fee_bps: u32,
 }
 


### PR DESCRIPTION
Implemented named constants for all literal numbers in the settlement token flow: dispute.rs: Extracted 30/100 into PARTIAL_REFUND_FREELANCER_SHARE_NUMERATOR and PARTIAL_REFUND_DENOMINATOR with rustdoc explaining the 30/70 split. lib.rs: Added BASIS_POINT_DENOMINATOR (10 000 bps = 100%) and MAX_FEE_BPS with rustdoc; replaced 10_000 in get_bounds and calculate_protocol_fee. governance.rs: Replaced 10_000 fee cap check with MAX_FEE_BPS. Test files: Updated test/dispute.rs, test/protocol_fees.rs, test/create_contract_bounds.rs, test/sac_custody.rs, and protocol_fees_test.rs to reference the new constants. Behaviour is identical — all values unchanged. cargo build passes.

Closes #1068