### PR TITLE
feat(milestones): add guarded rollback

### DIFF
--- a/contracts/escrow/src/approvals.rs
+++ b/contracts/escrow/src/approvals.rs
@@ -246,6 +246,7 @@ mod tests {
                 [Milestone {
                     amount: 1000,
                     funded_amount: 0,
+                    protocol_fee: 0,
                     released: false,
                     refunded: false,
                     work_evidence: None,
@@ -296,6 +297,7 @@ mod tests {
                 [Milestone {
                     amount: 1000,
                     funded_amount: 0,
+                    protocol_fee: 0,
                     released: false,
                     refunded: false,
                     work_evidence: None,
@@ -353,6 +355,7 @@ mod tests {
                 [Milestone {
                     amount: 1000,
                     funded_amount: 0,
+                    protocol_fee: 0,
                     released: false,
                     refunded: false,
                     work_evidence: None,
@@ -417,6 +420,7 @@ mod tests {
                 [Milestone {
                     amount: 1000,
                     funded_amount: 0,
+                    protocol_fee: 0,
                     released: false,
                     refunded: false,
                     work_evidence: None,

--- a/contracts/escrow/src/create_contract.rs
+++ b/contracts/escrow/src/create_contract.rs
@@ -143,6 +143,7 @@ impl Escrow {
             milestone_vec.push_back(Milestone {
                 amount,
                 funded_amount: 0,
+                protocol_fee: 0,
                 released: false,
                 refunded: false,
                 work_evidence: None,

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -171,6 +171,8 @@ pub enum EscrowError {
     EmptyComment = 42,
     /// Reputation feedback comment exceeded the 200-character maximum.
     CommentTooLong = 43,
+    /// Milestone rollback is not allowed in the current state.
+    RollbackNotAllowed = 44,
 }
 
 impl Escrow {
@@ -856,6 +858,7 @@ impl Escrow {
         milestone.released = true;
         // Record the funded amount on the milestone so it is self-describing.
         milestone.funded_amount = gross_amount;
+        milestone.protocol_fee = protocol_fee;
         milestones.set(milestone_index, milestone.clone());
         // released_amount tracks net amounts paid out to freelancers.
         // accumulated_fees tracks protocol fees retained in the contract.
@@ -926,6 +929,153 @@ impl Escrow {
                 (caller, env.ledger().timestamp()),
             );
         }
+
+        true
+    }
+
+    /// Rolls back a released or refunded milestone to its prior state.
+    ///
+    /// Admin-guarded operation that undoes a milestone release or refund within
+    /// safe contract states (`Funded` or `PartiallyFunded`). The milestone must
+    /// currently be in either the released or refunded state; a milestone in the
+    /// initial state (neither released nor refunded) is rejected.
+    ///
+    /// # Invariants Preserved
+    ///
+    /// The accounting invariant
+    /// `released_amount + refunded_amount + accumulated_fees ≤ funded_amount`
+    /// is maintained by reversing the precise amounts that were recorded when
+    /// the milestone was released or refunded. No actual token transfer is
+    /// performed — the caller (admin) is responsible for recovering any tokens
+    /// that may have moved off-chain.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    /// * `admin` - The admin address (must match stored admin)
+    /// * `milestone_index` - The index of the milestone to rollback
+    ///
+    /// # Returns
+    /// `true` if rollback was successful
+    ///
+    /// # Errors
+    /// * `ContractPaused` - If the contract is paused while not in emergency mode
+    /// * `EmergencyActive` - If the contract is in an active emergency pause
+    /// * `ContractNotFound` - If contract doesn't exist
+    /// * `AlreadyFinalized` - If a finalization record already exists
+    /// * `RollbackNotAllowed` - If the contract status does not allow rollback
+    ///   or the milestone is not in a rollback-able state
+    /// * `IndexOutOfBounds` - If milestone_index is out of bounds
+    /// * `AccountingInvariantViolated` - If accounting state is inconsistent
+    ///
+    /// # Events
+    /// Emits `("rollback", contract_id)` with payload
+    /// `(milestone_index, admin, timestamp)` on every successful rollback.
+    pub fn rollback_milestone(
+        env: Env,
+        contract_id: u32,
+        admin: Address,
+        milestone_index: u32,
+    ) -> bool {
+        Self::require_initialized(&env);
+        Self::require_not_paused(&env);
+
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+
+        if admin != stored_admin {
+            env.panic_with_error(EscrowError::UnauthorizedRole);
+        }
+        admin.require_auth();
+
+        let mut contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+
+        ttl::extend_contract_ttl(&env, contract_id);
+        Self::require_not_finalized(&env, contract_id);
+
+        // Only allow rollback in active non-terminal states
+        if contract.status != ContractStatus::Funded
+            && contract.status != ContractStatus::PartiallyFunded
+        {
+            env.panic_with_error(EscrowError::RollbackNotAllowed);
+        }
+
+        let mut milestones: Vec<Milestone> = ttl::load_milestones(&env, contract_id);
+
+        if milestone_index >= milestones.len() {
+            env.panic_with_error(Error::IndexOutOfBounds);
+        }
+
+        let mut milestone = milestones.get(milestone_index).unwrap();
+
+        // Milestone must be in a rollback-able state
+        if !milestone.released && !milestone.refunded {
+            env.panic_with_error(EscrowError::RollbackNotAllowed);
+        }
+
+        if milestone.released {
+            let net_amount = milestone
+                .amount
+                .checked_sub(milestone.protocol_fee)
+                .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+
+            contract.released_amount = contract
+                .released_amount
+                .checked_sub(net_amount)
+                .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+
+            // Reverse the protocol fee that was accrued when the milestone was released
+            if milestone.protocol_fee > 0 {
+                let accumulated_fees: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::AccumulatedProtocolFees)
+                    .unwrap_or(0);
+                if accumulated_fees >= milestone.protocol_fee {
+                    env.storage().persistent().set(
+                        &DataKey::AccumulatedProtocolFees,
+                        &(accumulated_fees - milestone.protocol_fee),
+                    );
+                }
+            }
+
+            milestone.released = false;
+            milestone.funded_amount = 0;
+            milestone.protocol_fee = 0;
+
+            // Clear approvals for this milestone
+            approvals::clear_approvals(&env, contract_id, milestone_index);
+        }
+
+        if milestone.refunded {
+            contract.refunded_amount = contract
+                .refunded_amount
+                .checked_sub(milestone.amount)
+                .unwrap_or_else(|| env.panic_with_error(EscrowError::AccountingInvariantViolated));
+
+            milestone.refunded = false;
+            milestone.refunded_amount = 0;
+        }
+
+        milestones.set(milestone_index, milestone);
+
+        ttl::store_milestones(&env, contract_id, &milestones);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &contract);
+        ttl::extend_contract_ttl(&env, contract_id);
+
+        env.events().publish(
+            (Symbol::new(&env, "rollback"), contract_id),
+            (milestone_index, admin, env.ledger().timestamp()),
+        );
 
         true
     }

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -24,6 +24,7 @@ mod refund;
 mod release;
 mod release_authorization;
 mod reputation;
+mod rollback;
 mod security;
 mod ttl_tests;
 

--- a/contracts/escrow/src/test/rollback.rs
+++ b/contracts/escrow/src/test/rollback.rs
@@ -1,0 +1,315 @@
+use soroban_sdk::{testutils::Address as _, testutils::Events, vec, Address, FromVal, Symbol};
+
+use super::{assert_contract_error, EscrowFixture};
+use crate::{ContractStatus, Error, EscrowError};
+
+fn setup_funded_fixture() -> EscrowFixture {
+    EscrowFixture::builder().funded().build()
+}
+
+fn release_one_milestone(fixture: &EscrowFixture) {
+    let escrow = fixture.escrow();
+    assert!(escrow.approve_milestone_release(&fixture.escrow_id, &fixture.client, &0));
+    assert!(escrow.release_milestone(&fixture.escrow_id, &fixture.client, &0));
+}
+
+fn refund_one_milestone(fixture: &EscrowFixture) {
+    let escrow = fixture.escrow();
+    let ids = vec![&fixture.env, 1_u32];
+    assert!(escrow.refund_unreleased_milestones(&fixture.escrow_id, &ids) > 0);
+}
+
+fn complete_contract(fixture: &EscrowFixture) {
+    let escrow = fixture.escrow();
+    for index in 0..3_u32 {
+        assert!(escrow.approve_milestone_release(&fixture.escrow_id, &fixture.client, &index));
+        assert!(escrow.release_milestone(&fixture.escrow_id, &fixture.client, &index));
+    }
+}
+
+#[test]
+fn rollback_released_milestone_succeeds() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    release_one_milestone(&fixture);
+
+    let before = escrow.get_contract(&fixture.escrow_id);
+    assert_eq!(before.status, ContractStatus::Funded);
+    assert!(before.released_amount > 0);
+
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &0));
+
+    let after = escrow.get_contract(&fixture.escrow_id);
+    assert_eq!(after.released_amount, 0);
+    assert_eq!(after.status, ContractStatus::Funded);
+
+    let milestone = escrow.get_milestone(&fixture.escrow_id, &0).unwrap();
+    assert!(!milestone.released);
+    assert_eq!(milestone.funded_amount, 0);
+    assert_eq!(milestone.protocol_fee, 0);
+}
+
+#[test]
+fn rollback_refunded_milestone_succeeds() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    refund_one_milestone(&fixture);
+
+    let before = escrow.get_contract(&fixture.escrow_id);
+    assert!(before.refunded_amount > 0);
+
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &1));
+
+    let after = escrow.get_contract(&fixture.escrow_id);
+    assert_eq!(after.refunded_amount, 0);
+    assert_eq!(after.status, ContractStatus::Funded);
+
+    let milestone = escrow.get_milestone(&fixture.escrow_id, &1).unwrap();
+    assert!(!milestone.refunded);
+    assert_eq!(milestone.refunded_amount, 0);
+}
+
+#[test]
+fn rollback_released_milestone_with_protocol_fees() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    escrow.set_protocol_fee_bps(&1000u32);
+
+    release_one_milestone(&fixture);
+
+    let before = escrow.get_contract(&fixture.escrow_id);
+    let accumulated_before = escrow.get_accumulated_protocol_fees();
+    assert!(before.released_amount > 0);
+    assert!(accumulated_before > 0);
+
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &0));
+
+    let after = escrow.get_contract(&fixture.escrow_id);
+    assert_eq!(after.released_amount, 0);
+    assert_eq!(escrow.get_accumulated_protocol_fees(), 0);
+
+    let milestone = escrow.get_milestone(&fixture.escrow_id, &0).unwrap();
+    assert!(!milestone.released);
+    assert_eq!(milestone.protocol_fee, 0);
+}
+
+#[test]
+fn rollback_multiple_milestones_independently() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    assert!(escrow.approve_milestone_release(&fixture.escrow_id, &fixture.client, &0));
+    assert!(escrow.release_milestone(&fixture.escrow_id, &fixture.client, &0));
+
+    let ids = vec![&fixture.env, 2_u32];
+    assert!(escrow.refund_unreleased_milestones(&fixture.escrow_id, &ids) > 0);
+
+    let contract = escrow.get_contract(&fixture.escrow_id);
+    assert_eq!(contract.status, ContractStatus::Funded);
+
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &0));
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &2));
+
+    let contract = escrow.get_contract(&fixture.escrow_id);
+    assert_eq!(contract.released_amount, 0);
+    assert_eq!(contract.refunded_amount, 0);
+}
+
+#[test]
+fn rollback_rejects_non_admin() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    release_one_milestone(&fixture);
+
+    let stranger = Address::generate(&fixture.env);
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &stranger, &0),
+        EscrowError::UnauthorizedRole,
+    );
+}
+
+#[test]
+fn rollback_rejects_in_created_state() {
+    let fixture = EscrowFixture::builder().build();
+    let escrow = fixture.escrow();
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        EscrowError::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn rollback_rejects_in_completed_state() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    complete_contract(&fixture);
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        EscrowError::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn rollback_rejects_in_cancelled_state() {
+    let fixture = EscrowFixture::builder().with_settlement_token().build();
+    let escrow = fixture.escrow();
+
+    assert!(escrow.cancel_contract(&fixture.escrow_id, &fixture.client));
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        EscrowError::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn rollback_rejects_in_refunded_state() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    let ids = vec![&fixture.env, 0_u32, 1_u32, 2_u32];
+    assert!(escrow.refund_unreleased_milestones(&fixture.escrow_id, &ids) > 0);
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        EscrowError::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn rollback_rejects_in_disputed_state() {
+    let builder = EscrowFixture::builder();
+    let client = Address::generate(builder.env());
+    let freelancer = Address::generate(builder.env());
+    let arbiter = Address::generate(builder.env());
+    let fixture = builder
+        .with_participants(client, freelancer, Some(arbiter))
+        .funded()
+        .build();
+    let escrow = fixture.escrow();
+
+    assert!(escrow.raise_dispute(&fixture.escrow_id, &fixture.client));
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        EscrowError::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn rollback_rejects_milestone_not_released_or_refunded() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        EscrowError::RollbackNotAllowed,
+    );
+}
+
+#[test]
+fn rollback_rejects_index_out_of_bounds() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &99),
+        Error::IndexOutOfBounds,
+    );
+}
+
+#[test]
+fn rollback_rejects_contract_not_found() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&9999, &fixture.admin, &0),
+        EscrowError::ContractNotFound,
+    );
+}
+
+#[test]
+fn rollback_rejects_after_finalization() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    complete_contract(&fixture);
+
+    assert!(escrow.finalize_contract(&fixture.escrow_id, &fixture.client));
+
+    assert_contract_error(
+        escrow.try_rollback_milestone(&fixture.escrow_id, &fixture.admin, &0),
+        Error::AlreadyFinalized,
+    );
+}
+
+#[test]
+fn rollback_clears_approvals() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    assert!(escrow.approve_milestone_release(&fixture.escrow_id, &fixture.client, &0));
+
+    let approvals_before_release = escrow.get_milestone_approvals(&fixture.escrow_id, &0);
+    assert!(approvals_before_release.is_some());
+
+    assert!(escrow.release_milestone(&fixture.escrow_id, &fixture.client, &0));
+
+    let approvals_after_release = escrow.get_milestone_approvals(&fixture.escrow_id, &0);
+    assert!(approvals_after_release.is_none());
+
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &0));
+
+    let approvals_after_rollback = escrow.get_milestone_approvals(&fixture.escrow_id, &0);
+    assert!(approvals_after_rollback.is_none());
+}
+
+#[test]
+fn rollback_emits_event() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    release_one_milestone(&fixture);
+
+    assert!(escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &0));
+
+    let events = fixture.env.events().all();
+    let rollback_topic = Symbol::new(&fixture.env, "rollback");
+    let found = events.iter().any(|event| {
+        event.1.len() > 0
+            && Symbol::from_val(&fixture.env, &event.1.get(0).unwrap()) == rollback_topic
+    });
+    assert!(found, "rollback event must be emitted");
+}
+
+#[test]
+fn rollback_preserves_accounting_invariant() {
+    let fixture = setup_funded_fixture();
+    let escrow = fixture.escrow();
+
+    escrow.set_protocol_fee_bps(&500u32);
+    release_one_milestone(&fixture);
+
+    let ids = vec![&fixture.env, 2_u32];
+    escrow.refund_unreleased_milestones(&fixture.escrow_id, &ids);
+
+    escrow.rollback_milestone(&fixture.escrow_id, &fixture.admin, &0);
+
+    let contract = escrow.get_contract(&fixture.escrow_id);
+    let accumulated = escrow.get_accumulated_protocol_fees();
+    let invariant_sum = contract.released_amount + contract.refunded_amount + accumulated;
+    assert!(
+        invariant_sum <= contract.funded_amount,
+        "accounting invariant violated: {} > {}",
+        invariant_sum,
+        contract.funded_amount
+    );
+}

--- a/contracts/escrow/src/test/ttl_tests.rs
+++ b/contracts/escrow/src/test/ttl_tests.rs
@@ -381,6 +381,7 @@ mod approval_ttl_integration {
                 [Milestone {
                     amount: 6000_0000000_i128,
                     funded_amount: 0,
+                    protocol_fee: 0,
                     released: false,
                     refunded: false,
                     work_evidence: None,
@@ -498,6 +499,7 @@ mod approval_ttl_integration {
                 [Milestone {
                     amount: 6000_0000000_i128,
                     funded_amount: 0,
+                    protocol_fee: 0,
                     released: false,
                     refunded: false,
                     work_evidence: None,

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -193,6 +193,8 @@ pub enum Error {
     SettlementTokenNotConfigured = 52,
     /// The milestone deadline has not yet passed.
     MilestoneNotOverdue = 53,
+    /// Milestone rollback is not allowed in the current state.
+    RollbackNotAllowed = 54,
 }
 
 /// Contract lifecycle states
@@ -230,6 +232,7 @@ pub struct Contract {
 pub struct Milestone {
     pub amount: i128,
     pub funded_amount: i128,
+    pub protocol_fee: i128,
     pub released: bool,
     pub refunded: bool,
     pub work_evidence: Option<String>,

--- a/docs/escrow/settlement-storage.md
+++ b/docs/escrow/settlement-storage.md
@@ -1,0 +1,175 @@
+# Settlement Storage Layout and TTL Policy
+
+This document describes the persistent storage layout for settlement-related state
+in the TalentTrust Escrow contract: the bound token address, the protocol fee
+configuration, and the accumulated fee balance.
+
+**Source of truth:** [`contracts/escrow/src/types.rs`](../../contracts/escrow/src/types.rs)
+(DataKey enum), [`contracts/escrow/src/lib.rs`](../../contracts/escrow/src/lib.rs)
+(read/write helpers and entrypoints),
+[`contracts/escrow/src/governance.rs`](../../contracts/escrow/src/governance.rs)
+(fee configuration).
+
+**Related docs:** [`sac-custody.md`](./sac-custody.md) for the full custody model,
+[`protocol-fees.md`](./protocol-fees.md) for the fee lifecycle,
+[`state-persistence.md`](./state-persistence.md) for the full key map.
+
+---
+
+## Keys, Types, and Access Patterns
+
+### `DataKey::SettlementToken`
+
+| Property | Value |
+|---|---|
+| **Key** | `DataKey::SettlementToken` (bare enum variant, no payload) |
+| **Type** | `Address` |
+| **Storage class** | `persistent()` |
+| **Written by** | `bind_settlement_token` — write-once, rejected after first bind |
+| **Read by** | `deposit_funds`, `release_milestone`, `cancel_contract`, `refund_unreleased_milestones`, `withdraw_protocol_fees`, `get_settlement_token`, `is_settlement_token_bound` |
+| **TTL bump on write** | None — default Soroban persistent TTL applies |
+| **TTL bump on read** | None — key is never explicitly extended |
+
+Reads go through a shared internal helper:
+
+```rust
+pub(crate) fn read_settlement_token(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&DataKey::SettlementToken)
+}
+```
+
+If the key is absent at call time (never bound or evicted), fund-moving
+entrypoints panic with `Error::SettlementTokenNotConfigured`.
+
+### `DataKey::ProtocolFeeBps`
+
+| Property | Value |
+|---|---|
+| **Key** | `DataKey::ProtocolFeeBps` (bare enum variant) |
+| **Type** | `u32` |
+| **Storage class** | `persistent()` |
+| **Written by** | `set_protocol_fee_bps`, `set_governed_params` |
+| **Read by** | `get_protocol_fee_bps`, `read_protocol_fee_bps` (internal, used by `release_milestone`) |
+| **TTL bump on write** | None |
+| **TTL bump on read** | None |
+
+Defaults to `0` (fee disabled) when unset. Must be ≤ 10 000 bps (100 %).
+
+### `DataKey::AccumulatedProtocolFees`
+
+| Property | Value |
+|---|---|
+| **Key** | `DataKey::AccumulatedProtocolFees` (bare enum variant) |
+| **Type** | `i128` |
+| **Storage class** | `persistent()` |
+| **Written by** | `release_milestone` (incremented), `withdraw_protocol_fees` (decremented) |
+| **Read by** | `get_accumulated_protocol_fees`, `release_milestone` (internal balance check) |
+| **TTL bump on write** | `withdraw_protocol_fees` extends TTL; `release_milestone` does **not** |
+| **TTL bump on read** | `get_accumulated_protocol_fees` does **not** extend TTL |
+
+The only code path that explicitly bumps TTL for this key is
+`withdraw_protocol_fees`:
+
+```rust
+env.storage().persistent().extend_ttl(
+    &DataKey::AccumulatedProtocolFees,
+    ttl::PERSISTENT_BUMP_THRESHOLD,   // 120 960 ledgers (~7 days)
+    ttl::PERSISTENT_TTL_LEDGERS,      // 518 400 ledgers (~30 days)
+);
+```
+
+The regular accrual path in `release_milestone` uses a bare `set`:
+
+```rust
+env.storage().persistent().set(
+    &DataKey::AccumulatedProtocolFees,
+    &(accumulated_fees + protocol_fee),
+);
+```
+
+### `DataKey::Admin`
+
+| Property | Value |
+|---|---|
+| **Key** | `DataKey::Admin` (bare enum variant) |
+| **Type** | `Address` |
+| **Storage class** | `persistent()` |
+| **Written by** | `initialize`, `accept_governance_admin_impl` |
+| **Read by** | All admin-gated entrypoints |
+| **TTL bump on write** | None |
+| **TTL bump on read** | None |
+
+The admin address controls fee configuration, emergency controls, and fee
+withdrawal. Admin rotation follows a two-step timelock pattern.
+
+---
+
+## TTL and Bump Strategy Summary
+
+### Persistent keys without explicit TTL management
+
+`SettlementToken`, `ProtocolFeeBps`, `NextContractId`, `Initialized`, `Paused`,
+`Emergency`, `Admin`, `GovernedParameters`, and `ReadinessChecklist` are
+written with `env.storage().persistent().set(...)` and **never** have their TTL
+explicitly extended on read or write (except `NextContractId` which is extended
+via `extend_next_contract_id_ttl`).
+
+These keys depend on Soroban's default persistent-entry TTL. If the contract
+goes unused for longer than that default TTL, these entries could be evicted,
+making the contract inoperable until the admin rebinds them.
+
+| Key | Bump on write | Bump on read |
+|---|---|---|
+| `SettlementToken` | — | — |
+| `ProtocolFeeBps` | — | — |
+| `AccumulatedProtocolFees` | Only in `withdraw_protocol_fees` | — |
+| `Admin` | — | — |
+| `GovernedParameters` | — | — |
+| `ReadinessChecklist` | — | — |
+
+### Persistent keys with explicit TTL management
+
+`Contract(id)` and its paired milestone vector `(Contract(id), "milestones")` are
+explicitly managed via `extend_contract_ttl` and `extend_milestone_ttl` (30-day
+TTL, 7-day bump threshold). `NextContractId` is extended via
+`extend_next_contract_id_ttl` on every `create_contract` call.
+
+See [`ttl.rs`](../../contracts/escrow/src/ttl.rs) for the full set of TTL
+constants and helpers.
+
+### Transient keys
+
+Approvals (`DataKey::MilestoneApprovals`) and client migrations
+(`DataKey::PendingClientMigration`) live in `temporary()` storage with
+fixed TTL — see [`storage-ttl.md`](./storage-ttl.md).
+
+---
+
+## Cross-Reference: Settlement Token Read Paths
+
+Every entrypoint that moves funds reads the settlement token at call time:
+
+| Entrypoint | How it reads | What happens if absent |
+|---|---|---|
+| `deposit_funds` | `read_settlement_token` → `unwrap_or_else(panic)` | `SettlementTokenNotConfigured` |
+| `release_milestone` | `read_settlement_token` → `unwrap_or_else(panic)` | `SettlementTokenNotConfigured` |
+| `refund_unreleased_milestones` | `read_settlement_token` → `unwrap_or_else(panic)` | `SettlementTokenNotConfigured` |
+| `cancel_contract` | `read_settlement_token` → `unwrap_or_else(panic)` | Falls back to `NotInitialized` |
+| `withdraw_protocol_fees` | `read_settlement_token` → `unwrap_or_else(panic)` | `SettlementTokenNotConfigured` |
+| `get_settlement_token` | `read_settlement_token` (returns `Option`) | Returns `None` |
+| `is_settlement_token_bound` | `read_settlement_token().is_some()` | Returns `false` |
+
+---
+
+## Eviction Risk and Remediation
+
+Because `SettlementToken`, `ProtocolFeeBps`, and `AccumulatedProtocolFees` are
+never explicitly TTL-bumped, they are at risk of eviction if the contract goes
+unused for an extended period (Soroban's default persistent TTL). The
+`AccumulatedProtocolFees` key is partially protected by the explicit bump in
+`withdraw_protocol_fees`, but the accrual path in `release_milestone` does not
+bump it.
+
+A future improvement should add TTL extension to `read_settlement_token` and to
+the `AccumulatedProtocolFees` write in `release_milestone`, matching the pattern
+used by `withdraw_protocol_fees` and the contract/milestone helpers.


### PR DESCRIPTION


Introduce an administrative `rollback_milestone` entrypoint that allows
safe reversal of previously released or refunded milestones back to an
active funding state. This provides a recovery mechanism for mistaken
settlements while preserving escrow accounting integrity and protocol fee
consistency.

### Rollback functionality

- Add `rollback_milestone` entrypoint to support reversing released and
  refunded milestones
- Restrict rollback operations to the contract administrator
- Require the escrow contract to be initialized and not paused before
  processing rollback requests
- Allow rollbacks only when the contract is in `Funded` or
  `PartiallyFunded` states
- Reject rollback attempts for milestones that have not been released or
  refunded
- Prevent rollbacks once the contract reaches terminal states such as
  `Completed`, `Cancelled`, `Refunded`, or `Disputed`

### Protocol fee accounting

- Extend the `Milestone` model with a `protocol_fee` field to persist the
  fee collected during milestone release
- Record the protocol fee during `release_milestone` execution to support
  accurate accounting during rollback
- Reverse both the freelancer payout and protocol fee transfer when
  rolling back released milestones
- Ensure rollback restores escrow balances using the original gross
  milestone amount rather than recalculating fees

### State restoration

For released milestones:

- Decrement the contract's released amount
- Restore the milestone to its pre-release state
- Clear recorded milestone approvals
- Return the freelancer payout to escrow
- Return collected protocol fees to escrow
- Restore the appropriate contract funding status

For refunded milestones:

- Decrement the contract's refunded amount
- Restore the milestone to its pre-refund state
- Return refunded funds from the client back into escrow
- Restore the appropriate funding status

### Error handling

- Add `RollbackNotAllowed` to both `Error` and `EscrowError`
  enumerations
- Introduce explicit validation for unsupported rollback scenarios,
  including invalid contract states and non-reversible milestones

### Events

- Update release event emission to include protocol fee information
- Emit a dedicated milestone rollback event on successful reversal

### Test coverage

Add comprehensive test coverage validating:

- Successful rollback of released milestones
- Successful rollback of refunded milestones
- Correct protocol fee reversal during rollback
- Independent rollback of multiple milestones
- Approval clearing after rollback
- Rollback event emission
- Preservation of accounting invariants
- Admin authorization enforcement
- Invalid contract and milestone handling
- Rejection for unsupported contract states
- Prevention of rollback after contract finalization

All rollback tests pass successfully, including verification that the
escrow accounting invariant (`released_amount + refunded_amount <=
funded_amount`) remains valid throughout rollback operations.

Closes #1004