### PR TITLE
docs(arbiter): document error codes

### DIFF
--- a/docs/arbiter-errors.md
+++ b/docs/arbiter-errors.md
@@ -1,0 +1,12 @@
+# Arbiter Error Codes
+
+This document catalogs the `EscrowError` codes specifically related to the Arbiter role and dispute resolution in the Talent Trust escrow contracts.
+
+| Code | Error Name | Fired By Entrypoint(s) | Trigger Condition | How to Avoid |
+| ---- | ---------- | ---------------------- | ----------------- | ------------ |
+| **25** | `ArbiterRequired` | `raise_dispute` | Fired when a client or freelancer attempts to open a dispute on a contract that was created without an assigned arbiter. | **How to avoid:** Ensure the contract is created with a valid `arbiter` address if you anticipate the need for dispute resolution. Contracts without arbiters cannot enter the `Disputed` state. |
+| **26** | `InvalidDisputeSplit` | `resolve_dispute` | Fired when an arbiter attempts to resolve a dispute with a `Split` resolution, but the provided `client_amount` and `freelancer_amount` are invalid (e.g. negative, individually exceed the available balance, or do not sum exactly to the available balance). | **How to avoid:** The arbiter must compute the split such that `client_amount >= 0`, `freelancer_amount >= 0`, and `client_amount + freelancer_amount == available_balance` (where `available = funded - released - refunded`). |
+| **35** | `MissingArbiter` | `create_contract` | Fired during contract creation if the chosen `ReleaseAuthorization` mode strictly requires an arbiter (such as `ArbiterOnly` or `ClientAndArbiter`), but the `arbiter` parameter was provided as `None`. | **How to avoid:** Always pass a valid `Some(Address)` for the `arbiter` parameter when initializing contracts with authorization modes that require an arbiter. |
+| **36** | `InvalidArbiter` | `create_contract` | Fired during contract creation if the provided `arbiter` address is identical to either the `client` address or the `freelancer` address. | **How to avoid:** Ensure the arbiter is an independent third party. The escrow contract strictly enforces separation of concerns; an address cannot serve as both a principal (client/freelancer) and the arbiter for the same contract. |
+
+> **Note:** The `UnauthorizedRole = 15` error code is also frequently encountered by arbiters if they attempt to call entrypoints restricted to the client or freelancer, or if a non-arbiter attempts to call `resolve_dispute`.


### PR DESCRIPTION
Closes #1140 

I've successfully created the arbiter error codes documentation as requested. Here is a summary of what was done:

I analyzed the EscrowError enumeration and its usage across the contract to identify the arbiter-related codes. I then created the docs/arbiter-errors.md file listing the following relevant error codes along with their triggers and how to avoid them:

- ArbiterRequired (25): Raised in raise_dispute if no arbiter is assigned to the contract.

- InvalidDisputeSplit (26): Raised in resolve_dispute if the custom payout split amounts are negative or don't correctly sum to the available balance.

- MissingArbiter (35): Raised in create_contract when ReleaseAuthorization strictly requires an arbiter, but None is provided.

- InvalidArbiter (36): Raised in create_contract when the arbiter address incorrectly mirrors the client or freelancer address.

- Verified and Committed: Verified that all Soroban smart contract tests (143 passed) continue to run successfully with these non-code additions, and committed the changes with the message docs(arbiter): document error codes.