### PR TITLE
Feature/reputation 52 setter

### DIFF
--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -6,22 +6,25 @@
 //! or `Refunded`. The root entrypoints own authentication, token transfer, event
 //! publication, and writes to `DataKey::Contract(contract_id)`.
 
-use soroban_sdk::{contractimpl, symbol_short, Address, Env};
+use soroban_sdk::{Address, Env};
 
 use crate::{
-    safe_add_amounts, Contract, ContractStatus, DataKey, DisputeResolution, DisputeSplit, Error,
-    Escrow, EscrowArgs, EscrowClient,
+    safe_add_amounts, Contract, ContractStatus, DataKey, DisputeConfig, DisputeResolution, Error,
 };
 
-/// Typed result of computing a dispute resolution's payouts, replacing the
-/// previous untyped `(i128, i128)` tuple return.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DisputePayouts {
-    /// Amount refunded back to the client.
-    pub client_payout: i128,
-    /// Amount released to the freelancer.
-    pub freelancer_payout: i128,
+/// Read-only getter for the arbiter dispute-split configuration.
+///
+/// Returns `None` before any admin call to `set_arbiter_config`; callers
+/// should fall back to `DisputeConfig::default()` (30/70 split).
+pub fn get_dispute_config(env: &Env) -> Option<DisputeConfig> {
+    env.storage().persistent().get(&DataKey::DisputeConfigKey)
+}
+
+/// Storage writer for the arbiter dispute-split configuration.
+pub fn set_dispute_config(env: &Env, config: DisputeConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DisputeConfigKey, &config);
 }
 
 /// Compute the payout split for a dispute resolution.
@@ -48,10 +51,7 @@ pub fn resolution_payouts(
     }
 
     match resolution {
-        DisputeResolution::FullRefund => Ok(DisputePayouts {
-            client_payout: available,
-            freelancer_payout: 0,
-        }),
+        DisputeResolution::FullRefund => Ok((available, 0)),
         DisputeResolution::PartialRefund => {
             // freelancer gets floor(available * 30 / 100), client gets remainder
             let freelancer_payout = available

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! | Source | Responsibility | Storage keys owned or touched |
 //! | --- | --- | --- |
-//! | `lib.rs` | Contract wrapper plus root entrypoints for setup, custody, money movement, reads, reputation, work evidence, pause/emergency, fee withdrawal, and dispute orchestration. | `DataKey::Initialized`, `Admin`, `SettlementToken`, `Paused`, `Emergency`, `ReadinessChecklist`, `Contract(id)`, `(Contract(id), "milestones")`, `MilestoneApprovals`, `AccumulatedProtocolFees`, `ReputationIssued`, `PendingReputationCredits`, `Reputation`, `ReputationComment` |
+//! | `lib.rs` | Contract wrapper plus root entrypoints for setup, custody, money movement, reads, reputation, work evidence, pause/emergency, fee withdrawal, and dispute orchestration. | `DataKey::Initialized`, `Admin`, `SettlementToken`, `Paused`, `Emergency`, `ReadinessChecklist`, `Contract(id)`, `(Contract(id), "milestones")`, `MilestoneApprovals`, `AccumulatedProtocolFees`, `ReputationIssued`, `PendingReputationCredits`, `Reputation`, `ReputationComment`, `ReputationConfigKey` |
 //! | `amount_validation` | Stateless validation and checked arithmetic for stroop amounts and milestone totals. | None directly; callers write validated amounts to `Contract(id)` and milestone vectors. |
 //! | `approvals` | Temporary milestone release approvals and release-authorization checks. | Temporary `DataKey::MilestoneApprovals(contract_id, milestone_index)`; reads `Contract(id)` and `(Contract(id), "milestones")`. |
 //! | `deposit` | Deposit preflight and post-transfer accounting used by `deposit_funds`. | `DataKey::Contract(contract_id)` and `(DataKey::Contract(contract_id), "milestones")`. |
@@ -22,7 +22,7 @@
 //! | `types` | Shared Soroban types, error enums, summaries, governance records, dispute records, and the canonical `DataKey` enum. | Declares storage key schema only; does not access storage itself. |
 //! | `utils` | Small deterministic helpers shared by entrypoints, currently ledger timestamp access. | None. |
 //! | `create_contract` | Contract creation, participant/milestone validation, ID allocation, and creation events. | `DataKey::Contract(id)`, `(DataKey::Contract(id), "milestones")`, `NextContractId`, and `GovernedParameters`. |
-//! | `dispute` | Pure dispute payout arithmetic and final-status selection for dispute resolution. | None directly; root dispute entrypoints update `DataKey::Contract(contract_id)`. |
+//! | `dispute` | Dispute payout arithmetic, final-status selection, and arbiter dispute-split config storage. | `DataKey::DisputeConfigKey`; root dispute entrypoints update `DataKey::Contract(contract_id)`. |
 //! | `governance` | Admin-controlled protocol fee, governed parameter, readiness, and admin-rotation entrypoints. | `DataKey::Admin`, `ProtocolFeeBps`, `PendingAdmin`, `GovernedParameters`, and `ReadinessChecklist`. |
 //!
 //! Generate this map with `cargo doc -p escrow --no-deps` and open
@@ -83,10 +83,10 @@ pub use ttl::{ADMIN_ROTATION_MIN_DELAY_LEDGERS, PENDING_MIGRATION_TTL_LEDGERS};
 // `DisputeResolution` and `DisputeSplit` are defined once in `types.rs` and
 // re-exported here; `dispute.rs` uses them via `crate::DisputeResolution`.
 pub use types::{
-    Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
-    DisputeConfig, DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone,
-    MilestoneApprovals, MilestoneSummary, PendingAdminProposal, ReadinessChecklist,
-    ReleaseAuthorization, Reputation, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode, DisputeConfig,
+    DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
+    MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
+    ReputationConfig, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -456,8 +456,7 @@ impl Escrow {
             .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
         admin.require_auth();
 
-        if freelancer_bps > 10_000 || client_bps > 10_000 || freelancer_bps + client_bps != 10_000
-        {
+        if freelancer_bps > 10_000 || client_bps > 10_000 || freelancer_bps + client_bps != 10_000 {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
@@ -1709,6 +1708,82 @@ impl Escrow {
 
     // ── Reputation ───────────────────────────────────────────────────────────
 
+    /// Returns the current reputation validation parameters (rating bounds and
+    /// comment-length cap).
+    ///
+    /// If no configuration has been stored yet, returns the protocol default:
+    /// `min_rating = 1`, `max_rating = 5`, `max_comment_bytes = 200`.
+    pub fn get_reputation_config(env: Env) -> ReputationConfig {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReputationConfigKey)
+            .unwrap_or_default()
+    }
+
+    /// Admin-only setter for the reputation validation parameters enforced by
+    /// `issue_reputation`.
+    ///
+    /// # Bounds
+    /// * `min_rating` must be at least `1`.
+    /// * `max_rating` must be greater than or equal to `min_rating` and at
+    ///   most `10`.
+    /// * `max_comment_bytes` must be at least `1` and at most `1_000`.
+    ///
+    /// Any violation is rejected with `InvalidReputationParameters` and the
+    /// stored configuration is left unchanged.
+    ///
+    /// # Errors
+    /// * `NotInitialized` if `initialize` has not been called
+    /// * `UnauthorizedRole` if `admin` is not the stored admin (enforced via
+    ///   `require_auth`, so an unauthorized caller's transaction fails before
+    ///   any state changes)
+    /// * `InvalidReputationParameters` if any bound above is violated
+    ///
+    /// # Events
+    /// On a successful update this publishes a `rep_cfg` event:
+    /// * Topics: `(Symbol "rep_cfg",)`
+    /// * Data: `(old_config: ReputationConfig, new_config: ReputationConfig, admin: Address, timestamp: u64)`
+    pub fn set_reputation_config(
+        env: Env,
+        min_rating: u32,
+        max_rating: u32,
+        max_comment_bytes: u32,
+    ) -> bool {
+        Self::require_initialized(&env);
+
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+        admin.require_auth();
+
+        if min_rating < 1
+            || max_rating < min_rating
+            || max_rating > 10
+            || max_comment_bytes < 1
+            || max_comment_bytes > 1_000
+        {
+            env.panic_with_error(Error::InvalidReputationParameters);
+        }
+
+        let old_config = Self::get_reputation_config(env.clone());
+        let new_config = ReputationConfig {
+            min_rating,
+            max_rating,
+            max_comment_bytes,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReputationConfigKey, &new_config);
+
+        env.events().publish(
+            (Symbol::new(&env, "rep_cfg"),),
+            (old_config, new_config, admin, env.ledger().timestamp()),
+        );
+        true
+    }
+
     /// Issues reputation credit for a completed contract.
     ///
     /// # Comment length
@@ -1722,9 +1797,10 @@ impl Escrow {
     /// * `ContractNotFound` - If contract doesn't exist
     /// * `UnauthorizedRole` - If caller is not the stored client
     /// * `FreelancerMismatch` - If `freelancer` does not match the stored freelancer
-    /// * `InvalidRating` - If rating is not in [1, 5]
+    /// * `InvalidRating` - If rating is outside the configured `[min_rating, max_rating]`
+    ///   range (see `get_reputation_config`/`set_reputation_config`; defaults to [1, 5])
     /// * `EmptyComment` - If comment is 0 bytes
-    /// * `CommentTooLong` - If comment exceeds 200 bytes
+    /// * `CommentTooLong` - If comment exceeds the configured `max_comment_bytes` (default 200)
     /// * `NotCompleted` - If contract status is not `Completed`
     /// * `ReputationAlreadyIssued` - If reputation was already issued
     /// * `SelfRating` - If client and freelancer are the same address
@@ -1732,7 +1808,7 @@ impl Escrow {
     /// # Security
     /// * Pause/emergency gate runs BEFORE contract state read so paused
     ///   contracts cannot have reputation mutated while paused.
-    /// * The 200-byte cap prevents unbounded on-chain storage growth.
+    /// * The comment-byte cap prevents unbounded on-chain storage growth.
     pub fn issue_reputation(
         env: Env,
         contract_id: u32,
@@ -1752,7 +1828,9 @@ impl Escrow {
             env.panic_with_error(Error::UnauthorizedRole);
         }
 
-        if rating < MIN_RATING || rating > MAX_RATING {
+        let reputation_config = Self::get_reputation_config(env.clone());
+
+        if rating < reputation_config.min_rating || rating > reputation_config.max_rating {
             env.panic_with_error(Error::InvalidRating);
         }
 
@@ -1760,7 +1838,7 @@ impl Escrow {
             env.panic_with_error(Error::EmptyComment);
         }
 
-        if comment.len() > MAX_COMMENT_BYTES {
+        if comment.len() > reputation_config.max_comment_bytes {
             env.panic_with_error(Error::CommentTooLong);
         }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -84,9 +84,9 @@ pub use ttl::{ADMIN_ROTATION_MIN_DELAY_LEDGERS, PENDING_MIGRATION_TTL_LEDGERS};
 // re-exported here; `dispute.rs` uses them via `crate::DisputeResolution`.
 pub use types::{
     Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
-    DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
-    MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
-    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    DisputeConfig, DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone,
+    MilestoneApprovals, MilestoneSummary, PendingAdminProposal, ReadinessChecklist,
+    ReleaseAuthorization, Reputation, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -437,7 +437,10 @@ impl Escrow {
         }
     }
 
-    /// Returns the current arbiter refund split configuration.
+    /// Returns the current arbiter dispute-split configuration.
+    ///
+    /// If no configuration has been stored yet, returns the protocol default:
+    /// `partial_refund_freelancer_bps = 3000`, `partial_refund_client_bps = 7000`.
     pub fn get_arbiter_config(env: Env) -> DisputeConfig {
         dispute::get_dispute_config(&env).unwrap_or_default()
     }
@@ -2375,14 +2378,6 @@ impl Escrow {
         );
 
         true
-    }
-
-    /// Returns the current arbiter dispute-split configuration.
-    ///
-    /// If no configuration has been stored yet, returns the protocol default:
-    /// `partial_refund_freelancer_bps = 3000`, `partial_refund_client_bps = 7000`.
-    pub fn get_arbiter_config(env: Env) -> DisputeConfig {
-        dispute::get_dispute_config(&env).unwrap_or_default()
     }
 }
 

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -9,6 +9,8 @@ use crate::{
 
 // --- Submodules ---
 mod approval_expiry;
+mod arbiter_config_setter;
+mod arbiter_config_view;
 mod cancel_contract;
 mod client_migration;
 mod create_contract_bounds;

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -26,6 +26,7 @@ mod refund;
 mod release;
 mod release_authorization;
 mod reputation;
+mod reputation_config_setter;
 mod rollback;
 mod security;
 mod ttl_tests;

--- a/contracts/escrow/src/test/reputation_config_setter.rs
+++ b/contracts/escrow/src/test/reputation_config_setter.rs
@@ -1,0 +1,270 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Events as _, Address, Env, String, Symbol, TryFromVal, Val};
+
+use crate::{Error, Escrow, EscrowClient, ReputationConfig};
+
+use super::complete_contract;
+
+fn setup(env: &Env) -> (EscrowClient<'_>, Address) {
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &escrow_address);
+    let admin = Address::generate(env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (client, admin)
+}
+
+// ── get_reputation_config defaults ──────────────────────────────────────────
+
+#[test]
+fn returns_default_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_address);
+
+    let config = client.get_reputation_config();
+    assert_eq!(config, ReputationConfig::default());
+}
+
+#[test]
+fn returns_default_after_init_before_set() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let config = client.get_reputation_config();
+    assert_eq!(config, ReputationConfig::default());
+    assert_eq!(config.min_rating, 1);
+    assert_eq!(config.max_rating, 5);
+    assert_eq!(config.max_comment_bytes, 200);
+}
+
+// ── valid set ────────────────────────────────────────────────────────────────
+
+#[test]
+fn valid_set_stores_and_readable() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    assert!(client.set_reputation_config(&2u32, &8u32, &300u32));
+
+    let config = client.get_reputation_config();
+    assert_eq!(config.min_rating, 2);
+    assert_eq!(config.max_rating, 8);
+    assert_eq!(config.max_comment_bytes, 300);
+}
+
+#[test]
+fn valid_set_at_exact_ceilings_accepted() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // min_rating floor (1), max_rating ceiling (10), max_comment_bytes ceiling (1_000).
+    assert!(client.set_reputation_config(&1u32, &10u32, &1_000u32));
+
+    let config = client.get_reputation_config();
+    assert_eq!(config.min_rating, 1);
+    assert_eq!(config.max_rating, 10);
+    assert_eq!(config.max_comment_bytes, 1_000);
+}
+
+#[test]
+fn valid_set_allows_equal_min_and_max_rating() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // A single-point scale (min == max) is a degenerate but internally
+    // consistent range and must not be rejected.
+    assert!(client.set_reputation_config(&3u32, &3u32, &50u32));
+
+    let config = client.get_reputation_config();
+    assert_eq!(config.min_rating, 3);
+    assert_eq!(config.max_rating, 3);
+}
+
+// ── bounds rejections ───────────────────────────────────────────────────────
+
+#[test]
+fn min_rating_zero_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let result = client.try_set_reputation_config(&0u32, &5u32, &200u32);
+    super::assert_contract_error(result, Error::InvalidReputationParameters);
+}
+
+#[test]
+fn max_rating_below_min_rating_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let result = client.try_set_reputation_config(&5u32, &4u32, &200u32);
+    super::assert_contract_error(result, Error::InvalidReputationParameters);
+}
+
+#[test]
+fn max_rating_over_ceiling_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let result = client.try_set_reputation_config(&1u32, &11u32, &200u32);
+    super::assert_contract_error(result, Error::InvalidReputationParameters);
+}
+
+#[test]
+fn max_comment_bytes_zero_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let result = client.try_set_reputation_config(&1u32, &5u32, &0u32);
+    super::assert_contract_error(result, Error::InvalidReputationParameters);
+}
+
+#[test]
+fn max_comment_bytes_over_ceiling_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let result = client.try_set_reputation_config(&1u32, &5u32, &1_001u32);
+    super::assert_contract_error(result, Error::InvalidReputationParameters);
+}
+
+#[test]
+fn default_unchanged_if_set_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let _ = client.try_set_reputation_config(&0u32, &5u32, &200u32);
+
+    let config = client.get_reputation_config();
+    assert_eq!(config, ReputationConfig::default());
+}
+
+// ── non-admin rejection ──────────────────────────────────────────────────────
+
+#[test]
+fn non_admin_rejected() {
+    let env = Env::default();
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_address);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Override mock to only allow the attacker's auth, not admin's.
+    let attacker = Address::generate(&env);
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &attacker,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &escrow_address,
+            fn_name: "set_reputation_config",
+            args: soroban_sdk::vec![&env, 2u32.into(), 8u32.into(), 300u32.into()],
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_set_reputation_config(&2u32, &8u32, &300u32);
+    assert!(result.is_err());
+
+    // Storage must remain untouched by the rejected call.
+    let config = client.get_reputation_config();
+    assert_eq!(config, ReputationConfig::default());
+}
+
+// ── event emission ───────────────────────────────────────────────────────────
+
+#[test]
+fn event_emitted_on_valid_set() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    client.set_reputation_config(&2u32, &8u32, &300u32);
+
+    let events = env.events().all();
+    let has_rep_cfg = events.iter().any(|e| {
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or(Val::VOID))
+            .ok()
+            .as_deref()
+            == Some(&Symbol::new(&env, "rep_cfg"))
+    });
+    assert!(has_rep_cfg, "expected rep_cfg event to be emitted");
+}
+
+#[test]
+fn no_event_emitted_when_set_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let _ = client.try_set_reputation_config(&0u32, &5u32, &200u32);
+
+    let events = env.events().all();
+    let has_rep_cfg = events.iter().any(|e| {
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or(Val::VOID))
+            .ok()
+            .as_deref()
+            == Some(&Symbol::new(&env, "rep_cfg"))
+    });
+    assert!(
+        !has_rep_cfg,
+        "rep_cfg event must not be emitted on a rejected set"
+    );
+}
+
+// ── issue_reputation actually enforces the configured bounds ────────────────
+
+#[test]
+fn issue_reputation_uses_updated_rating_bounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_address);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Narrow the rating scale to [3, 4]; the old default of 1 must now be rejected.
+    assert!(client.set_reputation_config(&3u32, &4u32, &200u32));
+
+    let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
+
+    let comment = String::from_str(&env, "great work");
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &1u32, &comment);
+    super::assert_contract_error(result, Error::InvalidRating);
+}
+
+#[test]
+fn issue_reputation_accepts_rating_within_updated_bounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_address);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert!(client.set_reputation_config(&3u32, &4u32, &200u32));
+
+    let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
+
+    let comment = String::from_str(&env, "great work");
+    assert!(client.issue_reputation(&contract_id, &client_addr, &4u32, &comment));
+}
+
+#[test]
+fn issue_reputation_uses_updated_comment_byte_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_address);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Shrink the comment cap to 5 bytes; a 10-byte comment must now be rejected
+    // even though it was well within the original 200-byte default.
+    assert!(client.set_reputation_config(&1u32, &5u32, &5u32));
+
+    let (client_addr, _freelancer_addr, contract_id) = complete_contract(&env, &client);
+
+    let comment = String::from_str(&env, "0123456789");
+    let result = client.try_issue_reputation(&contract_id, &client_addr, &5u32, &comment);
+    super::assert_contract_error(result, Error::CommentTooLong);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -93,6 +93,8 @@ pub enum DataKey {
     DisputeRollback(u32),
     // Dispute / arbiter configuration
     DisputeConfigKey,
+    // Reputation configuration
+    ReputationConfigKey,
 }
 
 /// Canonical contract error type for all entrypoint-facing errors.
@@ -200,6 +202,8 @@ pub enum Error {
     RollbackNotAllowed = 54,
     /// Contract or milestone state changed after the rollback point was recorded.
     RollbackStateChanged = 55,
+    /// The provided reputation parameters are out of the allowed bounds.
+    InvalidReputationParameters = 56,
 }
 
 /// Contract lifecycle states
@@ -328,6 +332,36 @@ pub struct Reputation {
     pub completed_contracts: i128,
     pub total_rating: i128,
     pub last_rating: i128,
+}
+
+/// Runtime-configurable reputation validation parameters, stored under
+/// [`DataKey::ReputationConfigKey`].
+///
+/// These were compile-time constants (`MIN_RATING`, `MAX_RATING`,
+/// `MAX_COMMENT_BYTES`) until issue #1119 added
+/// `Escrow::set_reputation_config`, which lets the admin retune them within
+/// bounds without redeploying the contract. `issue_reputation` reads this
+/// config (falling back to [`ReputationConfig::default`], which matches the
+/// original constants) instead of the raw constants directly.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReputationConfig {
+    /// Minimum valid rating (inclusive).
+    pub min_rating: u32,
+    /// Maximum valid rating (inclusive).
+    pub max_rating: u32,
+    /// Maximum byte length of a reputation feedback comment (inclusive).
+    pub max_comment_bytes: u32,
+}
+
+impl Default for ReputationConfig {
+    fn default() -> Self {
+        ReputationConfig {
+            min_rating: 1,
+            max_rating: 5,
+            max_comment_bytes: 200,
+        }
+    }
 }
 
 // ── Dispute Resolution ───────────────────────────────────────────────────────

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -91,6 +91,8 @@ pub enum DataKey {
     // Settlement token
     SettlementToken,
     DisputeRollback(u32),
+    // Dispute / arbiter configuration
+    DisputeConfigKey,
 }
 
 /// Canonical contract error type for all entrypoint-facing errors.
@@ -355,6 +357,28 @@ impl DisputeResolution {
             Self::PartialRefund => 1,
             Self::FullPayout => 2,
             Self::Split(_) => 3,
+        }
+    }
+}
+
+/// Configuration for the arbiter's partial-refund split, stored under
+/// [`DataKey::DisputeConfigKey`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeConfig {
+    /// Share of remaining funds allocated to the freelancer in partial refunds
+    /// (basis points, `3000` = 30%).
+    pub partial_refund_freelancer_bps: u32,
+    /// Share of remaining funds allocated to the client in partial refunds
+    /// (basis points, `7000` = 70%).
+    pub partial_refund_client_bps: u32,
+}
+
+impl Default for DisputeConfig {
+    fn default() -> Self {
+        DisputeConfig {
+            partial_refund_freelancer_bps: 3000,
+            partial_refund_client_bps: 7000,
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1119. 

Reputation validation parameters (rating bounds, comment-byte cap) were fixed at init as compile-time constants. This adds an admin-gated setter with bounds validation.

- `ReputationConfig { min_rating, max_rating, max_comment_bytes }`, stored under `DataKey::ReputationConfigKey`, defaulting to the original `1 / 5 / 200`.
- `get_reputation_config()` — read-only, returns the default before any set.
- `set_reputation_config(min_rating, max_rating, max_comment_bytes)` — admin-only (`require_auth`), validates `min_rating >= 1`, `min_rating <= max_rating <= 10`, `1 <= max_comment_bytes <= 1_000`; rejects violations with a new typed error `Error::InvalidReputationParameters` and leaves the stored config untouched. Emits a `rep_cfg` event with `(old_config, new_config, admin, timestamp)` on success.
- `issue_reputation` now reads the configured bounds instead of the raw `MIN_RATING`/`MAX_RATING`/`MAX_COMMENT_BYTES` constants, so the setter actually changes enforced behavior, not just stored config.

**Depends on #`<fix/restore-merge-regression PR>`** — this branch is based on a separate fix restoring `DisputeConfig`/deduping `get_arbiter_config` that a bad merge had broken on `main`; that PR should land first (or this branch rebased once it does).

