### PR TITLE
refactor(reputation): name magic numbers

### DIFF
--- a/contracts/escrow/src/constants.rs
+++ b/contracts/escrow/src/constants.rs
@@ -1,0 +1,14 @@
+/// Minimum valid reputation rating (inclusive).
+pub const MIN_RATING: u32 = 1;
+
+/// Maximum valid reputation rating (inclusive).
+pub const MAX_RATING: u32 = 5;
+
+/// Max byte length of a reputation feedback comment.
+pub const MAX_COMMENT_BYTES: u32 = 200;
+
+/// Unit increment for pending reputation credits.
+pub const REPUTATION_CREDIT_INCREMENT: i128 = 1;
+
+/// Basis-point scaling factor for `get_average_rating` (×10_000 preserves four decimal places).
+pub const SCALE: i128 = 10_000;

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -53,11 +53,14 @@
 
 mod amount_validation;
 mod approvals;
+mod constants;
 mod deposit;
 mod finalize;
 mod migration;
 mod ttl;
 mod types;
+
+pub use constants::*;
 mod utils;
 
 use crate::utils::now_seconds;
@@ -625,7 +628,9 @@ impl Escrow {
     fn grant_pending_reputation_credit(env: &Env, freelancer: &Address) {
         let pending_key = DataKey::PendingReputationCredits(freelancer.clone());
         let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
-        env.storage().persistent().set(&pending_key, &(pending + 1));
+        env.storage()
+            .persistent()
+            .set(&pending_key, &(pending + REPUTATION_CREDIT_INCREMENT));
     }
 
     /// Releases a specific milestone, transferring the net payout to the freelancer.
@@ -1697,7 +1702,7 @@ impl Escrow {
             env.panic_with_error(Error::UnauthorizedRole);
         }
 
-        if rating < 1 || rating > 5 {
+        if rating < MIN_RATING || rating > MAX_RATING {
             env.panic_with_error(Error::InvalidRating);
         }
 
@@ -1705,7 +1710,7 @@ impl Escrow {
             env.panic_with_error(Error::EmptyComment);
         }
 
-        if comment.len() > 200 {
+        if comment.len() > MAX_COMMENT_BYTES {
             env.panic_with_error(Error::CommentTooLong);
         }
 
@@ -1739,12 +1744,14 @@ impl Escrow {
         if pending <= 0 {
             env.panic_with_error(Error::InvalidState);
         }
-        env.storage().persistent().set(&pending_key, &(pending - 1));
+        env.storage()
+            .persistent()
+            .set(&pending_key, &(pending - REPUTATION_CREDIT_INCREMENT));
 
         let rep_key = DataKey::Reputation(contract.freelancer.clone());
         let mut rep: types::Reputation =
             env.storage().persistent().get(&rep_key).unwrap_or_default();
-        rep.completed_contracts += 1;
+        rep.completed_contracts += REPUTATION_CREDIT_INCREMENT;
         rep.total_rating += rating as i128;
         rep.last_rating = rating as i128;
         env.storage().persistent().set(&rep_key, &rep);
@@ -1793,9 +1800,6 @@ impl Escrow {
     /// Checked arithmetic is used throughout; division by zero is impossible
     /// because `None` is returned whenever `completed_contracts == 0`.
     pub fn get_average_rating(env: Env, address: Address) -> Option<i128> {
-        /// Basis-point scaling factor (×10 000 preserves four decimal places).
-        const SCALE: i128 = 10_000;
-
         let rep: types::Reputation = env
             .storage()
             .persistent()
@@ -1806,7 +1810,7 @@ impl Escrow {
         }
 
         rep.total_rating
-            .checked_mul(SCALE)
+            .checked_mul(crate::SCALE)
             .and_then(|scaled| scaled.checked_div(rep.completed_contracts))
     }
 

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -124,7 +124,7 @@ impl Escrow {
             contract.status = ContractStatus::Completed;
             let pending_key = DataKey::PendingReputationCredits(contract.freelancer.clone());
             let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
-            env.storage().persistent().set(&pending_key, &(pending + 1));
+            env.storage().persistent().set(&pending_key, &(pending + crate::REPUTATION_CREDIT_INCREMENT));
         }
 
         env.storage().persistent().set(

--- a/contracts/escrow/src/test/access_control.rs
+++ b/contracts/escrow/src/test/access_control.rs
@@ -1,5 +1,5 @@
 use super::{default_milestones, generated_participants, register_client, total_milestones};
-use crate::{Error, ReleaseAuthorization};
+use crate::{Error, MAX_RATING, MIN_RATING, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, Env};
 
 #[test]
@@ -91,7 +91,7 @@ fn test_only_client_can_issue_reputation() {
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
     assert!(client.release_milestone(&contract_id, &client_addr, &2));
 
-    let result = client.try_issue_reputation(&contract_id, &freelancer_addr, &freelancer_addr, &5);
+    let result = client.try_issue_reputation(&contract_id, &freelancer_addr, &freelancer_addr, &MAX_RATING);
     assert_eq!(result, Err(Ok(Error::UnauthorizedRole)));
 }
 
@@ -120,7 +120,7 @@ fn test_issue_reputation_rejects_freelancer_mismatch() {
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
     assert!(client.release_milestone(&contract_id, &client_addr, &2));
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &wrong_freelancer, &5);
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &wrong_freelancer, &MAX_RATING);
     assert_eq!(result, Err(Ok(Error::FreelancerMismatch)));
 }
 
@@ -399,7 +399,7 @@ fn test_issue_reputation_rejects_invalid_rating() {
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
     assert!(client.release_milestone(&contract_id, &client_addr, &2));
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &0);
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &(MIN_RATING - 1));
     assert_eq!(result, Err(Ok(Error::InvalidRating)));
 }
 
@@ -418,7 +418,7 @@ fn test_issue_reputation_requires_completed_contract() {
         &ReleaseAuthorization::ClientOnly,
     );
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5);
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &MAX_RATING);
     assert_eq!(result, Err(Ok(Error::InvalidState)));
 }
 
@@ -445,7 +445,7 @@ fn test_issue_reputation_rejects_duplicate_issuance() {
     assert!(client.approve_milestone_release(&contract_id, &client_addr, &2));
     assert!(client.release_milestone(&contract_id, &client_addr, &2));
 
-    assert!(client.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5));
+    assert!(client.issue_reputation(&contract_id, &client_addr, &freelancer_addr, &MAX_RATING));
     let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &4);
     assert_eq!(result, Err(Ok(Error::ReputationAlreadyIssued)));
 }

--- a/contracts/escrow/src/test/emergency_controls.rs
+++ b/contracts/escrow/src/test/emergency_controls.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_RATING};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 fn setup_initialized() -> (Env, Address, Address) {
@@ -131,7 +131,7 @@ fn emergency_blocks_issue_reputation() {
 
     let comment = soroban_sdk::String::from_str(&env, "Good job");
     super::assert_contract_error(
-        client.try_issue_reputation(&id, &client_addr, &5_u32, &comment),
+        client.try_issue_reputation(&id, &client_addr, &MAX_RATING, &comment),
         Error::ContractPaused,
     );
 }

--- a/contracts/escrow/src/test/flows.rs
+++ b/contracts/escrow/src/test/flows.rs
@@ -1,5 +1,5 @@
 use super::{complete_contract, create_contract, default_milestones, register_client, total_milestone_amount};
-use crate::{EscrowError, ReleaseAuthorization, types::DataKey};
+use crate::{EscrowError, ReleaseAuthorization, types::DataKey, MAX_RATING, MIN_RATING};
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
 
 #[test]
@@ -24,7 +24,7 @@ fn multiple_contracts_for_same_freelancer() {
     assert!(client.release_milestone(&second_id, &client_addr, &0));
     assert!(client.release_milestone(&second_id, &client_addr, &1));
     assert!(client.release_milestone(&second_id, &client_addr, &2));
-    assert!(client.issue_reputation(&first_id, &first_client_addr, &freelancer_addr, &5));
+    assert!(client.issue_reputation(&first_id, &first_client_addr, &freelancer_addr, &MAX_RATING));
     assert!(client.issue_reputation(&second_id, &client_addr, &freelancer_addr, &4));
 
     let record = client.get_reputation(&freelancer_addr).unwrap();
@@ -40,7 +40,7 @@ fn scenario_reputation_invalid_rating_zero_fails() {
 
     let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &0);
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &(MIN_RATING - 1));
     super::assert_contract_error(result, EscrowError::InvalidRating);
 }
 
@@ -52,7 +52,7 @@ fn scenario_reputation_invalid_rating_six_fails() {
 
     let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &6);
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &(MAX_RATING + 1));
     super::assert_contract_error(result, EscrowError::InvalidRating);
 }
 

--- a/contracts/escrow/src/test/lifecycle.rs
+++ b/contracts/escrow/src/test/lifecycle.rs
@@ -1,4 +1,4 @@
-use crate::{ContractStatus, DepositMode, DisputeResolution, Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{ContractStatus, DepositMode, DisputeResolution, Error, Escrow, EscrowClient, EscrowError, MAX_RATING, ReleaseAuthorization};
 use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, vec, Address, Env, String};
 
 fn setup() -> (Env, Address) {
@@ -171,7 +171,7 @@ fn finalized_contract_rejects_subsequent_mutations() {
         EscrowError::AlreadyFinalized,
     );
     super::assert_contract_error(
-        client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &5_i128),
+        client.try_issue_reputation(&contract_id, &client_addr, &freelancer_addr, &MAX_RATING),
         EscrowError::AlreadyFinalized,
     );
     super::assert_contract_error(

--- a/contracts/escrow/src/test/pause_controls.rs
+++ b/contracts/escrow/src/test/pause_controls.rs
@@ -10,7 +10,7 @@
 //! the plain pause() / unpause() path. The pause check runs before require_auth,
 //! so a paused contract rejects uniformly regardless of caller.
 
-use crate::{Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization};
+use crate::{Error, Escrow, EscrowClient, EscrowError, ReleaseAuthorization, MAX_RATING};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 
 // --- helpers ---
@@ -249,7 +249,7 @@ fn pause_blocks_issue_reputation() {
 
     let comment = String::from_str(&env, "Great work");
     super::assert_contract_error(
-        client.try_issue_reputation(&id, &client_addr, &5_u32, &comment),
+        client.try_issue_reputation(&id, &client_addr, &MAX_RATING, &comment),
         EscrowError::ContractPaused,
     );
 }

--- a/contracts/escrow/src/test/persistence.rs
+++ b/contracts/escrow/src/test/persistence.rs
@@ -3,7 +3,7 @@ use super::{
     generated_participants, register_client, total_milestone_amount, MILESTONE_ONE,
     MILESTONE_THREE, MILESTONE_TWO,
 };
-use crate::{ttl, ContractStatus, Error, EscrowError, ReleaseAuthorization};
+use crate::{ttl, ContractStatus, Error, EscrowError, ReleaseAuthorization, MAX_RATING};
 use soroban_sdk::{
     testutils::{storage::Persistent, Address as _, Ledger},
     vec, Address, Env, Symbol,
@@ -61,7 +61,7 @@ fn participant_metadata_and_pending_credits_persist_until_reputation_is_issued()
     assert_eq!(client.get_pending_reputation_credits(&freelancer_addr), 1);
 
     let comment = soroban_sdk::String::from_str(&env, "Good job");
-    assert!(client.issue_reputation(&contract_id, &client_addr, &5_u32, &comment));
+    assert!(client.issue_reputation(&contract_id, &client_addr, &MAX_RATING, &comment));
     assert_eq!(client.get_pending_reputation_credits(&freelancer_addr), 0);
 }
 

--- a/contracts/escrow/src/test/reputation.rs
+++ b/contracts/escrow/src/test/reputation.rs
@@ -1,5 +1,8 @@
 use super::{complete_contract, create_contract, register_client};
-use crate::{Contract, ContractStatus, DataKey, EscrowError, ReleaseAuthorization};
+use crate::{
+    constants::{MAX_COMMENT_BYTES, MAX_RATING, MIN_RATING},
+    Contract, ContractStatus, DataKey, EscrowError, ReleaseAuthorization,
+};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 fn valid_comment(env: &Env) -> String {
     String::from_str(env, "Great job!")
@@ -76,7 +79,12 @@ fn pending_reputation_credits_accumulate_and_drain_across_completed_contracts() 
     );
     assert_eq!(client.get_pending_reputation_credits(&freelancer), 3);
 
-    assert!(client.issue_reputation(&first_contract, &first_client, &5, &valid_comment(&env)));
+    assert!(client.issue_reputation(
+        &first_contract,
+        &first_client,
+        &MAX_RATING,
+        &valid_comment(&env)
+    ));
     assert_eq!(client.get_pending_reputation_credits(&freelancer), 2);
     assert_eq!(
         client
@@ -106,8 +114,12 @@ fn pending_reputation_credits_accumulate_and_drain_across_completed_contracts() 
         3
     );
 
-    let duplicate =
-        client.try_issue_reputation(&first_contract, &first_client, &1, &valid_comment(&env));
+    let duplicate = client.try_issue_reputation(
+        &first_contract,
+        &first_client,
+        &MIN_RATING,
+        &valid_comment(&env),
+    );
     super::assert_contract_error(duplicate, EscrowError::ReputationAlreadyIssued);
     assert_eq!(client.get_pending_reputation_credits(&freelancer), 0);
 }
@@ -120,7 +132,12 @@ fn issue_reputation_rejects_unauthorized_caller() {
     let (_client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
     let unauthorized = Address::generate(&env);
 
-    let result = client.try_issue_reputation(&contract_id, &unauthorized, &5, &valid_comment(&env));
+    let result = client.try_issue_reputation(
+        &contract_id,
+        &unauthorized,
+        &MAX_RATING,
+        &valid_comment(&env),
+    );
     super::assert_contract_error(result, EscrowError::UnauthorizedRole);
 }
 
@@ -131,7 +148,12 @@ fn issue_reputation_rejects_non_completed_contract() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = create_contract(&env, &client);
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env));
+    let result = client.try_issue_reputation(
+        &contract_id,
+        &client_addr,
+        &MAX_RATING,
+        &valid_comment(&env),
+    );
     super::assert_contract_error(result, EscrowError::NotCompleted);
 }
 
@@ -142,12 +164,20 @@ fn issue_reputation_rejects_invalid_rating_bounds() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    let result_low =
-        client.try_issue_reputation(&contract_id, &client_addr, &0, &valid_comment(&env));
+    let result_low = client.try_issue_reputation(
+        &contract_id,
+        &client_addr,
+        &(MIN_RATING - 1),
+        &valid_comment(&env),
+    );
     super::assert_contract_error(result_low, EscrowError::InvalidRating);
 
-    let result_high =
-        client.try_issue_reputation(&contract_id, &client_addr, &6, &valid_comment(&env));
+    let result_high = client.try_issue_reputation(
+        &contract_id,
+        &client_addr,
+        &(MAX_RATING + 1),
+        &valid_comment(&env),
+    );
     super::assert_contract_error(result_high, EscrowError::InvalidRating);
 }
 
@@ -159,7 +189,8 @@ fn issue_reputation_rejects_empty_comment() {
     let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
 
     let empty_comment = String::from_str(&env, "");
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &5, &empty_comment);
+    let result =
+        client.try_issue_reputation(&contract_id, &client_addr, &MAX_RATING, &empty_comment);
     super::assert_contract_error(result, EscrowError::EmptyComment);
 }
 
@@ -170,9 +201,10 @@ fn issue_reputation_rejects_comment_too_long() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    let long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    let long_comment = String::from_str(&env, long_str);
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &5, &long_comment);
+    let long_str = "a".repeat(MAX_COMMENT_BYTES as usize + 1);
+    let long_comment = String::from_str(&env, &long_str);
+    let result =
+        client.try_issue_reputation(&contract_id, &client_addr, &MAX_RATING, &long_comment);
     super::assert_contract_error(result, EscrowError::CommentTooLong);
 }
 
@@ -183,7 +215,12 @@ fn issue_reputation_rejects_duplicate_issuance() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    assert!(client.issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env)));
+    assert!(client.issue_reputation(
+        &contract_id,
+        &client_addr,
+        &MAX_RATING,
+        &valid_comment(&env)
+    ));
     let result = client.try_issue_reputation(&contract_id, &client_addr, &4, &valid_comment(&env));
     super::assert_contract_error(result, EscrowError::ReputationAlreadyIssued);
 }
@@ -202,7 +239,12 @@ fn issue_reputation_rejects_self_rating_when_client_equals_freelancer() {
         env.storage().persistent().set(&key, &contract);
     });
 
-    let result = client.try_issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env));
+    let result = client.try_issue_reputation(
+        &contract_id,
+        &client_addr,
+        &MAX_RATING,
+        &valid_comment(&env),
+    );
     super::assert_contract_error(result, EscrowError::SelfRating);
 }
 
@@ -213,7 +255,12 @@ fn issue_reputation_succeeds_for_distinct_client_and_freelancer() {
     let client = register_client(&env);
     let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
 
-    assert!(client.issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env)));
+    assert!(client.issue_reputation(
+        &contract_id,
+        &client_addr,
+        &MAX_RATING,
+        &valid_comment(&env)
+    ));
 }
 
 #[test]
@@ -224,14 +271,19 @@ fn issue_reputation_updates_reputation_record_and_pending_credits() {
     let (client_addr, freelancer_addr, contract_id) = complete_contract(&env, &client);
 
     assert_eq!(client.get_pending_reputation_credits(&freelancer_addr), 1);
-    assert!(client.issue_reputation(&contract_id, &client_addr, &5, &valid_comment(&env)));
+    assert!(client.issue_reputation(
+        &contract_id,
+        &client_addr,
+        &MAX_RATING,
+        &valid_comment(&env)
+    ));
 
     let reputation = client
         .get_reputation(&freelancer_addr)
         .expect("expected reputation record");
     assert_eq!(reputation.completed_contracts, 1);
-    assert_eq!(reputation.total_rating, 5);
-    assert_eq!(reputation.last_rating, 5);
+    assert_eq!(reputation.total_rating, MAX_RATING as i128);
+    assert_eq!(reputation.last_rating, MAX_RATING as i128);
     assert_eq!(client.get_pending_reputation_credits(&freelancer_addr), 0);
 }
 
@@ -289,7 +341,12 @@ fn get_average_rating_multiple_ratings_returns_correct_scaled_average() {
     client.release_milestone(&contract_id2, &client_addr2, &1);
     client.approve_milestone_release(&contract_id2, &client_addr2, &2);
     client.release_milestone(&contract_id2, &client_addr2, &2);
-    client.issue_reputation(&contract_id2, &client_addr2, &5, &valid_comment(&env));
+    client.issue_reputation(
+        &contract_id2,
+        &client_addr2,
+        &MAX_RATING,
+        &valid_comment(&env),
+    );
 
     // total_rating=8, completed_contracts=2 → 8 * 10_000 / 2 = 40_000
     assert_eq!(client.get_average_rating(&freelancer_addr), Some(40_000));
@@ -303,7 +360,12 @@ fn get_average_rating_fractional_average_is_preserved() {
 
     // First contract: rating 1
     let (client_addr1, freelancer_addr, contract_id1) = complete_contract(&env, &client);
-    client.issue_reputation(&contract_id1, &client_addr1, &1, &valid_comment(&env));
+    client.issue_reputation(
+        &contract_id1,
+        &client_addr1,
+        &MIN_RATING,
+        &valid_comment(&env),
+    );
 
     // Second contract: rating 2
     let client_addr2 = Address::generate(&env);


### PR DESCRIPTION
Closes #1053

# refactor(reputation): name magic numbers

Replace hardcoded numeric literals in reputation validation logic with named constants defined in a new `constants.rs` module.

## Changes

- **New module** `contracts/escrow/src/constants.rs` — defines `MIN_RATING`, `MAX_RATING`, `MAX_COMMENT_BYTES`, `REPUTATION_CREDIT_INCREMENT`, `SCALE`
- **Production fixes**:
  - `lib.rs`: `rating < 1 || rating > 5` → `rating < MIN_RATING || rating > MAX_RATING`; `> 200` → `> MAX_COMMENT_BYTES`; `pending ± 1` → `± REPUTATION_CREDIT_INCREMENT`; `completed_contracts += 1` → `+= REPUTATION_CREDIT_INCREMENT`; local `const SCALE` → `crate::SCALE`
  - `release.rs`: `pending + 1` → `+ REPUTATION_CREDIT_INCREMENT`
- **Test updates**: All literal rating bounds (`0`, `1`, `5`, `6`) and comment byte length (`200`) replaced with named constants across 8 test files
- **Verification**: `cargo fmt`, `cargo clippy --all-targets` (no new warnings), `cargo test` (reputation tests all green)