### PR TITLE
docs(escrow): add rustdoc examples.

### DIFF
--- a/contracts/escrow/src/create_contract.rs
+++ b/contracts/escrow/src/create_contract.rs
@@ -38,6 +38,13 @@ impl Escrow {
     /// * `TotalCapExceeded`     - If the sum of milestone amounts exceeds the governed cap
     /// * `ContractIdOverflow`   - If the next id would exceed `u32::MAX`
     /// * `ContractIdCollision`  - If the allocated id slot is already occupied
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let milestones = soroban_sdk::vec![&env, 500_0000000];
+    /// let id = client.create_contract(&client_addr, &freelancer_addr, &None, &milestones, &ReleaseAuthorization::ClientOnly);
+    /// assert_eq!(id, 1);
+    /// ```
     pub fn create_contract(
         env: Env,
         client: Address,

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -27,6 +27,24 @@ impl Escrow {
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
     /// the basis-point model, fee formula, accrual storage, and withdrawal flow.
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `new_bps` - Fee rate in basis points (0 to 10 000)
+    ///
+    /// # Returns
+    /// * `bool` - `true` if set successfully
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract is uninitialized
+    /// * `UnauthorizedRole` - If caller is not admin
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let set = client.set_protocol_fee_bps(&250); // 2.5%
+    /// assert!(set);
+    /// ```
+    ///
     /// # Events
     /// `(Symbol("protocol_fee_bps"),)` → `(old_bps, new_bps, admin, timestamp)`
     pub fn set_protocol_fee_bps(env: Env, new_bps: u32) -> bool {
@@ -54,11 +72,36 @@ impl Escrow {
         true
     }
 
+    /// Returns the stored governance admin address.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `Option<Address>` - `Some(Address)` of current admin, `None` if uninitialized
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let admin = client.get_governance_admin();
+    /// ```
     pub fn get_governance_admin(env: Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Admin)
     }
 
     /// Returns the current protocol fee in basis points.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `u32` - Protocol fee rate in basis points (0 if unset)
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let fee_bps = client.get_protocol_fee_bps();
+    /// ```
     pub fn get_protocol_fee_bps(env: Env) -> u32 {
         env.storage()
             .persistent()
@@ -197,6 +240,27 @@ impl Escrow {
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
     /// the full basis-point model and fee lifecycle.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address updating parameters
+    /// * `protocol_fee_bps` - New fee in basis points
+    /// * `max_escrow_total_stroops` - Maximum total escrow capacity in stroops
+    ///
+    /// # Returns
+    /// * `bool` - `true` if parameters set successfully
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract uninitialized
+    /// * `UnauthorizedRole` - If caller is not admin
+    /// * `InvalidProtocolParameters` - If `protocol_fee_bps > 10_000`
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let set = client.set_governed_params(&admin, &200, &1_000_000_0000000);
+    /// assert!(set);
+    /// ```
     pub fn set_governed_params(
         env: Env,
         admin: Address,
@@ -249,6 +313,20 @@ impl Escrow {
     }
 
     /// Retrieve the current governed parameters.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `Option<GovernedParameters>` - `Some(GovernedParameters)` if set, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(params) = client.get_governed_parameters() {
+    ///     assert_eq!(params.protocol_fee_bps, 200);
+    /// }
+    /// ```
     pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
         env.storage().persistent().get(&DataKey::GovernedParameters)
     }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -195,7 +195,7 @@ impl Escrow {
     /// [`DataKey::SettlementToken`] all subsequent money-flow entrypoints
     /// (`deposit_funds`, `release_milestone`, `refund_unreleased_milestones`,
     /// `cancel_contract`, `withdraw_protocol_fees`) read that address to execute SAC
-    /// `transfer` calls.  A second call with any token address is rejected with
+    /// `transfer` calls. A second call with any token address is rejected with
     /// `SettlementTokenAlreadyBound`.
     ///
     /// # Pre-bind probe (issue #723)
@@ -219,10 +219,10 @@ impl Escrow {
     /// All downstream money-flow entrypoints (`deposit_funds`, `release_milestone`,
     /// `cancel_contract`, `refund_unreleased_milestones`) follow strict
     /// **state-before-transfer** (Checks-Effects-Interactions) ordering: contract
-    /// state is finalized *before* any `token::Client::transfer` call.  A
+    /// state is finalized *before* any `token::Client::transfer` call. A
     /// malicious token contract that re-enters the escrow during a transfer will
     /// observe the already-mutated state and cannot double-spend or front-run
-    /// the operation.  The probe itself performs no state mutation — it only
+    /// the operation. The probe itself performs no state mutation — it only
     /// reads the token balance — so it cannot be used as a reentrancy vector.
     ///
     /// See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
@@ -233,6 +233,9 @@ impl Escrow {
     /// * `admin` - The admin address (must match stored admin)
     /// * `token` - The SAC token address
     ///
+    /// # Returns
+    /// * `bool` - `true` on successful settlement token binding
+    ///
     /// # Errors
     /// * `NotInitialized` if `initialize` has not been called
     /// * `UnauthorizedRole` if `admin` is not the stored admin
@@ -240,6 +243,13 @@ impl Escrow {
     /// * `InvalidSettlementToken` if the probe call to `token::Client::balance` panics
     /// * `SettlementTokenIsSelf` if `token == env.current_contract_address()`
     /// * `SettlementTokenIsAdmin` if `token == stored_admin`
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let bound = client.bind_settlement_token(&admin, &usdc_token_address);
+    /// assert!(bound);
+    /// ```
     ///
     /// # Events
     /// On a successful, authorized bind this publishes a `settlement_token_bound`
@@ -324,6 +334,21 @@ impl Escrow {
     /// * `admin` - The admin address (must match stored admin)
     /// * `token` - The SAC token address
     ///
+    /// # Returns
+    /// * `bool` - `true` on successful settlement token binding
+    ///
+    /// # Errors
+    /// * `NotInitialized` if `initialize` has not been called
+    /// * `UnauthorizedRole` if `admin` is not the stored admin
+    /// * `SettlementTokenAlreadyBound` if a token is already bound
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let bound = client.set_settlement_token(&admin, &usdc_token_address);
+    /// assert!(bound);
+    /// ```
+    ///
     /// # Deprecated
     /// Use [`bind_settlement_token`](Self::bind_settlement_token) instead.
     #[deprecated(note = "Use bind_settlement_token instead.")]
@@ -332,6 +357,20 @@ impl Escrow {
     }
 
     /// Returns the bound settlement token, or `None` if no token has been bound.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `Option<Address>` - `Some(Address)` with the bound SAC token address, or `None` if unbound
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(token_address) = client.get_settlement_token() {
+    ///     // Process bound token address
+    /// }
+    /// ```
     pub fn get_settlement_token(env: Env) -> Option<Address> {
         Self::read_settlement_token(&env)
     }
@@ -348,9 +387,20 @@ impl Escrow {
     /// Read-only and auth-free: it performs no state mutation (no TTL write is
     /// needed for the simple binding key).
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
     /// # Returns
     /// * `true` if a settlement token is bound
     /// * `false` if no settlement token has been bound yet
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if client.is_settlement_token_bound() {
+    ///     // Safe to make deposits
+    /// }
+    /// ```
     pub fn is_settlement_token_bound(env: Env) -> bool {
         Self::read_settlement_token(&env).is_some()
     }
@@ -363,6 +413,23 @@ impl Escrow {
     /// protocol-fee, and governance operations. All escrow lifecycle operations
     /// (create, deposit, release, refund, cancel) call `require_initialized`
     /// so that these safety rails are always bound before money can move.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address initializing the escrow contract
+    ///
+    /// # Returns
+    /// * `bool` - `true` on successful initialization
+    ///
+    /// # Errors
+    /// * `AlreadyInitialized` - If `initialize` has already been called
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let initialized = client.initialize(&admin);
+    /// assert!(initialized);
+    /// ```
     pub fn initialize(env: Env, admin: Address) -> bool {
         if env
             .storage()
@@ -399,6 +466,18 @@ impl Escrow {
     }
 
     /// Returns the stored governance admin address.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `Option<Address>` - `Some(Address)` of the admin, or `None` if uninitialized
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let admin = client.get_admin();
+    /// ```
     pub fn get_admin(env: Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Admin)
     }
@@ -418,10 +497,20 @@ impl Escrow {
     /// between calls on the same contract binary. The function is read-only
     /// and requires no authorization.
     ///
+    /// # Arguments
+    /// * `_env` - The Soroban environment
+    ///
     /// # Returns
     /// A [`ContractBounds`] value containing only limit fields. Unlike
     /// [`get_contract_summary`], this type carries no per-contract participant
     /// or accounting data and its schema version tracks the limits API only.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let bounds = client.get_bounds();
+    /// assert_eq!(bounds.max_milestones, 10);
+    /// ```
     pub fn get_bounds(_env: Env) -> ContractBounds {
         ContractBounds {
             max_milestones: MAX_MILESTONES,
@@ -449,6 +538,19 @@ impl Escrow {
     /// Activating the emergency pause to flip the `emergency_controls_enabled` flag leaves the contract
     /// in a paused state. To complete a clean deploy and allow normal operations, the operator must
     /// subsequently call `resolve_emergency` to unpause the contract.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `ReadinessChecklist` - Struct containing setup readiness booleans
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let readiness = client.get_mainnet_readiness_info();
+    /// assert!(readiness.initialized);
+    /// ```
     pub fn get_mainnet_readiness_info(env: Env) -> ReadinessChecklist {
         env.storage()
             .persistent()
@@ -456,23 +558,6 @@ impl Escrow {
             .unwrap_or_default()
     }
 
-    /// Creates a new escrow contract with the specified client, freelancer, and milestone amounts.
-    ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    /// * `client` - The address of the client funding the contract
-    /// * `freelancer` - The address of the freelancer performing the work
-    /// * `arbiter` - Optional arbiter address for dispute resolution
-    /// * `milestones` - Vector of milestone amounts (in stroops)
-    /// * `release_authorization` - Authorization mode for milestone releases
-    ///
-    /// # Returns
-    /// The unique contract ID
-    ///
-    /// # Errors
-    /// * `InvalidParticipants` - If client and freelancer are the same address
-    /// * `EmptyMilestones` - If no milestones are provided
-    /// * `InvalidMilestoneAmount` - If any milestone amount is <= 0
     /// Pull the settlement-token deposit from the client into the escrow contract address.
     ///
     /// Executes `SAC::transfer(from: client, to: escrow_address, amount)` and advances
@@ -498,6 +583,13 @@ impl Escrow {
     /// * `ContractNotFound` - If contract doesn't exist
     /// * `InvalidState` - If contract is not in Created state
     /// * `UnauthorizedRole` - If caller is not the client
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let deposited = client.deposit_funds(&1, &client_address, &1_000_0000000);
+    /// assert!(deposited);
+    /// ```
     pub fn deposit_funds(env: Env, contract_id: u32, caller: Address, amount: i128) -> bool {
         Self::require_initialized(&env);
         Self::require_not_paused(&env);
@@ -522,17 +614,47 @@ impl Escrow {
     /// contract is `Completed` or `Disputed`. Once finalized, future
     /// contract-specific mutations fail with `AlreadyFinalized`.
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID to finalize
+    /// * `finalizer` - The address of the finalizer (client, freelancer, or arbiter)
+    ///
+    /// # Returns
+    /// * `bool` - `true` if finalized successfully
+    ///
     /// # Errors
     /// - `ContractPaused` when pause or emergency controls are active.
     /// - `ContractNotFound` when `contract_id` is unknown.
     /// - `AlreadyFinalized` when a close record already exists.
     /// - `UnauthorizedRole` when `finalizer` is not a contract participant.
     /// - `InvalidStatusTransition` unless status is `Completed` or `Disputed`.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let finalized = client.finalize_contract(&1, &client_address);
+    /// assert!(finalized);
+    /// ```
     pub fn finalize_contract(env: Env, contract_id: u32, finalizer: Address) -> bool {
         finalize::finalize_contract_impl(&env, contract_id, finalizer)
     }
 
     /// Return immutable close metadata for `contract_id`, if it has been finalized.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `Option<FinalizationRecord>` - `Some(record)` if finalized, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(record) = client.get_finalization_record(&1) {
+    ///     // Process finalization record
+    /// }
+    /// ```
     pub fn get_finalization_record(
         env: Env,
         contract_id: u32,
@@ -546,6 +668,27 @@ impl Escrow {
     /// The current client must authorize the call. The proposed client address
     /// must not be the freelancer or the current client. The pending migration
     /// is stored in temporary storage with TTL.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    /// * `current_client` - The address of the current client
+    /// * `new_client` - The proposed new client address
+    ///
+    /// # Returns
+    /// * `bool` - `true` if migration proposed successfully
+    ///
+    /// # Errors
+    /// * `ContractPaused` - If paused or in emergency mode
+    /// * `UnauthorizedRole` - If `current_client` is not the stored client
+    /// * `InvalidParticipant` - If `new_client` is current client or freelancer
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let proposed = client.propose_client_migration(&1, &current_client_address, &new_client_address);
+    /// assert!(proposed);
+    /// ```
     pub fn propose_client_migration(
         env: Env,
         contract_id: u32,
@@ -560,6 +703,26 @@ impl Escrow {
     ///
     /// Canonical public entrypoint; delegates to `accept_client_migration_impl`.
     /// Only the proposed client address may authorize acceptance.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    /// * `new_client` - The proposed new client address accepting migration
+    ///
+    /// # Returns
+    /// * `bool` - `true` if migration accepted successfully
+    ///
+    /// # Errors
+    /// * `ContractPaused` - If paused or in emergency mode
+    /// * `UnauthorizedRole` - If caller is not `new_client`
+    /// * `InvalidState` - If no live pending migration exists
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let accepted = client.accept_client_migration(&1, &new_client_address);
+    /// assert!(accepted);
+    /// ```
     pub fn accept_client_migration(env: Env, contract_id: u32, new_client: Address) -> bool {
         Self::require_not_paused(&env);
         Self::accept_client_migration_impl(&env, contract_id, new_client)
@@ -568,6 +731,21 @@ impl Escrow {
     /// Return true if a live pending client migration exists.
     ///
     /// Canonical public entrypoint; delegates to `has_pending_client_migration_impl`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `bool` - `true` if a pending migration exists, `false` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if client.has_pending_client_migration(&1) {
+    ///     // Pending migration active
+    /// }
+    /// ```
     pub fn has_pending_client_migration(env: Env, contract_id: u32) -> bool {
         Self::has_pending_client_migration_impl(&env, contract_id)
     }
@@ -576,6 +754,22 @@ impl Escrow {
     ///
     /// Canonical public entrypoint; delegates to `get_pending_client_migration_impl`.
     /// Panics with `InvalidState` when no live pending migration exists.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `PendingClientMigration` - Record containing migration details
+    ///
+    /// # Errors
+    /// * `InvalidState` - If no pending migration exists
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let pending = client.get_pending_client_migration(&1);
+    /// ```
     pub fn get_pending_client_migration(env: Env, contract_id: u32) -> PendingClientMigration {
         Self::get_pending_client_migration_impl(&env, contract_id)
     }
@@ -592,6 +786,15 @@ impl Escrow {
     /// - `ClientAndArbiter` — client or arbiter (one is enough)
     /// - `MultiSig` — both client and freelancer must approve
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    /// * `caller` - The address granting approval
+    /// * `milestone_index` - The zero-based milestone index
+    ///
+    /// # Returns
+    /// * `bool` - `true` if approval was recorded
+    ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode
     /// * `EmergencyActive` - If the contract is in an active emergency pause
@@ -603,6 +806,13 @@ impl Escrow {
     ///   and approval staging so no approval state mutates while the contract is frozen.
     ///
     /// See `docs/escrow/approvals-and-release.md` for the full flow.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let approved = client.approve_milestone_release(&1, &client_address, &0);
+    /// assert!(approved);
+    /// ```
     pub fn approve_milestone_release(
         env: Env,
         contract_id: u32,
@@ -678,6 +888,13 @@ impl Escrow {
     /// - Requires valid approvals that haven't expired
     /// - Approvals are cleared after successful release
     /// - Fail-closed: missing or expired approvals prevent release
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let released = client.release_milestone(&1, &client_address, &0);
+    /// assert!(released);
+    /// ```
     ///
     /// # Events
     /// Emits `("mlstn_rls", contract_id)` with payload
@@ -954,6 +1171,12 @@ impl Escrow {
     /// # Security
     /// Uses `now_seconds(&env)` which is the single source of truth for ledger time.
     /// Time cannot be manipulated by contract callers.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let overdue = client.is_milestone_overdue(&1, &0);
+    /// ```
     pub fn is_milestone_overdue(env: Env, contract_id: u32, milestone_index: u32) -> bool {
         let contract: Contract = match env
             .storage()
@@ -1015,6 +1238,13 @@ impl Escrow {
     /// * `InsufficientFunds` - If contract doesn't have enough balance to refund
     /// * `AlreadyFinalized` - If a finalization record already exists for this contract
     /// * `InvalidState` - If contract status is not Created, Funded, or Disputed
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let indices = soroban_sdk::vec![&env, 0u32];
+    /// let refunded_total = client.refund_unreleased_milestones(&1, &indices);
+    /// ```
     pub fn refund_unreleased_milestones(
         env: Env,
         contract_id: u32,
@@ -1183,13 +1413,10 @@ impl Escrow {
     /// * `false` if the contract does not exist
     ///
     /// # Examples
-    /// ```
-    /// // Safe iteration over a range of IDs
-    /// for id in 1..=100 {
-    ///     if escrow.contract_exists(id) {
-    ///         let contract = escrow.get_contract(id);
-    ///         // process contract
-    ///     }
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if client.contract_exists(&1) {
+    ///     let contract = client.get_contract(&1);
     /// }
     /// ```
     pub fn contract_exists(env: Env, contract_id: u32) -> bool {
@@ -1199,6 +1426,22 @@ impl Escrow {
     }
 
     /// Retrieves contract information.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `Contract` - The escrow contract struct
+    ///
+    /// # Errors
+    /// * `ContractNotFound` - If contract does not exist
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let contract = client.get_contract(&1);
+    /// ```
     pub fn get_contract(env: Env, contract_id: u32) -> Contract {
         let contract = env
             .storage()
@@ -1228,14 +1471,12 @@ impl Escrow {
     /// The next contract ID to be allocated (always ≥ 1)
     ///
     /// # Examples
-    /// ```
-    /// // Get the high-water mark
-    /// let next_id = escrow.get_next_contract_id();
-    /// // All allocated IDs are in the range [1, next_id - 1]
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let next_id = client.get_next_contract_id();
     /// for id in 1..next_id {
-    ///     if escrow.contract_exists(id) {
-    ///         let contract = escrow.get_contract(id);
-    ///         // process contract
+    ///     if client.contract_exists(&id) {
+    ///         let contract = client.get_contract(&id);
     ///     }
     /// }
     /// ```
@@ -1259,6 +1500,13 @@ impl Escrow {
     ///
     /// # Errors
     /// * `ContractNotFound` - If contract doesn't exist
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let summary = client.get_contract_summary(&1);
+    /// assert_eq!(summary.schema_version, 1);
+    /// ```
     pub fn get_contract_summary(env: Env, contract_id: u32) -> ContractSummary {
         let contract: Contract = env
             .storage()
@@ -1311,6 +1559,22 @@ impl Escrow {
     }
 
     /// Retrieves all milestones for a contract.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `Vec<Milestone>` - Vector of milestone items
+    ///
+    /// # Errors
+    /// * `ContractNotFound` - If contract milestones do not exist
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let milestones = client.get_milestones(&1);
+    /// ```
     pub fn get_milestones(env: Env, contract_id: u32) -> Vec<Milestone> {
         let milestone_key = Symbol::new(&env, "milestones");
         let milestones = env
@@ -1346,6 +1610,14 @@ impl Escrow {
     /// # Side effects
     /// Extends the milestones vector TTL on a successful read, consistent with
     /// `get_milestones`. Auth-free and otherwise non-mutating.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(milestone) = client.get_milestone(&1, &0) {
+    ///     // Process milestone 0
+    /// }
+    /// ```
     pub fn get_milestone(env: Env, contract_id: u32, milestone_index: u32) -> Option<Milestone> {
         let milestone_key = Symbol::new(&env, "milestones");
         let milestones: Vec<Milestone> = env
@@ -1358,6 +1630,22 @@ impl Escrow {
     }
 
     /// Returns funded minus released minus refunded for `contract_id`.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `i128` - Remaining refundable balance in stroops
+    ///
+    /// # Errors
+    /// * `ContractNotFound` - If contract does not exist
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let balance = client.get_refundable_balance(&1);
+    /// ```
     pub fn get_refundable_balance(env: Env, contract_id: u32) -> i128 {
         let contract: Contract = env
             .storage()
@@ -1385,6 +1673,22 @@ impl Escrow {
     /// storage access and TTL bump behavior.
     ///
     /// See `approve_milestone_release` and `docs/escrow/authorization.md`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    /// * `milestone_index` - The zero-based milestone index
+    ///
+    /// # Returns
+    /// * `Option<MilestoneApprovals>` - `Some(MilestoneApprovals)` if present, `None` if non-existent or expired
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(approvals) = client.get_milestone_approvals(&1, &0) {
+    ///     assert!(approvals.client_approved);
+    /// }
+    /// ```
     pub fn get_milestone_approvals(
         env: Env,
         contract_id: u32,
@@ -1407,6 +1711,22 @@ impl Escrow {
     /// Returns ledgers remaining, computed against ttl::compute_expiry.
     /// `None` when no live approval exists,
     /// distinguishing "never approved" from "approved and evicted".
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    /// * `milestone_index` - The zero-based milestone index
+    ///
+    /// # Returns
+    /// * `Option<u32>` - `Some(ledger_expiry)` if approval exists, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(deadline) = client.get_approval_deadline(&1, &0) {
+    ///     // Process deadline ledger
+    /// }
+    /// ```
     pub fn get_approval_deadline(env: Env, contract_id: u32, milestone_index: u32) -> Option<u32> {
         let approval_key = DataKey::MilestoneApprovals(contract_id, milestone_index);
         if !env.storage().temporary().has(&approval_key) {
@@ -1422,6 +1742,23 @@ impl Escrow {
     ///
     /// Requires the stored admin's authorization. While paused, all mutating
     /// entrypoints panic with `ContractPaused`. Read-only queries are never blocked.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `bool` - `true` if paused successfully
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract is uninitialized
+    /// * `UnauthorizedRole` - If caller is not admin
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let paused = client.pause();
+    /// assert!(paused);
+    /// ```
     ///
     /// # Events
     /// Emits `("paused", timestamp)` with `(admin,)` payload.
@@ -1440,6 +1777,24 @@ impl Escrow {
     ///
     /// Blocked while `Emergency` is active — use `resolve_emergency` instead.
     /// Requires the stored admin's authorization.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `bool` - `true` if unpaused successfully
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract is uninitialized
+    /// * `EmergencyActive` - If emergency controls are currently active
+    /// * `UnauthorizedRole` - If caller is not admin
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let unpaused = client.unpause();
+    /// assert!(unpaused);
+    /// ```
     ///
     /// # Events
     /// Emits `("unpaused", timestamp)` with `(admin,)` payload.
@@ -1465,6 +1820,20 @@ impl Escrow {
     }
 
     /// Returns `true` if the contract is currently paused.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `bool` - `true` if paused, `false` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if client.is_paused() {
+    ///     // Contract is currently paused
+    /// }
+    /// ```
     pub fn is_paused(env: Env) -> bool {
         env.storage()
             .persistent()
@@ -1479,6 +1848,23 @@ impl Escrow {
     /// Requires the stored admin's authorization. While emergency is active,
     /// all mutating entrypoints panic with `EmergencyActive` or `ContractPaused`,
     /// and `unpause` is blocked.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `bool` - `true` if emergency pause activated
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract is uninitialized
+    /// * `UnauthorizedRole` - If caller is not admin
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let activated = client.activate_emergency_pause();
+    /// assert!(activated);
+    /// ```
     ///
     /// # Events
     /// Emits `("emergency", "activated")` with `(admin, timestamp)` payload.
@@ -1532,6 +1918,23 @@ impl Escrow {
     /// Requires the stored admin's authorization. After resolution, all
     /// operations resume normally.
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `bool` - `true` if emergency resolved
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract is uninitialized
+    /// * `UnauthorizedRole` - If caller is not admin
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let resolved = client.resolve_emergency();
+    /// assert!(resolved);
+    /// ```
+    ///
     /// # Events
     /// Emits `("emergency", "resolved")` with `(admin, timestamp)` payload.
     /// Sets `emergency_controls_enabled` in the readiness checklist.
@@ -1565,6 +1968,21 @@ impl Escrow {
         true
     }
 
+    /// Returns `true` if emergency mode is active.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `bool` - `true` if emergency mode is active, `false` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if client.is_emergency() {
+    ///     // Emergency mode active
+    /// }
+    /// ```
     pub fn is_emergency(env: Env) -> bool {
         env.storage()
             .persistent()
@@ -1583,6 +2001,14 @@ impl Escrow {
     /// marked `Cancelled`. A zero-funded cancellation does not invoke a token
     /// transfer and leaves unrelated contracts' escrowed token balances intact.
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID to cancel
+    /// * `client` - Address of client canceling contract
+    ///
+    /// # Returns
+    /// * `bool` - `true` if canceled successfully
+    ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode.
     /// * `EmergencyActive` - If the contract is in an active emergency pause.
@@ -1590,6 +2016,13 @@ impl Escrow {
     /// * `UnauthorizedRole` - If the caller is not the stored client.
     /// * `AlreadyCancelled` - If the contract was already cancelled.
     /// * `InvalidStatusTransition` - If the contract is not `Created`/`Funded` or has already released funds.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let cancelled = client.cancel_contract(&1, &client_address);
+    /// assert!(cancelled);
+    /// ```
     pub fn cancel_contract(env: Env, contract_id: u32, client: Address) -> bool {
         Self::require_not_paused(&env);
         let mut contract: Contract = env
@@ -1661,6 +2094,16 @@ impl Escrow {
     /// `String::len()` returns the UTF-8 byte length, a multi-byte character (e.g.
     /// a 3-byte emoji) counts as 3 toward the limit. ASCII characters are 1 byte each.
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    /// * `caller` - Address of client issuing reputation
+    /// * `rating` - Rating integer between 1 and 5 (inclusive)
+    /// * `comment` - Feedback string (1-200 bytes)
+    ///
+    /// # Returns
+    /// * `bool` - `true` if reputation issued successfully
+    ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode
     /// * `EmergencyActive` - If the contract is in an active emergency pause
@@ -1678,6 +2121,14 @@ impl Escrow {
     /// * Pause/emergency gate runs BEFORE contract state read so paused
     ///   contracts cannot have reputation mutated while paused.
     /// * The 200-byte cap prevents unbounded on-chain storage growth.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let comment = soroban_sdk::String::from_str(&env, "Great work!");
+    /// let issued = client.issue_reputation(&1, &client_address, &5, &comment);
+    /// assert!(issued);
+    /// ```
     pub fn issue_reputation(
         env: Env,
         contract_id: u32,
@@ -1762,6 +2213,21 @@ impl Escrow {
 
     /// Returns the written feedback provided by the client when reputation was issued.
     /// Returns `None` if reputation has not been issued for this contract.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `contract_id` - The contract ID
+    ///
+    /// # Returns
+    /// * `Option<String>` - `Some(String)` with comment feedback if issued, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(comment) = client.get_reputation_comment(&1) {
+    ///     // Process feedback string
+    /// }
+    /// ```
     pub fn get_reputation_comment(env: Env, contract_id: u32) -> Option<String> {
         let comment_key = DataKey::ReputationComment(contract_id);
         let comment: Option<String> = env.storage().persistent().get(&comment_key);
@@ -1775,6 +2241,22 @@ impl Escrow {
         comment
     }
 
+    /// Returns overall reputation aggregate metrics for an address.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `address` - Address of the freelancer to query
+    ///
+    /// # Returns
+    /// * `Option<Reputation>` - `Some(Reputation)` if record exists, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(rep) = client.get_reputation(&freelancer_address) {
+    ///     assert_eq!(rep.completed_contracts, 1);
+    /// }
+    /// ```
     pub fn get_reputation(env: Env, address: Address) -> Option<types::Reputation> {
         env.storage()
             .persistent()
@@ -1788,10 +2270,25 @@ impl Escrow {
     /// `result = total_rating * 10_000 / completed_contracts`
     ///
     /// A raw rating of 5 on a single contract returns `50_000` (5.0000 on a
-    /// 1–5 scale).  Clients divide by `10_000` to recover the decimal value.
+    /// 1–5 scale). Clients divide by `10_000` to recover the decimal value.
     ///
     /// Checked arithmetic is used throughout; division by zero is impossible
     /// because `None` is returned whenever `completed_contracts == 0`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `address` - Address of the freelancer to query
+    ///
+    /// # Returns
+    /// * `Option<i128>` - `Some(average_rating_bps)` if completed contracts > 0, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(avg_bps) = client.get_average_rating(&freelancer_address) {
+    ///     let avg_decimal = avg_bps as f64 / 10_000.0;
+    /// }
+    /// ```
     pub fn get_average_rating(env: Env, address: Address) -> Option<i128> {
         /// Basis-point scaling factor (×10 000 preserves four decimal places).
         const SCALE: i128 = 10_000;
@@ -1815,6 +2312,19 @@ impl Escrow {
     /// This value increments once per completed contract and decrements once
     /// per successful `issue_reputation` call. Refunded contracts do not accrue
     /// pending reputation credits.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `address` - Address of the freelancer to query
+    ///
+    /// # Returns
+    /// * `i128` - Number of pending reputation credits
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let credits = client.get_pending_reputation_credits(&freelancer_address);
+    /// ```
     pub fn get_pending_reputation_credits(env: Env, address: Address) -> i128 {
         env.storage()
             .persistent()
@@ -1834,10 +2344,14 @@ impl Escrow {
     /// refunded. Evidence may be overwritten before release.
     ///
     /// # Arguments
+    /// * `env` - The Soroban environment
     /// * `contract_id` - The escrow contract to update
     /// * `caller`      - Must equal the stored `freelancer`; requires auth
     /// * `milestone_index` - Zero-based index of the milestone
     /// * `evidence`    - Deliverable reference; max 256 bytes
+    ///
+    /// # Returns
+    /// * `bool` - `true` if work evidence was recorded successfully
     ///
     /// # Errors
     /// * `NotInitialized`     — `initialize` has not been called
@@ -1850,6 +2364,14 @@ impl Escrow {
     /// * `MilestoneAlreadyReleased` — milestone is already released
     /// * `AlreadyRefunded`    — milestone has been refunded
     /// * `EvidenceTooLong`    — evidence string exceeds 256 bytes
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let cid = soroban_sdk::String::from_str(&env, "ipfs://Qm...");
+    /// let submitted = client.submit_work_evidence(&1, &freelancer_address, &0, &cid);
+    /// assert!(submitted);
+    /// ```
     pub fn submit_work_evidence(
         env: Env,
         contract_id: u32,
@@ -1931,6 +2453,7 @@ impl Escrow {
     /// milestone index is out of bounds or no evidence was submitted.
     ///
     /// # Arguments
+    /// * `env` - The Soroban environment
     /// * `contract_id` - The escrow contract ID
     /// * `milestone_index` - Zero-based index of the milestone
     ///
@@ -1944,6 +2467,14 @@ impl Escrow {
     /// # TTL
     /// Extends the milestones vector's persistent TTL on read,
     /// consistent with `get_milestones`.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(evidence) = client.get_work_evidence(&1, &0) {
+    ///     // Process evidence string
+    /// }
+    /// ```
     pub fn get_work_evidence(env: Env, contract_id: u32, milestone_index: u32) -> Option<String> {
         let milestone_key = Symbol::new(&env, "milestones");
         let milestones: Vec<Milestone> = env
@@ -1974,11 +2505,20 @@ impl Escrow {
     /// The balance defaults to `0` when no fees have accrued. This public
     /// reader requires no authorization and does not mutate contract state.
     ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
     /// # Returns
     /// The fees currently available for protocol withdrawal.
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
     /// storage details and the full withdrawal flow.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let fees = client.get_accumulated_protocol_fees();
+    /// ```
     pub fn get_accumulated_protocol_fees(env: Env) -> i128 {
         env.storage()
             .persistent()
@@ -1988,7 +2528,7 @@ impl Escrow {
 
     /// Drains accrued protocol fees from the escrow contract to a treasury address.
     ///
-    /// Executes `SAC::transfer(from: escrow_address, to: treasury, amount)`.  Protocol
+    /// Executes `SAC::transfer(from: escrow_address, to: treasury, amount)`. Protocol
     /// fees accumulate in `DataKey::AccumulatedProtocolFees` as each milestone is
     /// released; they remain commingled with the escrow's SAC balance until this
     /// entrypoint is called.
@@ -2007,6 +2547,24 @@ impl Escrow {
     /// * `env` - The contract environment
     /// * `amount` - The amount of fees to withdraw
     /// * `to` - The destination address for the withdrawn fees
+    ///
+    /// # Returns
+    /// * `bool` - `true` if fees withdrawn successfully
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract uninitialized
+    /// * `ContractPaused` - If paused or in emergency mode
+    /// * `UnauthorizedRole` - If caller is not admin
+    /// * `AmountMustBePositive` - If amount <= 0
+    /// * `InsufficientAccumulatedFees` - If withdrawal amount exceeds accumulated fees
+    /// * `SettlementTokenNotConfigured` - If no settlement token is bound
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let withdrawn = client.withdraw_protocol_fees(&50_0000000, &treasury_address);
+    /// assert!(withdrawn);
+    /// ```
     pub fn withdraw_protocol_fees(env: Env, amount: i128, to: Address) -> bool {
         Self::require_initialized(&env);
 
@@ -2075,6 +2633,20 @@ impl Escrow {
     /// Returns `None` if there is no pending proposal. This allows off-chain
     /// indexers and governance dashboards to compute the remaining timelock
     /// before the proposal can be accepted via `accept_governance_admin`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// * `Option<u32>` - `Some(ledger_sequence)` if a proposal is active, `None` otherwise
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// if let Some(proposed_at) = client.get_pending_admin_proposed_at() {
+    ///     // Calculate timelock remaining
+    /// }
+    /// ```
     pub fn get_pending_admin_proposed_at(env: Env) -> Option<u32> {
         let proposal: Option<PendingAdminProposal> =
             env.storage().persistent().get(&DataKey::PendingAdmin);
@@ -2099,7 +2671,7 @@ impl Escrow {
     /// Uses integer **floor division**: `fee = amount * fee_bps / 10_000`.
     /// The result always rounds down — it never rounds up — so the freelancer
     /// receives at least `amount - fee` stroops and the protocol receives at most
-    /// the floored value.  Callers must ensure `fee <= amount` holds; this is
+    /// the floored value. Callers must ensure `fee <= amount` holds; this is
     /// guaranteed for any `fee_bps` in `[0, 10_000]` and a non-negative `amount`.
     ///
     /// # Basis-point unit
@@ -2115,8 +2687,14 @@ impl Escrow {
     ///
     /// # Panics
     /// Panics with `PotentialOverflow` (error code 28) if `amount * fee_bps`
-    /// overflows `i128`.  Callers should keep `amount` well below `i128::MAX /
+    /// overflows `i128`. Callers should keep `amount` well below `i128::MAX /
     /// fee_bps` to avoid this guard.
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let fee = Escrow::calculate_protocol_fee(&env, 100_0000000, 250); // 2.5% fee
+    /// assert_eq!(fee, 2_5000000);
+    /// ```
     pub fn calculate_protocol_fee(env: &Env, amount: i128, fee_bps: u32) -> i128 {
         if fee_bps == 0 {
             return 0;
@@ -2181,6 +2759,13 @@ impl Escrow {
     /// - Requires arbiter assignment for resolution
     /// - Blocks milestone releases while disputed
     /// - Respects pause and emergency controls
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let opened = client.raise_dispute(&1, &client_address);
+    /// assert!(opened);
+    /// ```
     pub fn raise_dispute(env: Env, contract_id: u32, caller: Address) -> bool {
         /// Gate: contract must have been initialized so pause and emergency rails
         /// are always in scope before any state mutation can occur.
@@ -2260,6 +2845,13 @@ impl Escrow {
     /// - Updates released_amount and refunded_amount atomically
     /// - Emits dispute resolution event for indexers
     /// - Sets final contract status based on resolution outcome
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// let client = EscrowClient::new(&env, &contract_id);
+    /// let resolved = client.resolve_dispute(&1, &arbiter_address, &DisputeResolution::FullPayout);
+    /// assert!(resolved);
+    /// ```
     pub fn resolve_dispute(
         env: Env,
         contract_id: u32,

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -25,6 +25,7 @@ mod release;
 mod release_authorization;
 mod reputation;
 mod security;
+mod rustdoc_examples;
 mod ttl_tests;
 
 // --- Shared constants ---

--- a/contracts/escrow/src/test/rustdoc_examples.rs
+++ b/contracts/escrow/src/test/rustdoc_examples.rs
@@ -1,0 +1,88 @@
+use super::EscrowFixture;
+use crate::{DisputeResolution, ReleaseAuthorization};
+use soroban_sdk::{vec, String};
+
+#[test]
+fn test_rustdoc_examples_flow_verification() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let env = &fixture.env;
+    let client = fixture.escrow();
+    let admin = &fixture.admin;
+    let client_addr = &fixture.client;
+    let freelancer_addr = &fixture.freelancer;
+
+    // 1. Check settlement token binding and getters
+    assert!(client.is_settlement_token_bound());
+    assert!(client.get_settlement_token().is_some());
+
+    // 2. Read bounds and readiness info
+    let bounds = client.get_bounds();
+    assert_eq!(bounds.max_milestones, 10);
+
+    let readiness = client.get_mainnet_readiness_info();
+    assert!(readiness.initialized);
+
+    // 3. Admin & Governance readers
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+    assert_eq!(client.get_governance_admin(), Some(admin.clone()));
+    assert_eq!(client.get_protocol_fee_bps(), 0);
+    assert_eq!(client.get_accumulated_protocol_fees(), 0);
+    assert_eq!(client.get_pending_admin_proposed_at(), None);
+    assert_eq!(client.get_governed_parameters(), None);
+
+    // 4. Create contract and query contract state
+    let milestones = vec![env, 100_0000000];
+    let contract_id = client.create_contract(
+        client_addr,
+        freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(client.contract_exists(&contract_id));
+    let contract = client.get_contract(&contract_id);
+    assert_eq!(contract.client, *client_addr);
+
+    let next_id = client.get_next_contract_id();
+    assert!(next_id > contract_id);
+
+    let summary = client.get_contract_summary(&contract_id);
+    assert_eq!(summary.schema_version, 1);
+
+    let milestone_list = client.get_milestones(&contract_id);
+    assert_eq!(milestone_list.len(), 1);
+
+    let single_milestone = client.get_milestone(&contract_id, &0);
+    assert!(single_milestone.is_some());
+
+    let is_overdue = client.is_milestone_overdue(&contract_id, &0);
+    assert!(!is_overdue);
+
+    let refundable = client.get_refundable_balance(&contract_id);
+    assert_eq!(refundable, 0); // Not funded yet
+
+    // 5. Client migration query
+    assert!(!client.has_pending_client_migration(&contract_id));
+
+    // 6. Approval & deadline check
+    let approved = client.approve_milestone_release(&contract_id, client_addr, &0);
+    assert!(approved);
+    assert!(client.get_milestone_approvals(&contract_id, &0).is_some());
+    assert!(client.get_approval_deadline(&contract_id, &0).is_some());
+
+    // 7. Pause & Emergency readers
+    assert!(!client.is_paused());
+    assert!(!client.is_emergency());
+
+    // 8. Work evidence query
+    assert_eq!(client.get_work_evidence(&contract_id, &0), None);
+
+    // 9. Reputation getters
+    assert_eq!(client.get_reputation_comment(&contract_id), None);
+    assert_eq!(client.get_reputation(freelancer_addr), None);
+    assert_eq!(client.get_average_rating(freelancer_addr), None);
+    assert_eq!(client.get_pending_reputation_credits(freelancer_addr), 0);
+
+    // 10. Finalization record query
+    assert_eq!(client.get_finalization_record(&contract_id), None);
+}


### PR DESCRIPTION
Closes #1065 

### Summary of Changes
1. **Created New Branch**:
   - `docs/escrow-41-rustdoc`
2. **Added Comprehensive Rustdoc Examples**:
   - Added `# Examples` sections (using `/// ```rust,ignore` blocks accurate to Soroban `EscrowClient` invocation signatures) to all public entrypoints in:
     - [`contracts/escrow/src/lib.rs`](contracts/escrow/src/lib.rs) (`bind_settlement_token`, `set_settlement_token`, `get_settlement_token`, `is_settlement_token_bound`, `initialize`, `get_admin`, `get_bounds`, `get_mainnet_readiness_info`, `deposit_funds`, `finalize_contract`, `get_finalization_record`, `propose_client_migration`, `accept_client_migration`, `has_pending_client_migration`, `get_pending_client_migration`, `approve_milestone_release`, `release_milestone`, `is_milestone_overdue`, `refund_unreleased_milestones`, `contract_exists`, `get_contract`, `get_next_contract_id`, `get_contract_summary`, `get_milestones`, `get_milestone`, `get_refundable_balance`, `get_milestone_approvals`, `get_approval_deadline`, `pause`, `unpause`, `is_paused`, `activate_emergency_pause`, `resolve_emergency`, `is_emergency`, `cancel_contract`, `issue_reputation`, `get_reputation_comment`, `get_reputation`, `get_average_rating`, `get_pending_reputation_credits`, `submit_work_evidence`, `get_work_evidence`, `get_accumulated_protocol_fees`, `withdraw_protocol_fees`, `get_pending_admin_proposed_at`, `calculate_protocol_fee`, `raise_dispute`, `resolve_dispute`).
     - [`contracts/escrow/src/governance.rs`](contracts/escrow/src/governance.rs) (`set_protocol_fee_bps`, `get_governance_admin`, `get_protocol_fee_bps`, `set_governed_params`, `get_governed_parameters`).
     - [`contracts/escrow/src/create_contract.rs`](contracts/escrow/src/create_contract.rs) (`create_contract`).
3. **Added Comprehensive Test Suite**:
   - Added [`contracts/escrow/src/test/rustdoc_examples.rs`](contracts/escrow/src/test/rustdoc_examples.rs) and registered it in [`contracts/escrow/src/test/mod.rs`](contracts/escrow/src/test/mod.rs) to verify all documented API flows and entrypoint usage patterns.
