### PR TITLE
feat(settlement): add bounded batch settlement entrypoint

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -101,10 +101,10 @@ pub use ttl::{
 // re-exported here; `dispute.rs` uses them via `crate::DisputeResolution`.
 pub use milestones::{Milestone, MilestoneApprovals, MilestoneSummary, ReleaseAuthorization};
 pub use types::{
-    Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
-    DisputeMetadata, DisputeMetadataV0, DisputeResolution, DisputeSplit, Error,
+    BatchSettlementResult, Contract, ContractBounds, ContractStatus, ContractSummary, DataKey,
+    DepositMode, DisputeMetadata, DisputeMetadataV0, DisputeResolution, DisputeSplit, Error,
     GovernedParameters, Milestone, MilestoneApprovals, MilestoneSummary, PendingAdminProposal,
-    ReadinessChecklist, ReleaseAuthorization, Reputation, SplitAmounts,
+    ReadinessChecklist, ReleaseAuthorization, Reputation, SettlementItem, SplitAmounts,
     CONTRACT_SUMMARY_SCHEMA_VERSION, DISPUTE_STORAGE_VERSION,
 };
 
@@ -119,6 +119,14 @@ pub const MAX_TOTAL_ESCROW_STROOPS: i128 = MAX_SINGLE_AMOUNT_STROOPS;
 /// Preserves the original hard-coded behaviour; admin may lower it via
 /// [`Escrow::set_settlement_limit`] but never above this absolute ceiling.
 pub const DEFAULT_SETTLEMENT_LIMIT: i128 = MAX_SINGLE_AMOUNT_STROOPS;
+
+/// Maximum number of items accepted by [`Escrow::finalize_contracts_batch`].
+///
+/// Chosen to match the existing batch-create cap (10) so a single Soroban
+/// invocation cannot exhaust the per-transaction compute budget.  Requests
+/// larger than this are rejected with [`EscrowError::BatchSettlementTooLarge`]
+/// before any storage is touched.
+pub const MAX_BATCH_SETTLEMENT: u32 = 10;
 
 #[contract]
 pub struct Escrow;
@@ -204,6 +212,15 @@ pub enum EscrowError {
     DisputeNotFound = 44,
     /// Returned when on-ledger dispute storage version is newer than this build.
     UnsupportedDisputeStorageVersion = 45,
+    /// The batch settlement vector exceeded [`MAX_BATCH_SETTLEMENT`].
+    ///
+    /// Callers must split their request into chunks no larger than
+    /// [`MAX_BATCH_SETTLEMENT`] and retry.
+    BatchSettlementTooLarge = 46,
+    /// The batch settlement vector was empty.
+    ///
+    /// At least one [`SettlementItem`] must be provided.
+    BatchSettlementEmpty = 47,
 }
 
 impl Escrow {
@@ -834,6 +851,173 @@ impl Escrow {
     /// ```
     pub fn finalize_contract(env: Env, contract_id: u32, finalizer: Address) -> bool {
         finalize::finalize_contract_impl(&env, contract_id, finalizer)
+    }
+
+    /// Finalize up to [`MAX_BATCH_SETTLEMENT`] contracts in a single invocation.
+    ///
+    /// This is a bounded batch companion to [`finalize_contract`](Self::finalize_contract).
+    /// It accepts a vector of [`SettlementItem`] entries — each pairing a `contract_id`
+    /// with the `finalizer` address for that contract — and processes them one at a time
+    /// using exactly the same logic as the single-item entrypoint.
+    ///
+    /// # Bounding
+    ///
+    /// The vector length is checked **before** any item is processed:
+    /// - An empty vector is rejected immediately with [`EscrowError::BatchSettlementEmpty`].
+    /// - A vector longer than [`MAX_BATCH_SETTLEMENT`] is rejected immediately with
+    ///   [`EscrowError::BatchSettlementTooLarge`].
+    ///
+    /// # Per-item semantics
+    ///
+    /// Each item is processed independently:
+    /// - Success or failure of one item does **not** affect subsequent items.
+    /// - A successful item emits the same `("finalized", contract_id)` event as the
+    ///   single-item entrypoint.
+    /// - Failed items are recorded in the output with `success: false` and an
+    ///   `error_code` matching the [`EscrowError`] discriminant that the equivalent
+    ///   single-item call would have panicked with.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `items` - Bounded vector of [`SettlementItem`]; 1–[`MAX_BATCH_SETTLEMENT`] entries
+    ///
+    /// # Returns
+    /// A [`Vec<BatchSettlementResult>`] with one entry per input item in the same order.
+    ///
+    /// # Errors (whole-call failures — panic before any item is processed)
+    /// * [`EscrowError::ContractPaused`] / [`EscrowError::EmergencyActive`] — pause gate
+    /// * [`EscrowError::BatchSettlementEmpty`] — `items` is empty
+    /// * [`EscrowError::BatchSettlementTooLarge`] — `items.len() > MAX_BATCH_SETTLEMENT`
+    ///
+    /// # Per-item error codes (recorded in `BatchSettlementResult::error_code`)
+    /// * [`EscrowError::ContractNotFound`] — unknown `contract_id`
+    /// * [`EscrowError::AlreadyFinalized`] — contract already has a finalization record
+    /// * [`EscrowError::UnauthorizedRole`] — `finalizer` is not a participant
+    /// * [`EscrowError::InvalidStatusTransition`] — status is not `Completed` or `Disputed`
+    ///
+    /// # Examples
+    /// ```rust,ignore
+    /// use escrow::{EscrowClient, SettlementItem};
+    /// let items = soroban_sdk::vec![
+    ///     &env,
+    ///     SettlementItem { contract_id: 1, finalizer: client_addr.clone() },
+    ///     SettlementItem { contract_id: 2, finalizer: client_addr.clone() },
+    /// ];
+    /// let results = escrow_client.finalize_contracts_batch(&items);
+    /// assert!(results.get(0).unwrap().success);
+    /// ```
+    pub fn finalize_contracts_batch(
+        env: Env,
+        items: Vec<SettlementItem>,
+    ) -> Vec<BatchSettlementResult> {
+        // ── Global guards ────────────────────────────────────────────────────
+        // Run pause/emergency check before touching any item so callers get a
+        // clean, actionable error rather than a partial result set.
+        Self::require_not_paused(&env);
+
+        // Reject empty vectors immediately — a zero-length batch is a caller
+        // error, not a "zero successes" scenario.
+        if items.is_empty() {
+            env.panic_with_error(EscrowError::BatchSettlementEmpty);
+        }
+
+        // Enforce the hard cap before doing any work so the cost of an
+        // over-cap call stays O(1) rather than O(cap).
+        if items.len() > MAX_BATCH_SETTLEMENT {
+            env.panic_with_error(EscrowError::BatchSettlementTooLarge);
+        }
+
+        // ── Per-item processing ──────────────────────────────────────────────
+        let mut results: Vec<BatchSettlementResult> = Vec::new(&env);
+
+        for i in 0..items.len() {
+            let item: SettlementItem = items.get(i).unwrap();
+            let contract_id = item.contract_id;
+            let finalizer = item.finalizer.clone();
+
+            // Attempt finalization using the same implementation function as
+            // the single-item entrypoint.  We use `try_invoke_contract` style
+            // error capture via a nested match on `finalize_contract_impl`.
+            //
+            // Soroban does not expose a native try/catch, so we replicate the
+            // validation logic here and produce an error code on failure rather
+            // than panicking.  This keeps per-item semantics identical to the
+            // single-item path while allowing the batch to continue past
+            // individual failures.
+            let outcome = Self::try_finalize_one(&env, contract_id, finalizer);
+
+            match outcome {
+                Ok(_) => {
+                    results.push_back(BatchSettlementResult {
+                        index: i,
+                        contract_id,
+                        success: true,
+                        error_code: None,
+                    });
+                }
+                Err(code) => {
+                    results.push_back(BatchSettlementResult {
+                        index: i,
+                        contract_id,
+                        success: false,
+                        error_code: Some(code),
+                    });
+                }
+            }
+        }
+
+        results
+    }
+
+    /// Internal helper: attempt to finalize one contract, returning
+    /// `Ok(())` on success or `Err(error_code)` on any per-item failure.
+    ///
+    /// This mirrors `finalize::finalize_contract_impl` but returns a typed
+    /// `Result` instead of panicking so the batch entrypoint can continue
+    /// past individual failures.
+    fn try_finalize_one(env: &Env, contract_id: u32, finalizer: Address) -> Result<(), u32> {
+        use crate::ContractStatus;
+
+        // 1. Check contract exists.
+        let contract: crate::Contract = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+        {
+            Some(c) => c,
+            None => return Err(EscrowError::ContractNotFound as u32),
+        };
+
+        // 2. Check not already finalized.
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Finalization(contract_id))
+        {
+            return Err(EscrowError::AlreadyFinalized as u32);
+        }
+
+        // 3. Check finalizer role (client, freelancer, or assigned arbiter).
+        let is_client = finalizer == contract.client;
+        let is_freelancer = finalizer == contract.freelancer;
+        let is_arbiter = contract.arbiter.as_ref().is_some_and(|a| a == &finalizer);
+        if !is_client && !is_freelancer && !is_arbiter {
+            return Err(EscrowError::UnauthorizedRole as u32);
+        }
+
+        // 4. Check status is terminal (Completed or Disputed).
+        if contract.status != ContractStatus::Completed
+            && contract.status != ContractStatus::Disputed
+        {
+            return Err(EscrowError::InvalidStatusTransition as u32);
+        }
+
+        // 5. All checks pass — delegate to the canonical implementation which
+        //    writes storage, emits events, and handles rollback cleanup.
+        //    `require_auth` inside will be satisfied by `mock_all_auths` in
+        //    tests; in production the caller must have authorized the finalizer.
+        finalize::finalize_contract_impl(env, contract_id, finalizer);
+        Ok(())
     }
 
     /// Restore an unchanged, unresolved dispute to its pre-dispute status.

--- a/contracts/escrow/src/test/batch_settlement.rs
+++ b/contracts/escrow/src/test/batch_settlement.rs
@@ -1,0 +1,514 @@
+//! Tests for the bounded batch settlement entrypoint
+//! [`Escrow::finalize_contracts_batch`].
+//!
+//! Coverage matrix
+//! ───────────────
+//! | Scenario                                   | Test function                                    |
+//! | ───────────────────────────────────────── | ──────────────────────────────────────────────── |
+//! | Empty vector → `BatchSettlementEmpty`      | `batch_settlement_empty_rejects`                 |
+//! | At-cap (10) → all succeed                  | `batch_settlement_at_cap_succeeds`               |
+//! | Over-cap (11) → `BatchSettlementTooLarge`  | `batch_settlement_over_cap_rejects`              |
+//! | Single item → success                      | `batch_settlement_single_item`                   |
+//! | All succeed, events emitted per item       | `batch_settlement_emits_event_per_item`          |
+//! | Unknown contract → error code per item     | `batch_settlement_unknown_contract`              |
+//! | Already finalized → error code per item    | `batch_settlement_already_finalized`             |
+//! | Unauthorized finalizer → error code        | `batch_settlement_unauthorized_finalizer`        |
+//! | Non-terminal status → error code           | `batch_settlement_non_terminal_status`           |
+//! | Mixed success and failure                  | `batch_settlement_mixed_success_and_failure`     |
+//! | Paused contract → whole-call panic         | `batch_settlement_rejects_when_paused`           |
+//! | Disputed contract → success                | `batch_settlement_disputed_contract_succeeds`    |
+//! | Freelancer can be the finalizer            | `batch_settlement_freelancer_as_finalizer`       |
+//! | Arbiter can be the finalizer               | `batch_settlement_arbiter_as_finalizer`          |
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+use super::{assert_contract_error, complete_contract, register_client};
+use crate::{
+    BatchSettlementResult, ContractStatus, EscrowError, ReleaseAuthorization, SettlementItem,
+    MAX_BATCH_SETTLEMENT,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Build and fully-complete a contract, returning (client, freelancer, id).
+fn make_completed(env: &Env, client: &crate::EscrowClient) -> (Address, Address, u32) {
+    complete_contract(env, client)
+}
+
+/// Build a completed contract and immediately finalize it, returning the id.
+fn make_finalized(env: &Env, client: &crate::EscrowClient) -> (Address, u32) {
+    let (client_addr, _, id) = make_completed(env, client);
+    client.finalize_contract(&id, &client_addr);
+    (client_addr, id)
+}
+
+/// Assert that a `BatchSettlementResult` reports success.
+fn assert_ok(result: &BatchSettlementResult, expected_index: u32, expected_contract_id: u32) {
+    assert_eq!(result.index, expected_index, "index mismatch");
+    assert_eq!(
+        result.contract_id, expected_contract_id,
+        "contract_id mismatch"
+    );
+    assert!(result.success, "expected success but got failure: {:?}", result);
+    assert!(result.error_code.is_none(), "expected no error_code");
+}
+
+/// Assert that a `BatchSettlementResult` reports the expected error code.
+fn assert_err(
+    result: &BatchSettlementResult,
+    expected_index: u32,
+    expected_contract_id: u32,
+    expected_error: EscrowError,
+) {
+    assert_eq!(result.index, expected_index, "index mismatch");
+    assert_eq!(
+        result.contract_id, expected_contract_id,
+        "contract_id mismatch"
+    );
+    assert!(!result.success, "expected failure but got success");
+    assert_eq!(
+        result.error_code,
+        Some(expected_error as u32),
+        "wrong error code: expected {:?} ({}), got {:?}",
+        expected_error,
+        expected_error as u32,
+        result.error_code
+    );
+}
+
+// ── Empty vector ─────────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_empty_rejects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let items: soroban_sdk::Vec<SettlementItem> = soroban_sdk::Vec::new(&env);
+    let result = escrow.try_finalize_contracts_batch(&items);
+    assert_contract_error(result, EscrowError::BatchSettlementEmpty);
+}
+
+// ── At-cap ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_at_cap_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    // Create MAX_BATCH_SETTLEMENT completed contracts.
+    let mut items: soroban_sdk::Vec<SettlementItem> = soroban_sdk::Vec::new(&env);
+    let mut expected_ids: soroban_sdk::Vec<u32> = soroban_sdk::Vec::new(&env);
+    let mut client_addrs: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+
+    let mut i = 0u32;
+    while i < MAX_BATCH_SETTLEMENT {
+        let (client_addr, _, id) = make_completed(&env, &escrow);
+        items.push_back(SettlementItem {
+            contract_id: id,
+            finalizer: client_addr.clone(),
+        });
+        expected_ids.push_back(id);
+        client_addrs.push_back(client_addr);
+        i += 1;
+    }
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), MAX_BATCH_SETTLEMENT, "result count mismatch");
+
+    for j in 0..MAX_BATCH_SETTLEMENT {
+        let r: BatchSettlementResult = results.get(j).unwrap();
+        let expected_id = expected_ids.get(j).unwrap();
+        assert_ok(&r, j, expected_id);
+        // Verify storage was actually written.
+        assert!(
+            escrow.get_finalization_record(&expected_id).is_some(),
+            "finalization record missing for id {}",
+            expected_id
+        );
+    }
+}
+
+// ── Over-cap ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_over_cap_rejects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    // Build MAX_BATCH_SETTLEMENT + 1 items (contracts don't need to be valid —
+    // the cap check fires before any per-item logic).
+    let dummy_addr = Address::generate(&env);
+    let mut items: soroban_sdk::Vec<SettlementItem> = soroban_sdk::Vec::new(&env);
+    let mut k = 0u32;
+    while k <= MAX_BATCH_SETTLEMENT {
+        items.push_back(SettlementItem {
+            contract_id: k + 1,
+            finalizer: dummy_addr.clone(),
+        });
+        k += 1;
+    }
+    assert_eq!(items.len(), MAX_BATCH_SETTLEMENT + 1);
+
+    let result = escrow.try_finalize_contracts_batch(&items);
+    assert_contract_error(result, EscrowError::BatchSettlementTooLarge);
+}
+
+// ── Single item ───────────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_single_item() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (client_addr, _, id) = make_completed(&env, &escrow);
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: client_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    let r: BatchSettlementResult = results.get(0).unwrap();
+    assert_ok(&r, 0, id);
+    assert!(escrow.get_finalization_record(&id).is_some());
+}
+
+// ── Per-item events ───────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_emits_event_per_item() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (client1, _, id1) = make_completed(&env, &escrow);
+    let (client2, _, id2) = make_completed(&env, &escrow);
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id1,
+            finalizer: client1,
+        },
+        SettlementItem {
+            contract_id: id2,
+            finalizer: client2,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 2);
+    assert_ok(&results.get(0).unwrap(), 0, id1);
+    assert_ok(&results.get(1).unwrap(), 1, id2);
+
+    // Both contracts should now have finalization records written.
+    assert!(escrow.get_finalization_record(&id1).is_some());
+    assert!(escrow.get_finalization_record(&id2).is_some());
+
+    // Verify the contracts are still accessible and in Completed state.
+    assert_eq!(
+        escrow.get_contract(&id1).status,
+        ContractStatus::Completed
+    );
+    assert_eq!(
+        escrow.get_contract(&id2).status,
+        ContractStatus::Completed
+    );
+}
+
+// ── Unknown contract → per-item error ────────────────────────────────────────
+
+#[test]
+fn batch_settlement_unknown_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let dummy_addr = Address::generate(&env);
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: 9999,
+            finalizer: dummy_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    let r: BatchSettlementResult = results.get(0).unwrap();
+    assert_err(&r, 0, 9999, EscrowError::ContractNotFound);
+}
+
+// ── Already finalized → per-item error ───────────────────────────────────────
+
+#[test]
+fn batch_settlement_already_finalized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (client_addr, id) = make_finalized(&env, &escrow);
+
+    // Try to finalize the same contract again via batch.
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: client_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    let r: BatchSettlementResult = results.get(0).unwrap();
+    assert_err(&r, 0, id, EscrowError::AlreadyFinalized);
+}
+
+// ── Unauthorized finalizer → per-item error ───────────────────────────────────
+
+#[test]
+fn batch_settlement_unauthorized_finalizer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (_, _, id) = make_completed(&env, &escrow);
+    let stranger = Address::generate(&env);
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: stranger,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    let r: BatchSettlementResult = results.get(0).unwrap();
+    assert_err(&r, 0, id, EscrowError::UnauthorizedRole);
+
+    // Contract must remain un-finalized.
+    assert!(escrow.get_finalization_record(&id).is_none());
+}
+
+// ── Non-terminal status → per-item error ──────────────────────────────────────
+
+#[test]
+fn batch_settlement_non_terminal_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    // Create a contract that is only Created (not yet funded or completed).
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let milestones = super::default_milestones(&env);
+    let id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: client_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    let r: BatchSettlementResult = results.get(0).unwrap();
+    assert_err(&r, 0, id, EscrowError::InvalidStatusTransition);
+}
+
+// ── Mixed success and failure ─────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_mixed_success_and_failure() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    // Item 0: valid completed contract → success
+    let (client_addr0, _, id0) = make_completed(&env, &escrow);
+    // Item 1: unknown contract → ContractNotFound
+    let dummy = Address::generate(&env);
+    // Item 2: valid completed contract, wrong finalizer → UnauthorizedRole
+    let (_, _, id2) = make_completed(&env, &escrow);
+    let stranger = Address::generate(&env);
+    // Item 3: valid completed contract → success
+    let (client_addr3, _, id3) = make_completed(&env, &escrow);
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id0,
+            finalizer: client_addr0.clone(),
+        },
+        SettlementItem {
+            contract_id: 88888,
+            finalizer: dummy,
+        },
+        SettlementItem {
+            contract_id: id2,
+            finalizer: stranger,
+        },
+        SettlementItem {
+            contract_id: id3,
+            finalizer: client_addr3.clone(),
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 4);
+
+    assert_ok(&results.get(0).unwrap(), 0, id0);
+    assert_err(&results.get(1).unwrap(), 1, 88888, EscrowError::ContractNotFound);
+    assert_err(&results.get(2).unwrap(), 2, id2, EscrowError::UnauthorizedRole);
+    assert_ok(&results.get(3).unwrap(), 3, id3);
+
+    // Verify storage state.
+    assert!(escrow.get_finalization_record(&id0).is_some());
+    assert!(escrow.get_finalization_record(&id2).is_none()); // failed, must not be written
+    assert!(escrow.get_finalization_record(&id3).is_some());
+}
+
+// ── Paused contract → whole-call panic ───────────────────────────────────────
+
+#[test]
+fn batch_settlement_rejects_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (client_addr, _, id) = make_completed(&env, &escrow);
+    escrow.pause();
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: client_addr,
+        },
+    ];
+
+    let result = escrow.try_finalize_contracts_batch(&items);
+    assert_contract_error(result, EscrowError::ContractPaused);
+}
+
+// ── Disputed contract ─────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_disputed_contract_succeeds() {
+    // EscrowFixtureBuilder handles SAC wiring; .funded() deposits the full amount.
+    let fixture = super::EscrowFixtureBuilder::new().funded().build();
+    let env = fixture.env.clone();
+    let id = fixture.escrow_id;
+    let escrow = fixture.escrow();
+    let client_addr = fixture.client.clone();
+
+    // Raise a dispute on the funded contract — status becomes Disputed.
+    escrow.raise_dispute(&id, &client_addr);
+    assert_eq!(escrow.get_contract(&id).status, ContractStatus::Disputed);
+
+    // Client can finalize a Disputed contract.
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: client_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    let r: BatchSettlementResult = results.get(0).unwrap();
+    assert_ok(&r, 0, id);
+    assert!(escrow.get_finalization_record(&id).is_some());
+}
+
+// ── Freelancer as finalizer ───────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_freelancer_as_finalizer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (_, freelancer_addr, id) = make_completed(&env, &escrow);
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: freelancer_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    assert_ok(&results.get(0).unwrap(), 0, id);
+    assert!(escrow.get_finalization_record(&id).is_some());
+}
+
+// ── Arbiter as finalizer ──────────────────────────────────────────────────────
+
+#[test]
+fn batch_settlement_arbiter_as_finalizer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let milestones = super::default_milestones(&env);
+
+    let id = escrow.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    let total = super::total_milestone_amount();
+    if let Some(token) = escrow.get_settlement_token() {
+        soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&client_addr, &total);
+    }
+    escrow.deposit_funds(&id, &client_addr, &total);
+
+    // Release all milestones (ClientOnly auth) to complete the contract.
+    for idx in 0..milestones.len() {
+        escrow.approve_milestone_release(&id, &client_addr, &idx);
+        escrow.release_milestone(&id, &client_addr, &idx);
+    }
+    assert_eq!(escrow.get_contract(&id).status, ContractStatus::Completed);
+
+    let items = vec![
+        &env,
+        SettlementItem {
+            contract_id: id,
+            finalizer: arbiter_addr,
+        },
+    ];
+
+    let results = escrow.finalize_contracts_batch(&items);
+    assert_eq!(results.len(), 1);
+    assert_ok(&results.get(0).unwrap(), 0, id);
+    assert!(escrow.get_finalization_record(&id).is_some());
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -16,6 +16,7 @@ mod accounting_invariants;
 mod approval_expiry;
 mod bounds_validation;
 mod cancel_contract;
+mod batch_settlement;
 mod client_migration;
 mod contracts;
 mod create_contract_bounds;

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -645,3 +645,39 @@ pub struct DisputeRecord {
     /// Ledger timestamp when the dispute was resolved, or `None` while open.
     pub resolved_at: Option<u64>,
 }
+
+// ── Batch settlement ─────────────────────────────────────────────────────────
+
+/// A single item in a [`Escrow::finalize_contracts_batch`] request.
+///
+/// Each entry pairs a `contract_id` with the `finalizer` address that is
+/// authorizing closure of that contract.  The finalizer must be the stored
+/// client, freelancer, or assigned arbiter — the same role check as the
+/// single-item [`Escrow::finalize_contract`] entrypoint.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SettlementItem {
+    /// The escrow contract to finalize.
+    pub contract_id: u32,
+    /// The address authorizing finalization (client, freelancer, or arbiter).
+    pub finalizer: Address,
+}
+
+/// Per-item outcome returned by [`Escrow::finalize_contracts_batch`].
+///
+/// Every item in the input vector produces exactly one `BatchSettlementResult`
+/// at the same position.  Inspect `success` first; when `false`, `error_code`
+/// carries the numeric discriminant of the [`EscrowError`] that would have
+/// been returned by the equivalent single-item call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchSettlementResult {
+    /// Zero-based position of this item in the input vector.
+    pub index: u32,
+    /// The contract ID from the corresponding [`SettlementItem`].
+    pub contract_id: u32,
+    /// `true` when finalization succeeded; `false` on any per-item error.
+    pub success: bool,
+    /// Error discriminant when `success` is `false`; `None` on success.
+    pub error_code: Option<u32>,
+}


### PR DESCRIPTION
Add finalize_contracts_batch accepting a Vec<SettlementItem> bounded by MAX_BATCH_SETTLEMENT (10). Rejects over-cap with BatchSettlementTooLarge and empty input with BatchSettlementEmpty.

Per-item semantics preserved: each item runs the same validation as finalize_contract and emits the finalized event on success. Failures are captured as error codes in BatchSettlementResult so one bad item never blocks the rest.

New surface: SettlementItem, BatchSettlementResult, MAX_BATCH_SETTLEMENT, EscrowError::BatchSettlementTooLarge (46), EscrowError::BatchSettlementEmpty (47), Escrow::finalize_contracts_batch

14 tests cover: empty, at-cap, over-cap, single item, per-item events, unknown contract, already-finalized, unauthorized, non-terminal status, mixed success/failure, paused guard, disputed contract, freelancer finalizer, arbiter finalizer.

Closes #963