### PR TITLE
feat(settlement): admin-configurable settlement limit

### DIFF
--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -10,7 +10,7 @@
 use crate::ttl::ADMIN_ROTATION_MIN_DELAY_LEDGERS;
 use crate::{
     DataKey, Error, Escrow, EscrowArgs, EscrowClient, GovernedParameters, PendingAdminProposal,
-    ReadinessChecklist,
+    ReadinessChecklist, EscrowError, DEFAULT_SETTLEMENT_LIMIT,
 };
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
@@ -251,5 +251,65 @@ impl Escrow {
     /// Retrieve the current governed parameters.
     pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
         env.storage().persistent().get(&DataKey::GovernedParameters)
+    }
+
+    // ── Settlement limit ──────────────────────────────────────────────────────
+
+    /// Set the per-milestone settlement limit (max single milestone amount in stroops).
+    ///
+    /// Admin-gated: the stored admin must authorize the call and the contract
+    /// must be initialized.
+    ///
+    /// `limit` must satisfy `1 ≤ limit ≤ DEFAULT_SETTLEMENT_LIMIT`. The
+    /// default (when no value has been set) preserves the original hard-coded
+    /// behaviour.
+    ///
+    /// Takes effect immediately for the next `create_contract` call.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `admin` - The admin address (must match stored admin)
+    /// * `limit` - The new settlement limit in stroops
+    ///
+    /// # Errors
+    /// * `NotInitialized` if `initialize` has not been called
+    /// * `UnauthorizedRole` if `admin` is not the stored admin
+    /// * `SettlementLimitOutOfBounds` if `limit` is outside `[1, DEFAULT_SETTLEMENT_LIMIT]`
+    ///
+    /// # Events
+    /// `(Symbol("settlement_limit"),)` → `(old_limit, new_limit, admin, timestamp)`
+    pub fn set_settlement_limit(env: Env, admin: Address, limit: i128) -> bool {
+        Self::require_initialized(&env);
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+        if admin != stored_admin {
+            env.panic_with_error(EscrowError::UnauthorizedRole);
+        }
+        admin.require_auth();
+
+        if limit < 1 || limit > DEFAULT_SETTLEMENT_LIMIT {
+            env.panic_with_error(EscrowError::SettlementLimitOutOfBounds);
+        }
+
+        let old_limit: i128 = Self::read_settlement_limit(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::SettlementLimit, &limit);
+
+        env.events().publish(
+            (Symbol::new(&env, "settlement_limit"),),
+            (old_limit, limit, admin, env.ledger().timestamp()),
+        );
+        true
+    }
+
+    /// Returns the current settlement limit in stroops.
+    ///
+    /// Defaults to [`DEFAULT_SETTLEMENT_LIMIT`] when no value has been set.
+    pub fn get_settlement_limit(env: Env) -> i128 {
+        Self::read_settlement_limit(&env)
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -91,6 +91,11 @@ pub const MAX_MILESTONES: u32 = 10;
 pub const MAX_SINGLE_AMOUNT_STROOPS: i128 = crate::amount_validation::MAX_SINGLE_AMOUNT_STROOPS;
 pub const MAX_TOTAL_ESCROW_STROOPS: i128 = MAX_SINGLE_AMOUNT_STROOPS;
 
+/// Default settlement limit (max single milestone amount in stroops).
+/// Preserves the original hard-coded behaviour; admin may lower it via
+/// [`Escrow::set_settlement_limit`] but never above this absolute ceiling.
+pub const DEFAULT_SETTLEMENT_LIMIT: i128 = MAX_SINGLE_AMOUNT_STROOPS;
+
 #[contract]
 pub struct Escrow;
 
@@ -171,6 +176,8 @@ pub enum EscrowError {
     EmptyComment = 42,
     /// Reputation feedback comment exceeded the 200-character maximum.
     CommentTooLong = 43,
+    /// The settlement limit value is out of the allowed bounds.
+    SettlementLimitOutOfBounds = 44,
 }
 
 impl Escrow {
@@ -184,6 +191,15 @@ impl Escrow {
         env.storage()
             .persistent()
             .set(&DataKey::SettlementToken, token);
+    }
+
+    /// Read the admin-configurable settlement limit from storage, falling back
+    /// to [`DEFAULT_SETTLEMENT_LIMIT`] when no value has been set.
+    pub(crate) fn read_settlement_limit(env: &Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SettlementLimit)
+            .unwrap_or(DEFAULT_SETTLEMENT_LIMIT)
     }
 }
 
@@ -403,29 +419,31 @@ impl Escrow {
         env.storage().persistent().get(&DataKey::Admin)
     }
 
-    /// Returns the protocol-wide hard-coded bounds used by validation paths.
+    /// Returns the current protocol-wide bounds used by validation paths.
     ///
     /// Callers and off-chain indexers should query this endpoint to discover
-    /// the limits enforced by `create_contract` without relying on hard-coded
-    /// constants:
+    /// the limits enforced by `create_contract`:
     ///
     /// - `max_milestones`: maximum number of milestones per contract.
-    /// - `max_single_milestone_stroops`: maximum amount for any single milestone.
+    /// - `max_single_milestone_stroops`: maximum amount for any single milestone
+    ///   (admin-configurable via [`set_settlement_limit`](Self::set_settlement_limit),
+    ///   defaults to [`DEFAULT_SETTLEMENT_LIMIT`]).
     /// - `max_total_escrow_stroops`: maximum sum of all milestone amounts.
     /// - `max_fee_bps`: protocol fee ceiling in basis points (10 000 = 100 %).
     ///
-    /// These are compile-time constants — the return value never changes
-    /// between calls on the same contract binary. The function is read-only
-    /// and requires no authorization.
+    /// Most fields are compile-time constants. The settlement limit is read
+    /// from persistent storage and may change at runtime via admin governance.
     ///
     /// # Returns
     /// A [`ContractBounds`] value containing only limit fields. Unlike
     /// [`get_contract_summary`], this type carries no per-contract participant
     /// or accounting data and its schema version tracks the limits API only.
+    ///
+    /// The function is read-only and requires no authorization.
     pub fn get_bounds(_env: Env) -> ContractBounds {
         ContractBounds {
             max_milestones: MAX_MILESTONES,
-            max_single_milestone_stroops: MAX_SINGLE_AMOUNT_STROOPS,
+            max_single_milestone_stroops: Self::read_settlement_limit(&_env),
             max_total_escrow_stroops: MAX_TOTAL_ESCROW_STROOPS,
             max_fee_bps: 10_000,
         }

--- a/contracts/escrow/src/test/governance.rs
+++ b/contracts/escrow/src/test/governance.rs
@@ -238,3 +238,141 @@ fn propose_emits_event() {
     });
     assert!(found_proposed, "propose event should be emitted");
 }
+
+// ── Settlement limit tests ──────────────────────────────────────────────────
+
+#[test]
+fn settlement_limit_defaults_to_compile_time_constant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let limit = client.get_settlement_limit();
+    assert_eq!(limit, crate::DEFAULT_SETTLEMENT_LIMIT);
+}
+
+#[test]
+fn set_settlement_limit_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let new_limit: i128 = 500_000_0000000; // 500k tokens
+    assert!(client.set_settlement_limit(&new_limit));
+    assert_eq!(client.get_settlement_limit(), new_limit);
+}
+
+#[test]
+fn set_settlement_limit_at_minimum_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    assert!(client.set_settlement_limit(&1));
+    assert_eq!(client.get_settlement_limit(), 1);
+}
+
+#[test]
+fn set_settlement_limit_at_maximum_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    assert!(client.set_settlement_limit(&crate::DEFAULT_SETTLEMENT_LIMIT));
+    assert_eq!(
+        client.get_settlement_limit(),
+        crate::DEFAULT_SETTLEMENT_LIMIT
+    );
+}
+
+#[test]
+fn set_settlement_limit_zero_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let result = client.try_set_settlement_limit(&0);
+    super::assert_contract_error(result, crate::EscrowError::SettlementLimitOutOfBounds);
+}
+
+#[test]
+fn set_settlement_limit_negative_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let result = client.try_set_settlement_limit(&-1);
+    super::assert_contract_error(result, crate::EscrowError::SettlementLimitOutOfBounds);
+}
+
+#[test]
+fn set_settlement_limit_above_max_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let result =
+        client.try_set_settlement_limit(&(crate::DEFAULT_SETTLEMENT_LIMIT + 1));
+    super::assert_contract_error(result, crate::EscrowError::SettlementLimitOutOfBounds);
+}
+
+#[test]
+fn set_settlement_limit_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+    // register_client already initialized with a random admin
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_set_settlement_limit(&non_admin, &100);
+    super::assert_contract_error(result, crate::EscrowError::UnauthorizedRole);
+}
+
+#[test]
+fn set_settlement_limit_updates_get_bounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let new_limit: i128 = 200_000_0000000; // 200k tokens
+    client.set_settlement_limit(&new_limit);
+
+    let bounds = client.get_bounds();
+    assert_eq!(bounds.max_single_milestone_stroops, new_limit);
+}
+
+#[test]
+fn set_settlement_limit_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let new_limit: i128 = 300_000_0000000;
+    client.set_settlement_limit(&new_limit);
+
+    let events = env.events().all();
+    let topic = Symbol::new(&env, "settlement_limit");
+    let found = events.iter().any(|event| {
+        event.1.len() >= 1
+            && Symbol::try_from_val(&env, &event.1.get(0).unwrap())
+                .ok()
+                .as_ref()
+                == Some(&topic)
+    });
+    assert!(found, "settlement_limit event should be emitted");
+}
+
+#[test]
+fn set_settlement_limit_overwrites_previous() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let first: i128 = 100_000_0000000;
+    let second: i128 = 50_000_0000000;
+    client.set_settlement_limit(&first);
+    assert_eq!(client.get_settlement_limit(), first);
+
+    client.set_settlement_limit(&second);
+    assert_eq!(client.get_settlement_limit(), second);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -33,12 +33,12 @@ pub struct ContractSummary {
 
 /// Protocol-wide bounds for contract validation.
 ///
-/// This type carries the hard-coded limits used by `create_contract` and other
+/// This type carries the limits used by `create_contract` and other
 /// validation paths. It is returned by `get_bounds()` for off-chain indexers
 /// and client applications.
 ///
-/// Dedicated struct for protocol bounds prevents coupling the limits ABI to the
-/// per-contract summary schema version.
+/// The settlement limit (`max_single_milestone_stroops`) is admin-configurable
+/// at runtime; all other fields are compile-time constants.
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ContractBounds {
@@ -90,6 +90,8 @@ pub enum DataKey {
     Finalization(u32),
     // Settlement token
     SettlementToken,
+    // Admin-configurable settlement limit (max single milestone amount in stroops)
+    SettlementLimit,
 }
 
 /// Canonical contract error type for all entrypoint-facing errors.


### PR DESCRIPTION
Closes
#896
Problem
The per-milestone settlement limit (MAX_SINGLE_AMOUNT_STROOPS) is a hard-coded compile-time constant (1_000_000_0000000 stroops / 1M tokens). Adjusting it requires a contract upgrade and redeployment. There is no admin entrypoint to tune this value at runtime.
Solution
Introduce two new public entrypoints — set_settlement_limit and get_settlement_limit — that allow the admin to configure the maximum single-milestone amount at runtime via persistent storage. The default value preserves the original hard-coded behaviour, so existing deployments are unaffected until the admin explicitly opts in.
What Changed
contracts/escrow/src/types.rs
- Added DataKey::SettlementLimit variant to the storage key enum, holding the admin-configurable limit in stroops.
contracts/escrow/src/lib.rs
- Added EscrowError::SettlementLimitOutOfBounds (error code 44) — a typed error returned when the supplied limit is outside the valid range.
- Added pub const DEFAULT_SETTLEMENT_LIMIT: i128 equal to MAX_SINGLE_AMOUNT_STROOPS. This is the absolute ceiling and the default when no value has been set.
- Added pub(crate) fn read_settlement_limit(env: &Env) -> i128 — reads the stored limit from DataKey::SettlementLimit, falling back to DEFAULT_SETTLEMENT_LIMIT.
- Updated get_bounds() to return read_settlement_limit(env) for max_single_milestone_stroops instead of the hard-coded constant. Off-chain indexers now reflect the runtime-configured value.
contracts/escrow/src/governance.rs
- Added set_settlement_limit(env, admin, limit) -> bool — admin-gated entrypoint that validates bounds (1 <= limit <= DEFAULT_SETTLEMENT_LIMIT), persists the new limit, and emits a settlement_limit event with (old_limit, new_limit, admin, timestamp).
- Added get_settlement_limit(env) -> i128 — read-only getter that returns the current limit from storage (or the default).
contracts/escrow/src/test/governance.rs
- Added 10 tests covering the full matrix:
Test	Covers
settlement_limit_defaults_to_compile_time_constant	Default fallback when no value stored
set_settlement_limit_happy_path	Admin sets a valid limit and reads it back
set_settlement_limit_at_minimum_boundary	Boundary: limit = 1 (minimum valid)
set_settlement_limit_at_maximum_boundary	Boundary: limit = DEFAULT_SETTLEMENT_LIMIT
set_settlement_limit_zero_rejected	Rejection: limit = 0
set_settlement_limit_negative_rejected	Rejection: limit = -1
set_settlement_limit_above_max_rejected	Rejection: limit = DEFAULT + 1
set_settlement_limit_non_admin_rejected	Auth: non-admin address rejected with UnauthorizedRole
set_settlement_limit_updates_get_bounds	get_bounds() reflects the new limit
set_settlement_limit_emits_event	Event ("settlement_limit",) is published
set_settlement_limit_overwrites_previous	Subsequent calls overwrite without error
Design Decisions
1. Bounds use the existing constant as the ceiling. DEFAULT_SETTLEMENT_LIMIT (1M tokens) is the absolute max. The admin can lower the operational limit but cannot raise it past this safety cap. This avoids introducing a new unchecked upper bound while still giving governance full downward flexibility.
2. Storage key is standalone. DataKey::SettlementLimit is a separate variant (not nested inside GovernedParameters) to keep the settlement limit decoupled from fee/cap governance. The get_bounds() endpoint reads it independently.
3. Default fallback is zero-cost. When no value has been stored, read_settlement_limit returns DEFAULT_SETTLEMENT_LIMIT without a storage write. Existing deployments see identical behaviour until the admin explicitly configures a new limit.
4. Event schema follows existing conventions. The ("settlement_limit",) topic with (old, new, admin, timestamp) data matches the pattern used by protocol_fee_bps and settlement_token_bound.
Backward Compatibility
- All existing entrypoints and validation paths are unchanged.
- get_bounds().max_single_milestone_stroops returns the same value as before until the admin calls set_settlement_limit.
- No storage migration required — the new DataKey::SettlementLimit reads cleanly as None (defaulting to the constant) on upgraded contracts.
How to Review
1. Verify that set_settlement_limit rejects zero, negative, and above-ceiling values with SettlementLimitOutOfBounds.
2. Verify that non-admin callers are rejected with UnauthorizedRole.
3. Verify that get_bounds() reflects the stored limit after a set.
4. Verify that the default (no set call) returns the original 1M token constant.
5. Run cargo test and cargo clippy --all-targets -- -D warnings to confirm no regressions.