### PR TITLE
feat(disputes): add pause-aware guard

### DIFF
--- a/contracts/escrow/src/test/dispute_pause_guard.rs
+++ b/contracts/escrow/src/test/dispute_pause_guard.rs
@@ -1,0 +1,107 @@
+#![cfg(test)]
+
+//! Confirms disputes' existing pause guard: `raise_dispute` and
+//! `resolve_dispute` already call `Self::require_not_paused`, which rejects
+//! while `Paused` or `Emergency` is set and allows otherwise. This adds the
+//! regression coverage that was missing for that behaviour.
+
+use soroban_sdk::{testutils::Address as _, Address};
+
+use soroban_sdk::token::StellarAssetClient;
+
+use crate::test::EscrowFixture;
+use crate::{DisputeResolution, Error};
+
+#[test]
+fn raise_dispute_rejected_while_paused() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let escrow = fixture.escrow();
+    let arbiter = Address::generate(&fixture.env);
+    // Re-create with an arbiter: fund flow already done, so raise a fresh
+    // arbitered contract instead of retrofitting one.
+    let contract_id = escrow.create_contract(
+        &fixture.client,
+        &fixture.freelancer,
+        &Some(arbiter.clone()),
+        &crate::test::default_milestones(&fixture.env),
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+    let total = crate::test::total_milestone_amount();
+    StellarAssetClient::new(&fixture.env, fixture.settlement_token.as_ref().unwrap())
+        .mint(&fixture.client, &total);
+    escrow.deposit_funds(&contract_id, &fixture.client, &total);
+
+    escrow.pause();
+
+    let result = escrow.try_raise_dispute(&contract_id, &fixture.client);
+    crate::test::assert_contract_error(result, Error::ContractPaused);
+}
+
+#[test]
+fn raise_dispute_allowed_when_unpaused() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let escrow = fixture.escrow();
+    let arbiter = Address::generate(&fixture.env);
+    let contract_id = escrow.create_contract(
+        &fixture.client,
+        &fixture.freelancer,
+        &Some(arbiter.clone()),
+        &crate::test::default_milestones(&fixture.env),
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+    let total = crate::test::total_milestone_amount();
+    StellarAssetClient::new(&fixture.env, fixture.settlement_token.as_ref().unwrap())
+        .mint(&fixture.client, &total);
+    escrow.deposit_funds(&contract_id, &fixture.client, &total);
+
+    // Never paused: should succeed.
+    let result = escrow.raise_dispute(&contract_id, &fixture.client);
+    assert!(result);
+}
+
+#[test]
+fn resolve_dispute_rejected_while_paused() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let escrow = fixture.escrow();
+    let arbiter = Address::generate(&fixture.env);
+    let contract_id = escrow.create_contract(
+        &fixture.client,
+        &fixture.freelancer,
+        &Some(arbiter.clone()),
+        &crate::test::default_milestones(&fixture.env),
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+    let total = crate::test::total_milestone_amount();
+    StellarAssetClient::new(&fixture.env, fixture.settlement_token.as_ref().unwrap())
+        .mint(&fixture.client, &total);
+    escrow.deposit_funds(&contract_id, &fixture.client, &total);
+    escrow.raise_dispute(&contract_id, &fixture.client);
+
+    escrow.pause();
+
+    let result = escrow.try_resolve_dispute(&contract_id, &arbiter, &DisputeResolution::FullRefund);
+    crate::test::assert_contract_error(result, Error::ContractPaused);
+}
+
+#[test]
+fn resolve_dispute_allowed_when_unpaused() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let escrow = fixture.escrow();
+    let arbiter = Address::generate(&fixture.env);
+    let contract_id = escrow.create_contract(
+        &fixture.client,
+        &fixture.freelancer,
+        &Some(arbiter.clone()),
+        &crate::test::default_milestones(&fixture.env),
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+    let total = crate::test::total_milestone_amount();
+    StellarAssetClient::new(&fixture.env, fixture.settlement_token.as_ref().unwrap())
+        .mint(&fixture.client, &total);
+    escrow.deposit_funds(&contract_id, &fixture.client, &total);
+    escrow.raise_dispute(&contract_id, &fixture.client);
+
+    // Never paused: should succeed.
+    let result = escrow.resolve_dispute(&contract_id, &arbiter, &DisputeResolution::FullRefund);
+    assert!(result);
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -14,6 +14,7 @@ mod client_migration;
 mod create_contract_bounds;
 mod deposit;
 mod dispute;
+mod dispute_pause_guard;
 mod emergency_controls;
 mod input_sanitization_amounts;
 mod input_sanitization_identities;


### PR DESCRIPTION
Closes #1059

## Summary
`raise_dispute` and `resolve_dispute` already call `Self::require_not_paused` (which rejects when either `Paused` or `Emergency` is set) — the guard existed, but had no test coverage for disputes specifically. This PR adds that coverage.

## What was found
Both dispute entrypoints call the guard in the correct position (before `require_auth`), matching every other mutating entrypoint in the crate. No production code change was needed — the "gap" was missing regression tests, not missing logic.

## Tests
New `contracts/escrow/src/test/dispute_pause_guard.rs`, 4 tests:
- `raise_dispute` rejected with `ContractPaused` while paused
- `raise_dispute` allowed when unpaused
- `resolve_dispute` rejected with `ContractPaused` while paused
- `resolve_dispute` allowed when unpaused

## Test output

running 4 tests
test test::dispute_pause_guard::raise_dispute_allowed_when_unpaused ... ok
test test::dispute_pause_guard::resolve_dispute_allowed_when_unpaused ... ok
test test::dispute_pause_guard::raise_dispute_rejected_while_paused ... ok
test test::dispute_pause_guard::resolve_dispute_rejected_while_paused ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 338 filtered out


Full suite: `154 passed; 181 failed; 7 ignored` — the 181 are the pre-existing baseline documented in prior PRs on this repo. This branch adds exactly 4 new passing tests and breaks none.

## Gates
- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 new warnings from our file
- `cargo test` — matches baseline exactly, 0 regressions