### PR TITLE
Test/milestones 51 events

### DIFF
--- a/contracts/escrow/src/test/milestones_events.rs
+++ b/contracts/escrow/src/test/milestones_events.rs
@@ -54,15 +54,15 @@ fn release_event_has_expected_topic_and_payload() {
 
     let event = latest_event(&fixture);
     assert_topic(&fixture, &event, symbol_short!("mlstn_rls"));
-    let payload: (u32, i128, i128, i128, i128, Address, u64) =
+    let payload: (u32, i128, i128, i128, Address, u64) =
         TryFromVal::try_from_val(&fixture.env, &event.2).unwrap();
     assert_eq!(
         payload,
         (
             milestone_index,
-            4_0000000_i128,
+            400_0000000_i128,
             0_i128,
-            4_0000000_i128,
+            400_0000000_i128,
             fixture.client.clone(),
             timestamp,
         )
@@ -82,7 +82,10 @@ fn refund_event_has_expected_topic_and_payload() {
     assert_topic(&fixture, &event, symbol_short!("refunded"));
     let payload: (i128, ContractStatus, u64) =
         TryFromVal::try_from_val(&fixture.env, &event.2).unwrap();
-    assert_eq!(payload, (8_0000000_i128, ContractStatus::Funded, timestamp));
+    assert_eq!(
+        payload,
+        (800_0000000_i128, ContractStatus::Funded, timestamp)
+    );
 }
 
 #[test]

--- a/contracts/escrow/src/test/milestones_events.rs
+++ b/contracts/escrow/src/test/milestones_events.rs
@@ -1,0 +1,155 @@
+#![cfg(test)]
+
+use super::EscrowFixture;
+use crate::ContractStatus;
+use soroban_sdk::{symbol_short, testutils::Events, Address, String, Symbol, TryFromVal};
+
+fn latest_event(
+    fixture: &EscrowFixture,
+) -> (
+    Address,
+    soroban_sdk::Vec<soroban_sdk::Val>,
+    soroban_sdk::Val,
+) {
+    fixture
+        .env
+        .events()
+        .all()
+        .iter()
+        .last()
+        .cloned()
+        .expect("the emitting call must publish an event")
+}
+
+fn assert_topic(
+    fixture: &EscrowFixture,
+    event: &(
+        Address,
+        soroban_sdk::Vec<soroban_sdk::Val>,
+        soroban_sdk::Val,
+    ),
+    expected: Symbol,
+) {
+    assert_eq!(event.0, fixture.escrow_address);
+    assert_eq!(event.1.len(), 2, "milestone events have two topics");
+    assert_eq!(
+        Symbol::try_from_val(&fixture.env, &event.1.get(0).unwrap()).unwrap(),
+        expected
+    );
+    assert_eq!(
+        u32::try_from_val(&fixture.env, &event.1.get(1).unwrap()).unwrap(),
+        fixture.escrow_id
+    );
+}
+
+#[test]
+fn release_event_has_expected_topic_and_payload() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let client = fixture.escrow();
+    let milestone_index = 1_u32;
+    let timestamp = fixture.env.ledger().timestamp();
+
+    client.approve_milestone_release(&fixture.escrow_id, &fixture.client, &milestone_index);
+    client.release_milestone(&fixture.escrow_id, &fixture.client, &milestone_index);
+
+    let event = latest_event(&fixture);
+    assert_topic(&fixture, &event, symbol_short!("mlstn_rls"));
+    let payload: (u32, i128, i128, i128, i128, Address, u64) =
+        TryFromVal::try_from_val(&fixture.env, &event.2).unwrap();
+    assert_eq!(
+        payload,
+        (
+            milestone_index,
+            4_0000000_i128,
+            0_i128,
+            4_0000000_i128,
+            fixture.client.clone(),
+            timestamp,
+        )
+    );
+}
+
+#[test]
+fn refund_event_has_expected_topic_and_payload() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let client = fixture.escrow();
+    let indices = soroban_sdk::vec![&fixture.env, 0_u32, 2_u32];
+    let timestamp = fixture.env.ledger().timestamp();
+
+    client.refund_unreleased_milestones(&fixture.escrow_id, &indices);
+
+    let event = latest_event(&fixture);
+    assert_topic(&fixture, &event, symbol_short!("refunded"));
+    let payload: (i128, ContractStatus, u64) =
+        TryFromVal::try_from_val(&fixture.env, &event.2).unwrap();
+    assert_eq!(payload, (8_0000000_i128, ContractStatus::Funded, timestamp));
+}
+
+#[test]
+fn evidence_event_has_expected_topic_and_payload() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let client = fixture.escrow();
+    let milestone_index = 2_u32;
+    let evidence = String::from_str(&fixture.env, "ipfs://milestone-2");
+    let timestamp = fixture.env.ledger().timestamp();
+
+    client.submit_work_evidence(
+        &fixture.escrow_id,
+        &fixture.freelancer,
+        &milestone_index,
+        &evidence,
+    );
+
+    let event = latest_event(&fixture);
+    assert_topic(&fixture, &event, symbol_short!("evidence"));
+    let payload: (u32, String, u64) = TryFromVal::try_from_val(&fixture.env, &event.2).unwrap();
+    assert_eq!(payload, (milestone_index, evidence, timestamp));
+}
+
+#[test]
+fn milestone_event_topics_do_not_collide_with_each_other_or_existing_topics() {
+    let milestone_topics = [
+        symbol_short!("mlstn_rls"),
+        symbol_short!("refunded"),
+        symbol_short!("evidence"),
+    ];
+    for (index, topic) in milestone_topics.iter().enumerate() {
+        assert!(
+            milestone_topics[index + 1..]
+                .iter()
+                .all(|other| topic != other),
+            "milestone event topics must be unique"
+        );
+    }
+
+    let existing_topics = [
+        symbol_short!("init"),
+        symbol_short!("admin"),
+        symbol_short!("created"),
+        symbol_short!("contract"),
+        symbol_short!("deposit"),
+        symbol_short!("ctrct_st"),
+        symbol_short!("ctrct_cmp"),
+        symbol_short!("pause"),
+        symbol_short!("unpaused"),
+        symbol_short!("cancelled"),
+        symbol_short!("fee"),
+        symbol_short!("withdraw"),
+        symbol_short!("dispute"),
+        symbol_short!("opened"),
+        symbol_short!("resolved"),
+        symbol_short!("finalized"),
+        symbol_short!("mlstn_idx"),
+        symbol_short!("proto_fee"),
+        symbol_short!("sttl_bind"),
+        symbol_short!("repr_put"),
+    ];
+    for milestone_topic in milestone_topics {
+        assert!(
+            existing_topics
+                .iter()
+                .all(|topic| topic != &milestone_topic),
+            "milestone topic {milestone_topic:?} collides with an existing topic"
+        );
+    }
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -18,6 +18,7 @@ mod emergency_controls;
 mod input_sanitization_amounts;
 mod input_sanitization_identities;
 mod mainnet_readiness;
+mod milestones_events;
 mod pause_controls;
 mod persistence;
 mod refund;


### PR DESCRIPTION
## Summary Closes #1112 
- Add `contracts/escrow/src/test/milestones_events.rs` covering the milestone event topics (`mlstn_rls`, `refunded`, `evidence`) and asserting their exact payload fields.
- Capture each event immediately after the emitting call and assert topic symbol, indexed `contract_id`, and payload shape/values against the fixture's real state.
- Assert the three milestone topics don't collide with each other or with existing contract event topics.

## Why
milestones's emitted events weren't asserted anywhere, so topic or payload drift (renamed field, reordered tuple, wrong unit) could ship silently. This closes that gap.

## Changes
- `contracts/escrow/src/test/milestones_events.rs` (new): 4 tests —
  - `release_event_has_expected_topic_and_payload`
  - `refund_event_has_expected_topic_and_payload`
  - `evidence_event_has_expected_topic_and_payload`
  - `milestone_event_topics_do_not_collide_with_each_other_or_existing_topics`
- `contracts/escrow/src/test/mod.rs`: register the new `milestones_events` test module.


