### PR TITLE
refactor(tests): merge duplicate participant index pagination modules

### DIFF
--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -21,6 +21,7 @@ mod input_sanitization_amounts;
 mod input_sanitization_identities;
 mod mainnet_readiness;
 mod milestones_events;
+mod participant_index_pagination;
 mod pause_controls;
 mod persistence;
 mod refund;

--- a/contracts/escrow/src/test/pagination_participant_index.rs
+++ b/contracts/escrow/src/test/pagination_participant_index.rs
@@ -1,4 +1,0 @@
-#![cfg(test)]
-// Deprecated module retained for compatibility.
-// Participant index pagination tests are implemented in `participant_index_pagination.rs`.
-

--- a/contracts/escrow/src/test/participant_index_pagination.rs
+++ b/contracts/escrow/src/test/participant_index_pagination.rs
@@ -1,11 +1,18 @@
-use super::{default_milestones, generated_participants, register_client};
+//! Tests for participant index pagination in the escrow contract.
+//!
+//! This module verifies listing contracts by participant address for both client (role 0)
+//! and freelancer (role 1) roles, ensuring pagination edge cases (empty pages, offset past end,
+//! oversized limits, zero limit) and TTL extension routines operate as expected.
 
+use super::{default_milestones, generated_participants, register_client};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
+/// Helper to generate client and freelancer addresses for test setups.
 fn make_client_freelancer(env: &Env) -> (Address, Address) {
     generated_participants(env)
 }
 
+/// Tests that querying an empty participant index returns an empty vector for both client and freelancer roles.
 #[test]
 fn participant_index_empty_returns_empty_page() {
     let env = Env::default();
@@ -14,14 +21,16 @@ fn participant_index_empty_returns_empty_page() {
 
     let participant = Address::generate(&env);
 
+    // Client role (0u8)
     let page_client = client.list_contracts_by_participant(&participant, &0u8, &0u32, &10u32);
     assert_eq!(page_client.len(), 0);
 
-    let page_freelancer =
-        client.list_contracts_by_participant(&participant, &1u8, &0u32, &10u32);
+    // Freelancer role (1u8)
+    let page_freelancer = client.list_contracts_by_participant(&participant, &1u8, &0u32, &10u32);
     assert_eq!(page_freelancer.len(), 0);
 }
 
+/// Tests participant contract indexing, role filtering, offset bounds, and limit capping.
 #[test]
 fn participant_index_client_and_freelancer_lists_are_correct_and_paginated() {
     let env = Env::default();
@@ -31,7 +40,6 @@ fn participant_index_client_and_freelancer_lists_are_correct_and_paginated() {
     let (client1, freelancer1) = make_client_freelancer(&env);
     let (client2, freelancer2) = make_client_freelancer(&env);
 
-    // Create two contracts.
     let milestones = default_milestones(&env);
 
     let id1 = escrow.create_contract(
@@ -60,12 +68,91 @@ fn participant_index_client_and_freelancer_lists_are_correct_and_paginated() {
     assert_eq!(page.len(), 1);
     assert_eq!(page.get(0), id2);
 
-    // start out of range -> empty
+    // Start out of range (offset past end) -> returns empty page.
     let page = escrow.list_contracts_by_participant(&client1, &0u8, &5u32, &10u32);
     assert_eq!(page.len(), 0);
 
-    // limit cap behavior: request more than available; should return remaining only.
+    // Limit cap behavior: requesting limit (1000) larger than available items returns remaining items.
     let page = escrow.list_contracts_by_participant(&client1, &0u8, &0u32, &1000u32);
     assert_eq!(page.len(), 1);
 }
 
+/// Tests pagination edge cases including zero limit, offset equal to total length, and multi-page iteration.
+#[test]
+fn participant_index_pagination_edge_cases_and_multi_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (client, freelancer) = make_client_freelancer(&env);
+    let milestones = default_milestones(&env);
+
+    // Create 5 contracts for the same client.
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        let id = escrow.create_contract(
+            &client,
+            &freelancer,
+            &None,
+            &milestones,
+            &crate::types::ReleaseAuthorization::ClientOnly,
+        );
+        ids.push_back(id);
+    }
+
+    // Zero limit request -> empty page.
+    let page_zero = escrow.list_contracts_by_participant(&client, &0u8, &0u32, &0u32);
+    assert_eq!(page_zero.len(), 0);
+
+    // Page 1: offset 0, limit 2 -> first 2 contracts.
+    let page1 = escrow.list_contracts_by_participant(&client, &0u8, &0u32, &2u32);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0), ids.get(0));
+    assert_eq!(page1.get(1), ids.get(1));
+
+    // Page 2: offset 2, limit 2 -> next 2 contracts.
+    let page2 = escrow.list_contracts_by_participant(&client, &0u8, &2u32, &2u32);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0), ids.get(2));
+    assert_eq!(page2.get(1), ids.get(3));
+
+    // Page 3: offset 4, limit 2 -> last 1 contract.
+    let page3 = escrow.list_contracts_by_participant(&client, &0u8, &4u32, &2u32);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3.get(0), ids.get(4));
+
+    // Offset equal to total count (5) -> empty page.
+    let page_exact_end = escrow.list_contracts_by_participant(&client, &0u8, &5u32, &2u32);
+    assert_eq!(page_exact_end.len(), 0);
+
+    // Offset strictly past total count (10) -> empty page.
+    let page_past_end = escrow.list_contracts_by_participant(&client, &0u8, &10u32, &2u32);
+    assert_eq!(page_past_end.len(), 0);
+}
+
+/// Tests that `ttl::extend_participant_contract_index_ttl` functions properly when invoked on participant keys.
+#[test]
+fn participant_index_ttl_extension_helper_exercised() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let escrow = register_client(&env);
+
+    let (client, freelancer) = make_client_freelancer(&env);
+    let milestones = default_milestones(&env);
+
+    let id = escrow.create_contract(
+        &client,
+        &freelancer,
+        &None,
+        &milestones,
+        &crate::types::ReleaseAuthorization::ClientOnly,
+    );
+
+    let page = escrow.list_contracts_by_participant(&client, &0u8, &0u32, &10u32);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0), id);
+
+    // Confirm ttl::extend_participant_contract_index_ttl remains exercised
+    let key = crate::DataKey::Contract(id);
+    crate::ttl::extend_participant_contract_index_ttl(&env, &key);
+}

--- a/tests/abi_reference_doc_test.rs
+++ b/tests/abi_reference_doc_test.rs
@@ -5,7 +5,13 @@ fn abi_reference_document_lists_current_public_entrypoints() {
     // Integration test lives under contracts/escrow; ABI docs are at repo root.
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut root = manifest_dir.to_path_buf();
-    while !root.join("docs").join("escrow").join("abi-reference.md").exists() && root.parent().is_some() {
+    while !root
+        .join("docs")
+        .join("escrow")
+        .join("abi-reference.md")
+        .exists()
+        && root.parent().is_some()
+    {
         root = root.parent().unwrap().to_path_buf();
     }
     let doc_path = root.join("docs").join("escrow").join("abi-reference.md");


### PR DESCRIPTION
## Summary
Resolves #728

This PR merges the duplicate participant index pagination test modules (`pagination_participant_index.rs` and `participant_index_pagination.rs`) under `contracts/escrow/src/test/` into a single, comprehensive suite in `participant_index_pagination.rs`, eliminating maintenance duplication and drift.

## Changes Made
- **Consolidated Tests**: Merged all assertions into [`contracts/escrow/src/test/participant_index_pagination.rs`](file:///c:/Users/olamide/Desktop/talenttrust/contracts/escrow/src/test/participant_index_pagination.rs).
- **Deleted Redundant File**: Removed `contracts/escrow/src/test/pagination_participant_index.rs`.
- **Module Registration**: Registered `mod participant_index_pagination;` in [`contracts/escrow/src/test/mod.rs`](file:///c:/Users/olamide/Desktop/talenttrust/contracts/escrow/src/test/mod.rs).
- **Edge Cases Covered**:
  - Empty page queries for both client (`0u8`) and freelancer (`1u8`) roles.
  - Offset out of bounds and offset equal to total items.
  - Limits exceeding available index count (`limit = 1000`) and zero limit requests (`limit = 0`).
  - Multi-page iteration across contract batches.
  - Exercised `ttl::extend_participant_contract_index_ttl` helper.
- **Documentation**: Added NatSpec-style `///` doc comments for test functions and helpers.
