### PR TITLE
feat(escrow): add guarded rollback

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -173,3 +173,53 @@ pub fn get_finalization_record_impl(env: &Env, contract_id: u32) -> Option<Final
         .persistent()
         .get(&Escrow::finalization_key(contract_id))
 }
+
+/// Roll back a finalized contract by removing its immutable close record.
+///
+/// `admin` must be the stored admin and authorize the call. Rollback is only
+/// safe while the contract is finalized and in either `Completed` or `Disputed`
+/// status; no accounting fields are modified.
+///
+/// # Errors
+/// - `NotInitialized` if the contract has not been initialized.
+/// - `UnauthorizedRole` if `admin` is not the stored admin.
+/// - `RollbackNotAllowed` if the contract is not finalized or not in a safe status.
+pub fn rollback_contract_impl(env: &Env, contract_id: u32, admin: Address) -> bool {
+    Escrow::require_initialized(env);
+
+    admin.require_auth();
+
+    let stored_admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+    if admin != stored_admin {
+        env.panic_with_error(EscrowError::UnauthorizedRole);
+    }
+
+    let contract = Escrow::load_contract_for_finalization(env, contract_id);
+
+    if !Escrow::is_finalized(env, contract_id) {
+        env.panic_with_error(EscrowError::RollbackNotAllowed);
+    }
+
+    if contract.status != ContractStatus::Completed && contract.status != ContractStatus::Disputed {
+        env.panic_with_error(EscrowError::RollbackNotAllowed);
+    }
+
+    let status = contract.status;
+
+    env.storage()
+        .persistent()
+        .remove(&Escrow::finalization_key(contract_id));
+
+    crate::ttl::extend_contract_ttl(env, contract_id);
+
+    env.events().publish(
+        (symbol_short!("rollback"), contract_id),
+        (admin, status, env.ledger().timestamp()),
+    );
+
+    true
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -171,6 +171,8 @@ pub enum EscrowError {
     EmptyComment = 42,
     /// Reputation feedback comment exceeded the 200-character maximum.
     CommentTooLong = 43,
+    /// Rollback is not allowed in the current contract state.
+    RollbackNotAllowed = 54,
 }
 
 impl Escrow {
@@ -538,6 +540,24 @@ impl Escrow {
         contract_id: u32,
     ) -> Option<finalize::FinalizationRecord> {
         finalize::get_finalization_record_impl(&env, contract_id)
+    }
+
+    /// Roll back a finalized escrow contract, removing its immutable close record.
+    ///
+    /// `admin` must authorize the call and match the stored admin. Rollback is
+    /// allowed only when the contract is finalized and its status is `Completed`
+    /// or `Disputed`. Removing the finalization record re-enables mutating
+    /// lifecycle operations without changing any accounting fields.
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If `initialize` has not been called.
+    /// * `UnauthorizedRole` - If `admin` is not the stored admin.
+    /// * `RollbackNotAllowed` - If the contract is not finalized or not in a safe status.
+    ///
+    /// # Events
+    /// `("rollback", contract_id)` -> `(admin, status, timestamp)`
+    pub fn rollback_contract(env: Env, admin: Address, contract_id: u32) -> bool {
+        finalize::rollback_contract_impl(&env, contract_id, admin)
     }
 
     /// Propose a client migration for an existing contract.

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -24,6 +24,7 @@ mod refund;
 mod release;
 mod release_authorization;
 mod reputation;
+mod rollback;
 mod security;
 mod ttl_tests;
 

--- a/contracts/escrow/src/test/rollback.rs
+++ b/contracts/escrow/src/test/rollback.rs
@@ -1,0 +1,138 @@
+use super::MILESTONE_ONE;
+use crate::{ContractStatus, DisputeResolution, EscrowError, ReleaseAuthorization};
+use soroban_sdk::{testutils::Address as _, vec, Address};
+
+fn setup(arbiter: bool) -> super::EscrowFixture {
+    let builder = super::EscrowFixtureBuilder::new();
+    let client = Address::generate(builder.env());
+    let freelancer = Address::generate(builder.env());
+    let arbiter_addr = if arbiter {
+        Some(Address::generate(builder.env()))
+    } else {
+        None
+    };
+    builder
+        .with_participants(client, freelancer, arbiter_addr)
+        .funded()
+        .build()
+}
+
+#[test]
+fn admin_can_rollback_completed_contract() {
+    let fixture = setup(false);
+    let contract_id = fixture.escrow_id;
+    let client = fixture.client.clone();
+    let admin = fixture.admin.clone();
+    let escrow = fixture.escrow();
+
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client, &i);
+        escrow.release_milestone(&contract_id, &client, &i);
+    }
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Completed
+    );
+
+    escrow.finalize_contract(&contract_id, &client);
+    assert!(escrow.get_finalization_record(&contract_id).is_some());
+
+    let before = escrow.get_contract(&contract_id);
+    assert!(escrow.rollback_contract(&admin, &contract_id));
+    let after = escrow.get_contract(&contract_id);
+
+    assert!(escrow.get_finalization_record(&contract_id).is_none());
+    assert_eq!(after.status, ContractStatus::Completed);
+    assert_eq!(after.funded_amount, before.funded_amount);
+    assert_eq!(after.released_amount, before.released_amount);
+    assert_eq!(after.refunded_amount, before.refunded_amount);
+}
+
+#[test]
+fn admin_can_rollback_disputed_contract_and_resolve_afterwards() {
+    let fixture = setup(true);
+    let contract_id = fixture.escrow_id;
+    let client = fixture.client.clone();
+    let admin = fixture.admin.clone();
+    let arbiter = fixture.arbiter.clone().unwrap();
+    let escrow = fixture.escrow();
+
+    escrow.raise_dispute(&contract_id, &client);
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Disputed
+    );
+
+    escrow.finalize_contract(&contract_id, &client);
+    assert!(escrow.get_finalization_record(&contract_id).is_some());
+
+    assert!(escrow.rollback_contract(&admin, &contract_id));
+
+    assert!(escrow.get_finalization_record(&contract_id).is_none());
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Disputed
+    );
+
+    // After rollback the arbiter can resolve the dispute again.
+    escrow.resolve_dispute(&contract_id, &arbiter, &DisputeResolution::FullRefund);
+    assert_eq!(
+        escrow.get_contract(&contract_id).status,
+        ContractStatus::Refunded
+    );
+}
+
+#[test]
+fn non_admin_cannot_rollback() {
+    let fixture = setup(false);
+    let contract_id = fixture.escrow_id;
+    let client = fixture.client.clone();
+    let escrow = fixture.escrow();
+
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client, &i);
+        escrow.release_milestone(&contract_id, &client, &i);
+    }
+    escrow.finalize_contract(&contract_id, &client);
+
+    let result = escrow.try_rollback_contract(&client, &contract_id);
+    super::assert_contract_error(result, EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn rollback_rejected_when_not_finalized() {
+    let fixture = setup(false);
+    let contract_id = fixture.escrow_id;
+    let client = fixture.client.clone();
+    let admin = fixture.admin.clone();
+    let escrow = fixture.escrow();
+
+    for i in 0..3u32 {
+        escrow.approve_milestone_release(&contract_id, &client, &i);
+        escrow.release_milestone(&contract_id, &client, &i);
+    }
+    // Contract is Completed but not finalized.
+
+    let result = escrow.try_rollback_contract(&admin, &contract_id);
+    super::assert_contract_error(result, EscrowError::RollbackNotAllowed);
+}
+
+#[test]
+fn rollback_rejected_for_created_contract() {
+    let fixture = setup(false);
+    let new_client = Address::generate(&fixture.env);
+    let new_freelancer = Address::generate(&fixture.env);
+    let milestones = vec![&fixture.env, MILESTONE_ONE];
+    let admin = fixture.admin.clone();
+    let escrow = fixture.escrow();
+    let contract_id = escrow.create_contract(
+        &new_client,
+        &new_freelancer,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    let result = escrow.try_rollback_contract(&admin, &contract_id);
+    super::assert_contract_error(result, EscrowError::RollbackNotAllowed);
+}


### PR DESCRIPTION
Closes #1019

---

## Summary

Implements a guarded rollback entrypoint for the escrow module, allowing administrators to safely roll back escrow operations only when the escrow is in a valid rollback state.

The implementation preserves escrow invariants, returns a typed error for invalid rollback attempts, emits a rollback event upon success, and includes comprehensive test coverage for both successful and rejected scenarios.

## Changes Made

- Added an admin-authorized escrow rollback entrypoint.
- Restricted rollback to predefined safe escrow states.
- Added typed errors for:
  - Rollback attempted in a disallowed state.
  - Unauthorized (non-admin) rollback attempts.
- Preserved all escrow state invariants during rollback.
- Emitted a rollback event on successful execution.
- Added comprehensive unit tests covering:
  - Successful rollback from an allowed state.
  - Rollback rejected from a disallowed state.
  - Non-admin rollback rejection.
  - Relevant edge cases.

## Testing

Verified formatting, linting, and functionality with:

```bash
cargo fmt
cargo clippy --all-targets -- -D warnings
cargo test