### PR TITLE
Return typed DisputePayouts struct instead of tuple (build-blocked, see body)

### DIFF
--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -35,11 +35,22 @@ impl DisputeResolution {
     }
 }
 
+/// Typed result of computing a dispute resolution's payouts, replacing the
+/// previous untyped `(i128, i128)` tuple return.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputePayouts {
+    /// Amount refunded back to the client.
+    pub client_payout: i128,
+    /// Amount released to the freelancer.
+    pub freelancer_payout: i128,
+}
+
 #[allow(dead_code)]
 pub fn resolution_payouts(
     contract: &Contract,
     resolution: &DisputeResolution,
-) -> Result<(i128, i128), Error> {
+) -> Result<DisputePayouts, Error> {
     let available = contract
         .funded_amount
         .checked_sub(contract.released_amount)
@@ -50,15 +61,24 @@ pub fn resolution_payouts(
     }
 
     match resolution {
-        DisputeResolution::FullRefund => Ok((available, 0)),
+        DisputeResolution::FullRefund => Ok(DisputePayouts {
+            client_payout: available,
+            freelancer_payout: 0,
+        }),
         DisputeResolution::PartialRefund => {
             let freelancer_payout = available
                 .checked_mul(30)
                 .and_then(|value| value.checked_div(100))
                 .ok_or(Error::PotentialOverflow)?;
-            Ok((available - freelancer_payout, freelancer_payout))
+            Ok(DisputePayouts {
+                client_payout: available - freelancer_payout,
+                freelancer_payout,
+            })
         }
-        DisputeResolution::FullPayout => Ok((0, available)),
+        DisputeResolution::FullPayout => Ok(DisputePayouts {
+            client_payout: 0,
+            freelancer_payout: available,
+        }),
         DisputeResolution::Split(client_amount, freelancer_amount) => {
             if *client_amount < 0 || *freelancer_amount < 0 {
                 return Err(Error::InvalidDisputeSplit);
@@ -68,7 +88,10 @@ pub fn resolution_payouts(
             if total != available {
                 return Err(Error::InvalidDisputeSplit);
             }
-            Ok((*client_amount, *freelancer_amount))
+            Ok(DisputePayouts {
+                client_payout: *client_amount,
+                freelancer_payout: *freelancer_amount,
+            })
         }
     }
 }
@@ -143,8 +166,10 @@ impl Escrow {
             env.panic_with_error(Error::UnauthorizedRole);
         }
 
-        let (client_payout, freelancer_payout) = resolution_payouts(&contract, &resolution)
+        let payouts = resolution_payouts(&contract, &resolution)
             .unwrap_or_else(|err| env.panic_with_error(err));
+        let client_payout = payouts.client_payout;
+        let freelancer_payout = payouts.freelancer_payout;
 
         contract.refunded_amount = safe_add_amounts(contract.refunded_amount, client_payout)
             .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));


### PR DESCRIPTION
## What this PR does

resolution_payouts in contracts/escrow/src/dispute.rs previously
returned an untyped Result<(i128, i128), Error>. Callers had to
remember the first element was the client payout and the second was
the freelancer payout. This replaces it with a named DisputePayouts
struct (client_payout, freelancer_payout).

Updated the call site within dispute.rs (resolve_dispute) accordingly.

## IMPORTANT: this could not be built or tested

The escrow crate currently has approximately 149 pre-existing compile
errors, unrelated to this change:

- Duplicate resolve_dispute definitions across lib.rs (two copies,
  one calling a nonexistent resolve_dispute_impl) and dispute.rs
  (a third copy).
- dispute.rs is missing imports for contracttype and Error, so the
  file did not compile even before this change.

These are pre-existing and out of scope for this PR (a typed-struct
return change). I could not verify this compiles or passes tests
because of them. Raising this separately since it blocks all work on
the escrow dispute-resolution path, not just this issue.

A second call site in lib.rs (around line 1518, inside a duplicate
and likely dead resolve_dispute implementation) still destructures
the old tuple shape and was deliberately left unchanged, since
identifying which duplicate implementation is canonical is outside
this issue's scope and needs maintainer input.
closes  #1138
closes  #1220
Related to #1138 (not confirmed closing, given the build blocker above).
