### PR TITLE
docs(authorization): document the model and invariants

### DIFF
--- a/docs/escrow/authorization.md
+++ b/docs/escrow/authorization.md
@@ -1,345 +1,461 @@
-# Release Authorization and Approval Lifecycle
+# Authorization Model and Invariants
 
-This document provides an authoritative guide to the escrow contract's release authorization modes and the approval-then-release flow. It defines who may approve milestones, who may trigger releases, how many approvals each mode requires, and how TTL-based approval expiry interacts with release operations.
+This document is the authoritative reference for the escrow contract's authorization model. It covers every principal role, the per-entrypoint authorization rules, the four `ReleaseAuthorization` modes and their approval lifecycle, the invariants the model upholds, and a worked end-to-end example an auditor can follow.
 
-## Overview
+**Source files:** `contracts/escrow/src/types.rs`, `contracts/escrow/src/approvals.rs`, `contracts/escrow/src/release.rs`, `contracts/escrow/src/deposit.rs`, `contracts/escrow/src/finalize.rs`, `contracts/escrow/src/create_contract.rs`, `contracts/escrow/src/governance.rs`, `contracts/escrow/src/lib.rs`
 
-The escrow contract supports four `ReleaseAuthorization` modes that control who can approve milestone releases and who can execute the release transaction. These modes are defined in `contracts/escrow/src/types.rs` and enforced across `contracts/escrow/src/approvals.rs` and `release_milestone` in `contracts/escrow/src/lib.rs`.
+---
 
-## ReleaseAuthorization Modes
+## 1. Principal Roles
 
-The four authorization modes are:
+The contract recognizes four principal roles. Each maps to a stored address on the `Contract` struct or on the global admin slot.
 
-| Mode | Enum Value | Description |
-|------|------------|-------------|
-| `ClientOnly` | 0 | Only the client can approve and release |
-| `ClientAndArbiter` | 1 | Either the client or arbiter can approve and release |
-| `ArbiterOnly` | 2 | Only the arbiter can approve and release |
-| `MultiSig` | 3 | Both client and freelancer must approve; either can release |
+| Role | Storage field | Scope | Notes |
+|------|--------------|-------|-------|
+| **Admin** | `DataKey::Admin` (persistent) | Protocol-wide | Set once by `initialize`; can be rotated via a two-step timelock |
+| **Client** | `Contract.client` | Per-contract | Set at `create_contract`; may change via `propose_client_migration` / `accept_client_migration` |
+| **Freelancer** | `Contract.freelancer` | Per-contract | Set at `create_contract`; immutable |
+| **Arbiter** | `Contract.arbiter` (optional) | Per-contract | Required for `ArbiterOnly` and `ClientAndArbiter` modes; must be distinct from client and freelancer |
 
-## Authorization Matrix
+The arbiter field is `Option<Address>`. An absent arbiter means the contract cannot use arbiter-gated authorization modes. Attempting to create a contract with `ArbiterOnly` or `ClientAndArbiter` mode without providing an arbiter panics with `MissingArbiter`.
 
-Per-mode authorization rules for approval and release operations:
+---
 
-### ClientOnly Mode
+## 2. Entrypoint Authorization Table
 
-| Aspect | Rule |
-|--------|------|
-| **Allowed Approvers** | Client only |
-| **Required Approvals** | Client approval (1 signature) |
-| **Allowed Release Callers** | Client only |
-| **Approval Check Logic** | `approvals.client_approved` must be `true` |
-| **Failure Error Codes** | `UnauthorizedRole` (if non-client attempts), `AlreadyApproved` (duplicate), `InsufficientApprovals` (missing) |
+Every state-changing entrypoint that can move funds or mutate contract state is listed below. "Required signer" is the address the Soroban host checks via `require_auth()`. Entrypoints not listed here are read-only and require no auth.
 
-### ArbiterOnly Mode
+### Admin-gated entrypoints
 
-| Aspect | Rule |
-|--------|------|
-| **Allowed Approvers** | Arbiter only |
-| **Required Approvals** | Arbiter approval (1 signature) |
-| **Allowed Release Callers** | Arbiter only |
-| **Approval Check Logic** | `approvals.arbiter_approved` must be `true` |
-| **Failure Error Codes** | `UnauthorizedRole` (if non-arbiter attempts), `AlreadyApproved` (duplicate), `InsufficientApprovals` (missing) |
-| **Contract Creation Requirement** | Arbiter must be provided (enforced by `MissingArbiter` error) |
+All of these require the address stored under `DataKey::Admin` to have authorized the call.
 
-### ClientAndArbiter Mode
+| Entrypoint | Required signer | Additional preconditions |
+|-----------|----------------|--------------------------|
+| `initialize(admin)` | `admin` (the passed argument) | Fails with `AlreadyInitialized` if already run |
+| `bind_settlement_token(admin, token)` | `admin` == stored admin | Contract must be initialized; token must not already be bound; token must pass SAC probe |
+| `pause()` | Stored admin | Contract must be initialized |
+| `unpause()` | Stored admin | Contract must be initialized; blocked while emergency flag is set |
+| `activate_emergency_pause()` | Stored admin | Contract must be initialized |
+| `resolve_emergency()` | Stored admin | Contract must be initialized |
+| `set_protocol_fee_bps(new_bps)` | Stored admin | Contract initialized; `new_bps ≤ 10_000` |
+| `set_governed_params(admin, fee_bps, max_stroops)` | `admin` == stored admin | Contract initialized; `fee_bps ≤ 10_000` |
+| `propose_governance_admin(proposed)` | Stored admin | Contract initialized |
+| `accept_governance_admin()` | The pending proposed admin | Timelock of `ADMIN_ROTATION_MIN_DELAY_LEDGERS` (≈ 2 days) must have elapsed since `propose_governance_admin` |
+| `cancel_governance_admin_proposal()` | Stored admin | A pending proposal must exist |
+| `withdraw_protocol_fees(admin, amount)` | Stored admin | Settlement token must be bound; `AccumulatedProtocolFees ≥ amount` |
 
-| Aspect | Rule |
-|--------|------|
-| **Allowed Approvers** | Client OR Arbiter |
-| **Required Approvals** | Either client OR arbiter approval (1 signature, OR logic) |
-| **Allowed Release Callers** | Client OR Arbiter |
-| **Approval Check Logic** | `approvals.client_approved || approvals.arbiter_approved` must be `true` |
-| **Failure Error Codes** | `UnauthorizedRole` (if freelancer attempts), `AlreadyApproved` (duplicate from same party), `InsufficientApprovals` (neither approved) |
-| **Contract Creation Requirement** | Arbiter must be provided (enforced by `MissingArbiter` error) |
+### Contract-lifecycle entrypoints
 
-### MultiSig Mode
+| Entrypoint | Required signer | Authorized role(s) | Additional preconditions |
+|-----------|----------------|--------------------|--------------------------|
+| `create_contract(client, freelancer, arbiter, milestones, mode)` | `client` | Client | Contract not paused; participants valid; milestones valid |
+| `deposit_funds(contract_id, caller, amount)` | `caller` == `contract.client` | Client only | Contract initialized, not paused; status `Created` or `PartiallyFunded`; amount ≤ remaining unfunded total |
+| `approve_milestone_release(contract_id, caller, milestone_index)` | `caller` | Mode-dependent (see §3) | Contract not paused, not finalized; status `Funded` or `PartiallyFunded`; milestone not released |
+| `release_milestone(contract_id, caller, milestone_index)` | `caller` | Mode-dependent (see §3) | Contract not paused, not finalized; status `Funded`; valid non-expired approvals present |
+| `refund_unreleased_milestones(contract_id, milestone_indices)` | `contract.client` | Client only | Contract not paused, not finalized; status `Created`, `Funded`, or `Disputed`; milestones meet deadline/overdue rules |
+| `cancel_contract(contract_id, client)` | `client` == `contract.client` | Client only | Contract not paused, not finalized; status `Created` or `Funded`; `released_amount == 0` |
+| `finalize_contract(contract_id, finalizer)` | `finalizer` | Client, freelancer, or arbiter | Contract not paused; status `Completed` or `Disputed`; not already finalized |
+| `issue_reputation(contract_id, caller, rating, comment)` | `caller` == `contract.client` | Client only | Contract not paused; status `Completed`; reputation not yet issued; rating in [1,5] |
+| `propose_client_migration(contract_id, current_client, new_client)` | `current_client` == `contract.client` | Current client | Contract not paused |
+| `accept_client_migration(contract_id, new_client)` | `new_client` | Proposed new client | Contract not paused; live pending migration must exist |
+| `resolve_dispute(contract_id, arbiter, resolution)` | `arbiter` | Arbiter only | Contract not paused; status `Disputed`; arbiter must be set and match |
 
-| Aspect | Rule |
-|--------|------|
-| **Allowed Approvers** | Client AND Freelancer |
-| **Required Approvals** | Both client AND freelancer approval (2 signatures, AND logic) |
-| **Allowed Release Callers** | Client OR Freelancer (either can trigger release after both approve) |
-| **Approval Check Logic** | `approvals.client_approved && approvals.freelancer_approved` must be `true` |
-| **Failure Error Codes** | `UnauthorizedRole` (if arbiter attempts), `AlreadyApproved` (duplicate from same party), `InsufficientApprovals` (one or both missing) |
-| **Contract Creation Requirement** | Arbiter optional (not required) |
+### Global gate applied before all state-changing entrypoints
 
-**Note on MultiSig Inconsistency**: The MultiSig mode requires both client and freelancer to approve, but allows either party to trigger the release. This differs from the typical multi-signature pattern where approval and release are the same operation. The current implementation separates approval (recording intent) from release (executing the transfer), which enables the release caller to be different from the approvers.
+Before any of the above entrypoints reads or mutates contract state, `require_not_paused` checks both the `Paused` flag and the `Emergency` flag. If either is `true`, the call panics with `ContractPaused` or `EmergencyActive` respectively. This gate runs before `require_auth()` on the participant for lifecycle entrypoints, meaning a paused contract cannot be interacted with even by authorized principals.
 
-## Approval Lifecycle
+---
 
-The approval-then-release flow follows this sequence:
+## 3. ReleaseAuthorization — Data Model
 
-### 1. Approve Milestone (`approve_milestone_release`)
-
-**Entry Point**: `contracts/escrow/src/lib.rs::approve_milestone_release` → `contracts/escrow/src/approvals.rs::approve_milestone`
-
-**Purpose**: Records a party's approval for a specific milestone release.
-
-**Prerequisites**:
-- Contract must exist and be in `Funded` state
-- Milestone index must be valid
-- Milestone must not already be released
-- Caller must be authenticated via `require_auth()`
-- Caller must be authorized based on the `ReleaseAuthorization` mode
-
-**Storage**: Approvals are stored in temporary storage under `DataKey::MilestoneApprovals(contract_id, milestone_index)` with the following structure:
 ```rust
+// contracts/escrow/src/types.rs
+
+pub enum ReleaseAuthorization {
+    ClientOnly      = 0,
+    ClientAndArbiter = 1,
+    ArbiterOnly     = 2,
+    MultiSig        = 3,
+}
+
 pub struct MilestoneApprovals {
-    pub client_approved: bool,
+    pub client_approved:    bool,
     pub freelancer_approved: bool,
-    pub arbiter_approved: bool,
+    pub arbiter_approved:   bool,
 }
 ```
 
-**TTL Configuration**:
-- Initial TTL: `PENDING_APPROVAL_TTL_LEDGERS` = 120,960 ledgers (~7 days at ~5s per ledger)
-- Bump threshold: `PENDING_APPROVAL_BUMP_THRESHOLD` = 17,280 ledgers (~1 day)
-- TTL is extended to the full `PENDING_APPROVAL_TTL_LEDGERS` whenever the entry is accessed above the bump threshold
+`ReleaseAuthorization` is set once at `create_contract` and stored on `Contract.release_authorization`. It controls two independent checks for every milestone release:
 
-**Error Codes**:
-- `ContractNotFound`: Contract does not exist
-- `InvalidState`: Contract not in `Funded` state
-- `IndexOutOfBounds`: Milestone index invalid
-- `MilestoneAlreadyReleased`: Milestone already released
-- `UnauthorizedRole`: Caller not authorized to approve for this mode
-- `AlreadyApproved`: Caller already approved this milestone
+1. **Approval gate** (`approve_milestone_release`): which principals may record approval.
+2. **Release gate** (`release_milestone`): which principals may call the release entrypoint after approvals are satisfied.
 
-**Security Properties**:
-- Caller authentication enforced via `require_auth()`
-- Duplicate approvals from the same party are rejected
-- Approvals auto-expire after TTL elapses (Soroban temporary storage eviction)
-- Fail-closed: missing or expired approvals prevent release
+### Mode matrix
 
-### 2. Check Approvals (`check_approvals`)
+| Mode | Arbiter required at creation | Who may approve | How many approvals needed | Who may call `release_milestone` |
+|------|------------------------------|----------------|--------------------------|----------------------------------|
+| `ClientOnly` | No | Client | 1 (client) | Client |
+| `ClientAndArbiter` | **Yes** | Client or arbiter | 1 (either) | Client or arbiter |
+| `ArbiterOnly` | **Yes** | Arbiter | 1 (arbiter) | Arbiter |
+| `MultiSig` | No | Client and freelancer | 2 (both must approve) | Client **or** freelancer |
 
-**Entry Point**: `contracts/escrow/src/approvals.rs::check_approvals`
+The `ClientAndArbiter` check uses OR logic: a single approval from either the client or the arbiter satisfies the check. This differs from `MultiSig`, which requires AND logic (both client and freelancer).
 
-**Purpose**: Validates that sufficient approvals exist for a milestone release.
+`MultiSig` separates approval (recording intent by each party) from release (executing the transfer). After both parties have approved, either party may call `release_milestone`. This prevents either side from holding the other hostage for the final on-chain transaction.
 
-**Behavior**:
-- Loads approvals from temporary storage
-- Returns `None` if approvals don't exist or have expired (TTL elapsed)
-- Checks approval sufficiency based on `ReleaseAuthorization` mode
+### Approval sufficiency logic
 
-**Approval Sufficiency Logic**:
+Implemented in `approvals::check_approvals` (`contracts/escrow/src/approvals.rs`):
+
 ```rust
 match contract.release_authorization {
-    ReleaseAuthorization::ClientOnly => approvals.client_approved,
-    ReleaseAuthorization::ArbiterOnly => approvals.arbiter_approved,
-    ReleaseAuthorization::ClientAndArbiter => {
-        approvals.client_approved || approvals.arbiter_approved
-    }
-    ReleaseAuthorization::MultiSig => {
-        approvals.client_approved && approvals.freelancer_approved
-    }
+    ClientOnly       => approvals.client_approved,
+    ArbiterOnly      => approvals.arbiter_approved,
+    ClientAndArbiter => approvals.client_approved || approvals.arbiter_approved,
+    MultiSig         => approvals.client_approved && approvals.freelancer_approved,
 }
 ```
 
-**Error Codes**:
-- `InsufficientApprovals`: Approvals missing, insufficient, or expired
+---
 
-**Security Properties**:
-- Fail-closed: expired approvals are treated as absent
-- TTL expiry is enforced by Soroban's temporary storage (automatic eviction)
+## 4. Approval Lifecycle
 
-### 3. Release Milestone (`release_milestone`)
+### 4.1 Storage
 
-**Entry Point**: `contracts/escrow/src/lib.rs::release_milestone`
+Approvals live in Soroban **temporary storage** under `DataKey::MilestoneApprovals(contract_id, milestone_index)`. Temporary storage entries are automatically evicted by the Soroban host when their TTL reaches zero.
 
-**Purpose**: Executes the fund transfer to the freelancer for a specific milestone.
+| TTL constant | Ledgers | Wall time (≈5 s/ledger) |
+|---|---|---|
+| `PENDING_APPROVAL_TTL_LEDGERS` | 120,960 | ~7 days |
+| `PENDING_APPROVAL_BUMP_THRESHOLD` | 17,280 | ~1 day |
 
-**Prerequisites**:
-- Contract must exist and be in `Funded` state
-- Caller must be authenticated via `require_auth()`
-- Caller must be authorized to release based on the `ReleaseAuthorization` mode
-- Valid, non-expired approvals must exist (checked via `check_approvals`)
-- Milestone must not already be released or refunded
-- Sufficient funds must be available
+When an approval is recorded, the entry TTL is set to `PENDING_APPROVAL_TTL_LEDGERS`. Each subsequent write resets it. If the entry is not accessed within the bump threshold of expiry, Soroban evicts it automatically.
 
-**Release Authorization Check**:
-```rust
-match contract.release_authorization {
-    ReleaseAuthorization::ClientOnly => {
-        if !is_client { return Err(Error::UnauthorizedRole); }
-    }
-    ReleaseAuthorization::ArbiterOnly => {
-        if !is_arbiter { return Err(Error::UnauthorizedRole); }
-    }
-    ReleaseAuthorization::ClientAndArbiter => {
-        if !is_client && !is_arbiter { return Err(Error::UnauthorizedRole); }
-    }
-    ReleaseAuthorization::MultiSig => {
-        if !is_client && !is_freelancer { return Err(Error::UnauthorizedRole); }
-    }
-}
+### 4.2 Step-by-step flow
+
+```
+1. approve_milestone_release(contract_id, caller, milestone_index)
+   ├─ require_not_paused, require_not_finalized
+   ├─ caller.require_auth()
+   ├─ load Contract, validate status (Funded or PartiallyFunded)
+   ├─ validate milestone index, milestone not released
+   ├─ verify caller role vs. mode (UnauthorizedRole if invalid)
+   ├─ load or create MilestoneApprovals from temp storage
+   ├─ check for duplicate approval (AlreadyApproved if duplicate)
+   ├─ set caller's flag: client_approved / freelancer_approved / arbiter_approved
+   └─ store with TTL = PENDING_APPROVAL_TTL_LEDGERS
+
+2. release_milestone(contract_id, caller, milestone_index)
+   ├─ require_not_paused
+   ├─ caller.require_auth()
+   ├─ load Contract, require_not_finalized
+   ├─ validate status == Funded
+   ├─ verify caller role vs. mode (UnauthorizedRole if invalid)
+   ├─ load milestones, validate index, milestone not released or refunded
+   ├─ check_approvals → reads temp storage; None / insufficient → InsufficientApprovals
+   ├─ check available balance ≥ milestone.amount
+   ├─ compute protocol_fee = floor(gross × fee_bps / 10_000)
+   ├─ net_amount = gross_amount − protocol_fee
+   ├─ SAC transfer: escrow → freelancer, amount = net_amount
+   ├─ accumulate protocol_fee into AccumulatedProtocolFees
+   ├─ mark milestone.released = true, update released_amount
+   ├─ verify accounting invariant: released + refunded + accumulated_fees ≤ funded
+   ├─ clear_approvals (remove temp storage entry)
+   ├─ if all milestones released/refunded → status = Completed, grant reputation credit
+   └─ emit events
 ```
 
-**Error Codes**:
-- `ContractNotFound`: Contract does not exist
-- `InvalidState`: Contract not in `Funded` state
-- `IndexOutOfBounds`: Milestone index invalid
-- `MilestoneAlreadyReleased`: Milestone already released
-- `AlreadyRefunded`: Milestone already refunded
-- `InsufficientFunds`: Insufficient contract balance
-- `InsufficientApprovals`: Required approvals missing or expired
-- `UnauthorizedRole`: Caller not authorized to release for this mode
+### 4.3 Fail-closed properties
 
-**Side Effects**:
-- Transfers milestone amount to freelancer
-- Marks milestone as released
-- Updates contract `released_amount`
-- Accumulates protocol fees if configured
-- Transitions contract to `Completed` if all milestones released/refunded
-- Clears approval records (see below)
+- A missing approval record (never set, or TTL expired) returns `None` from `env.storage().temporary().get(...)`, which `check_approvals` maps to `InsufficientApprovals`. The call panics without moving funds.
+- Expired approvals are indistinguishable from absent approvals. Parties must re-approve if their approvals expire before the release is submitted.
+- `clear_approvals` is called immediately after the SAC transfer succeeds, inside the same transaction. A partially executed transaction cannot leave stale approvals alive.
 
-### 4. Clear Approvals (`clear_approvals`)
+---
 
-**Entry Point**: `contracts/escrow/src/approvals.rs::clear_approvals`
+## 5. Authorization Invariants
 
-**Purpose**: Removes approval records after successful release to prevent reuse.
+The following invariants must hold at all times. Each is verified by reading the source code; the test evidence column references the test module that exercises the invariant.
 
-**Behavior**:
-- Removes the `MilestoneApprovals` entry from temporary storage
-- Called automatically after successful `release_milestone`
+### I1 — Admin is initialized before any money moves
 
-**Security Properties**:
-- Prevents approval reuse across multiple releases
-- Cleans up temporary storage
-- Idempotent: safe to call multiple times
+`require_initialized` is called at the start of every money-flow entrypoint (`deposit_funds`, `release_milestone`, `cancel_contract`, `refund_unreleased_milestones`, `withdraw_protocol_fees`). Without initialization the admin slot is empty and safety rails (pause, fees) are unbound.
 
-## TTL Expiry Behavior
+**Source:** `lib.rs::require_initialized`, called unconditionally in each entrypoint.
+**Test:** `test/mainnet_readiness.rs`, `test/lifecycle.rs`
 
-### Pending Approval TTL
+### I2 — Only the stored client may deposit
 
-Pending approvals are stored in Soroban's temporary storage with a time-to-live (TTL) policy defined in `contracts/escrow/src/ttl.rs`:
+`deposit::validate_deposit` checks `caller != &contract.client` before anything else and panics with `UnauthorizedRole`. The client identity check runs before the SAC transfer so a rejected deposit cannot debit the caller.
 
-**Constants**:
-```rust
-pub const LEDGERS_PER_DAY: u32 = 17_280;
-pub const PENDING_APPROVAL_TTL_LEDGERS: u32 = LEDGERS_PER_DAY * 7;  // ~7 days
-pub const PENDING_APPROVAL_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY;   // ~1 day
+**Source:** `deposit.rs::validate_deposit` line: `if caller != &contract.client`.
+
+### I3 — Release callers are mode-restricted
+
+`release_milestone` re-checks the caller's role against `contract.release_authorization` independently of `approve_milestone_release`. Even if approvals are present in storage, an unauthorized caller cannot trigger a release.
+
+**Source:** `lib.rs::release_milestone` — the `match contract.release_authorization` block runs before `check_approvals`.
+
+### I4 — Approvals are mode-restricted at record time
+
+`approve_milestone_release` performs a role check before recording any approval. An arbiter cannot record a `client_approved = true` bit, and a freelancer cannot approve in `ClientOnly` or `ArbiterOnly` modes.
+
+**Source:** `approvals.rs::approve_milestone` — the second `match contract.release_authorization` block.
+
+### I5 — Approvals expire automatically
+
+Approval records live in temporary storage. The Soroban host evicts them after `PENDING_APPROVAL_TTL_LEDGERS` (≈7 days) if not extended. Expired approvals cannot release funds.
+
+**Source:** `ttl.rs` constants; `approvals.rs::approve_milestone` → `env.storage().temporary().extend_ttl(...)`.
+
+### I6 — Approvals are consumed on release
+
+`clear_approvals` is called unconditionally after a successful SAC transfer inside `release_milestone`. A given `(contract_id, milestone_index)` approval set can only be used once.
+
+**Source:** `lib.rs::release_milestone` → `approvals::clear_approvals(...)`.
+
+### I7 — Duplicate approvals are rejected
+
+Each flag in `MilestoneApprovals` starts `false`. If the flag is already `true` when the same principal attempts to approve again, the call panics with `AlreadyApproved`.
+
+**Source:** `approvals.rs::approve_milestone` — `if approvals.client_approved { return Err(AlreadyApproved); }` etc.
+
+### I8 — ArbiterOnly and ClientAndArbiter require a non-null arbiter
+
+`create_contract` panics with `MissingArbiter` if these modes are requested without an arbiter address. Arbiter is validated as distinct from client and freelancer (`InvalidArbiter`).
+
+**Source:** `create_contract.rs` — the `match release_authorization` guard.
+
+### I9 — Only client may cancel
+
+`cancel_contract` verifies `client != contract.client → UnauthorizedRole` before `client.require_auth()`. Cancellation is additionally restricted to contracts with `released_amount == 0` and status `Created` or `Funded`.
+
+**Source:** `lib.rs::cancel_contract`.
+
+### I10 — Only the client may issue reputation
+
+`issue_reputation` checks `caller != contract.client → UnauthorizedRole` before `caller.require_auth()`. Reputation can only be issued once per contract (`ReputationAlreadyIssued`), and only after status `Completed`.
+
+**Source:** `lib.rs::issue_reputation`.
+
+### I11 — Finalization is restricted to participants
+
+`finalize_contract` calls `require_finalizer_role` which checks that the finalizer is the stored client, freelancer, or arbiter. Any other address panics with `UnauthorizedRole`.
+
+**Source:** `finalize.rs::require_finalizer_role`.
+
+### I12 — Admin rotation enforces a timelock
+
+`accept_governance_admin` reads `pending.proposed_at_ledger` and computes `elapsed = current_ledger − proposed_at_ledger`. If `elapsed < ADMIN_ROTATION_MIN_DELAY_LEDGERS` (≈2 days), it panics with `TimelockNotElapsed`. Only after the delay may the pending admin call `accept_governance_admin` with their own `require_auth`.
+
+**Source:** `governance.rs::accept_governance_admin_impl`.
+
+### I13 — Pause gate runs before auth checks on lifecycle entrypoints
+
+`require_not_paused` is the first instruction in every state-changing lifecycle entrypoint. This prevents paused contracts from being interacted with by any principal, including the admin (the admin uses a separate pause/unpause path).
+
+**Source:** `lib.rs` — first line of `create_contract`, `deposit_funds`, `release_milestone`, `cancel_contract`, `refund_unreleased_milestones`, `issue_reputation`.
+
+### I14 — Settlement token is write-once
+
+`bind_settlement_token` checks `Self::read_settlement_token(&env).is_some()` before binding and panics with `SettlementTokenAlreadyBound` if a token is already present. This prevents substituting the custody token after contracts have been funded.
+
+**Source:** `lib.rs::bind_settlement_token`.
+
+### I15 — Accounting invariant is checked after every release
+
+After each release, the contract verifies: `released_amount + refunded_amount + accumulated_fees ≤ funded_amount`. Violation panics with `AccountingInvariantViolated` and reverts the transaction.
+
+**Source:** `lib.rs::release_milestone` — `if invariant_sum > contract.funded_amount { panic_with_error(AccountingInvariantViolated) }`.
+
+---
+
+## 6. Worked Example — MultiSig Two-Milestone Contract
+
+This example traces the full authorization sequence for a contract with two milestones and `MultiSig` release mode.
+
+### Setup
+
+| Participant | Address |
+|---|---|
+| Client | `G...CLIENT` |
+| Freelancer | `G...FREELANCER` |
+| Arbiter | none (not required for MultiSig) |
+| Mode | `MultiSig` |
+| Milestones | 500 XLM (M0), 500 XLM (M1) |
+
+### Step 1 — Admin initializes the contract
+
+```
+initialize(admin = G...ADMIN)
+  → require_auth(G...ADMIN)
+  → writes DataKey::Initialized = true, DataKey::Admin = G...ADMIN
 ```
 
-**Expiry Window**: 120,960 ledgers (~7 days at ~5s per ledger on mainnet)
+### Step 2 — Admin binds settlement token and sets fee
 
-**TTL Extension Logic**:
-- When an approval is recorded, TTL is set to `PENDING_APPROVAL_TTL_LEDGERS`
-- When the approval entry is accessed above the bump threshold, TTL is extended back to the full `PENDING_APPROVAL_TTL_LEDGERS`
-- If the entry is not accessed before TTL elapses, Soroban auto-evicts it
+```
+bind_settlement_token(admin = G...ADMIN, token = G...USDC_SAC)
+  → require_auth(G...ADMIN)
+  → probes token::Client::balance(escrow_address) — must not panic
+  → writes DataKey::SettlementToken = G...USDC_SAC
 
-**Interaction with Release**:
-- Expired approvals are indistinguishable from never-set approvals (both return `None`)
-- `check_approvals` treats expired approvals as insufficient and returns `InsufficientApprovals`
-- This provides a fail-closed security property: expired approvals cannot be used to release funds
+set_protocol_fee_bps(new_bps = 100)   // 1%
+  → require_auth(G...ADMIN)
+  → writes DataKey::ProtocolFeeBps = 100
+```
 
-**Recovery from Expiry**:
-- If approvals expire, all parties must re-approve the milestone
-- This prevents stale approvals from being used long after they were granted
-- Integrators should monitor approval TTL and re-approve before expiry if needed
+### Step 3 — Client creates the escrow contract
 
-## Complete Flow Example
+```
+create_contract(
+  client      = G...CLIENT,
+  freelancer  = G...FREELANCER,
+  arbiter     = None,
+  milestones  = [500_000_000, 500_000_000],  // stroops
+  mode        = MultiSig
+)
+  → require_not_paused()
+  → require_auth(G...CLIENT)
+  → validates participants distinct, milestones valid, no arbiter required for MultiSig
+  → writes DataKey::Contract(1), milestones vector
+  → returns contract_id = 1
+```
 
-### ClientOnly Mode Flow
+### Step 4 — Client deposits funds
 
-1. **Client calls** `approve_milestone_release(contract_id, client_address, milestone_index)`
-   - Approval recorded: `client_approved = true`
-   - TTL set to 7 days
+```
+deposit_funds(contract_id = 1, caller = G...CLIENT, amount = 1_000_000_000)
+  → require_initialized(), require_not_paused()
+  → validate_deposit: caller == contract.client ✓
+  → SAC transfer: G...CLIENT → escrow, 1_000_000_000
+  → apply_validated_deposit: require_auth(G...CLIENT)
+  → funded_amount = 1_000_000_000, status = Funded
+```
 
-2. **Client calls** `release_milestone(contract_id, client_address, milestone_index)`
-   - Caller authorization check: client is authorized ✓
-   - Approval check: `client_approved = true` ✓
-   - Funds transferred to freelancer
-   - Approval cleared
+### Step 5 — Approve milestone 0
 
-### MultiSig Mode Flow
+Both client and freelancer must approve (MultiSig mode).
 
-1. **Client calls** `approve_milestone_release(contract_id, client_address, milestone_index)`
-   - Approval recorded: `client_approved = true`
-   - TTL set to 7 days
-   - Approval check fails: `client_approved && freelancer_approved = false` → `InsufficientApprovals`
+```
+approve_milestone_release(contract_id = 1, caller = G...CLIENT, milestone_index = 0)
+  → require_not_paused(), require_not_finalized()
+  → require_auth(G...CLIENT)
+  → role check: is_client = true → allowed ✓
+  → loads MilestoneApprovals{false, false, false} (absent → default)
+  → sets client_approved = true
+  → stores with TTL = 120,960 ledgers (~7 days)
 
-2. **Freelancer calls** `approve_milestone_release(contract_id, freelancer_address, milestone_index)`
-   - Approval recorded: `freelancer_approved = true`
-   - TTL extended to 7 days
-   - Approval check passes: `client_approved && freelancer_approved = true` ✓
+approve_milestone_release(contract_id = 1, caller = G...FREELANCER, milestone_index = 0)
+  → require_auth(G...FREELANCER)
+  → role check: is_freelancer = true → allowed ✓
+  → loads MilestoneApprovals{true, false, false}
+  → sets freelancer_approved = true
+  → stores updated record, resets TTL
+```
 
-3. **Either client or freelancer calls** `release_milestone(contract_id, caller_address, milestone_index)`
-   - Caller authorization check: client or freelancer is authorized ✓
-   - Approval check: both approved ✓
-   - Funds transferred to freelancer
-   - Approval cleared
+### Step 6 — Release milestone 0
 
-## Error Code Reference
+Either the client or freelancer may call `release_milestone` now that both have approved.
 
-| Error Code | Value | When Raised |
-|------------|-------|-------------|
-| `UnauthorizedRole` | 10, 11 | Caller not authorized for approval or release in current mode |
-| `AlreadyApproved` | 18 | Caller already approved this milestone (duplicate approval) |
-| `InsufficientApprovals` | 19, 20 | Required approvals missing, insufficient, or expired |
-| `MissingArbiter` | 2 | Arbiter required but not provided (ArbiterOnly or ClientAndArbiter modes) |
-| `InvalidArbiter` | 3 | Arbiter is same as client or freelancer |
-| `ContractNotFound` | 9 | Contract does not exist |
-| `InvalidState` | 11, 16 | Contract not in `Funded` state |
-| `IndexOutOfBounds` | 3, 12 | Milestone index invalid |
-| `MilestoneAlreadyReleased` | 13, 17 | Milestone already released |
+```
+release_milestone(contract_id = 1, caller = G...CLIENT, milestone_index = 0)
+  → require_not_paused()
+  → require_auth(G...CLIENT)
+  → status == Funded ✓
+  → role check (MultiSig): is_client = true → allowed ✓
+  → check_approvals: client_approved && freelancer_approved = true ✓
+  → available = 1_000_000_000 − 0 − 0 = 1_000_000_000 ≥ 500_000_000 ✓
+  → protocol_fee = floor(500_000_000 × 100 / 10_000) = 5_000_000
+  → net_amount = 495_000_000
+  → SAC transfer: escrow → G...FREELANCER, 495_000_000
+  → AccumulatedProtocolFees += 5_000_000
+  → milestone[0].released = true
+  → released_amount = 495_000_000
+  → invariant: 495_000_000 + 0 + 5_000_000 = 500_000_000 ≤ 1_000_000_000 ✓
+  → clear_approvals(1, 0) — temp entry removed
+  → not all milestones done; status remains Funded
+```
 
-## Security Considerations
+### Step 7 — Attempt to re-approve milestone 0 (rejected)
 
-### Fail-Closed Design
+```
+approve_milestone_release(contract_id = 1, caller = G...CLIENT, milestone_index = 0)
+  → milestone[0].released = true → MilestoneAlreadyReleased ✗
+```
 
-- Missing approvals prevent release (`InsufficientApprovals`)
-- Expired approvals prevent release (treated as missing)
-- Unauthorized callers are rejected (`UnauthorizedRole`)
-- Duplicate approvals are rejected (`AlreadyApproved`)
+### Step 8 — Approve and release milestone 1
 
-### Authentication
+```
+approve_milestone_release(1, G...CLIENT, 1)  → client_approved = true
+approve_milestone_release(1, G...FREELANCER, 1) → freelancer_approved = true
 
-- All approval and release operations require `require_auth()`
-- Soroban's native authentication ensures the caller is who they claim to be
+release_milestone(1, G...FREELANCER, 1)
+  → role check (MultiSig): is_freelancer = true → allowed ✓
+  → check_approvals ✓
+  → net_amount = 495_000_000
+  → SAC transfer: escrow → G...FREELANCER, 495_000_000
+  → all milestones done → status = Completed
+  → PendingReputationCredits(G...FREELANCER) += 1
+```
 
-### Approval Isolation
+### Step 9 — Client issues reputation
 
-- Approvals are stored per-milestone, not per-contract
-- Clearing approvals after release prevents reuse
-- TTL expiry prevents stale approvals from being used
+```
+issue_reputation(1, G...CLIENT, rating = 5, comment = "Excellent work")
+  → require_auth(G...CLIENT)
+  → caller == contract.client ✓, status == Completed ✓
+  → reputation_issued = false → proceed
+  → Reputation(G...FREELANCER).completed_contracts += 1, total_rating += 5
+  → contract.reputation_issued = true
+```
 
-### Mode-Specific Guarantees
+### Step 10 — Finalize the contract
 
-- **ClientOnly**: Only client can approve/release, ensuring client control
-- **ArbiterOnly**: Only arbiter can approve/release, enabling dispute resolution
-- **ClientAndArbiter**: Either can approve/release, providing flexibility
-- **MultiSig**: Both must approve, ensuring mutual agreement before release
+```
+finalize_contract(1, G...CLIENT)
+  → require_auth(G...CLIENT)
+  → require_finalizer_role: is_client = true ✓
+  → status == Completed ✓
+  → writes DataKey::Finalization(1) = FinalizationRecord{...}
+```
 
-## Implementation References
+After finalization, any further mutation (`deposit_funds`, `release_milestone`, `cancel_contract`, etc.) on contract 1 panics with `AlreadyFinalized`.
 
-- **Type definitions**: `contracts/escrow/src/types.rs` (ReleaseAuthorization enum, MilestoneApprovals struct)
-- **Approval logic**: `contracts/escrow/src/approvals.rs` (approve_milestone, check_approvals, clear_approvals)
-- **Release logic**: `contracts/escrow/src/lib.rs` (release_milestone, approve_milestone_release)
-- **TTL configuration**: `contracts/escrow/src/ttl.rs` (PENDING_APPROVAL_TTL_LEDGERS, PENDING_APPROVAL_BUMP_THRESHOLD)
+---
 
-## Testing Coverage
+## 7. Error Quick-Reference
 
-The authorization modes are tested in:
-- `contracts/escrow/src/approvals.rs` (unit tests for approval logic)
-- `contracts/escrow/src/test/flows.rs` (integration tests for complete flows)
-- `contracts/escrow/src/test/security.rs` (security-focused tests for authorization)
+| Error | Code | Raised by |
+|-------|------|-----------|
+| `UnauthorizedRole` | 11 | Wrong caller role for the mode or operation |
+| `AlreadyApproved` | 18 | Same party approving a milestone twice |
+| `InsufficientApprovals` | 20 | Approvals absent, insufficient, or expired |
+| `MissingArbiter` | 12 | `ArbiterOnly`/`ClientAndArbiter` mode without arbiter |
+| `InvalidArbiter` | 13 | Arbiter equals client or freelancer |
+| `AlreadyInitialized` | 34 | `initialize` called more than once |
+| `NotInitialized` | 36 | Money-flow entrypoint before `initialize` |
+| `ContractPaused` | 37 | Any state-changing call while paused |
+| `EmergencyActive` | 38 | Any state-changing call during emergency |
+| `AlreadyFinalized` | 46 | Mutation after finalization |
+| `AlreadyCancelled` | 50 | `cancel_contract` on an already-cancelled contract |
+| `TimelockNotElapsed` | 48 | Admin rotation accepted too soon |
+| `SettlementTokenAlreadyBound` | (EscrowError::32) | Second `bind_settlement_token` call |
+| `AccountingInvariantViolated` | 44 | Release causes `released + refunded + fees > funded` |
+| `InvalidStatusTransition` | 41 | Operation invalid for current contract status |
+| `ReputationAlreadyIssued` | 23 | `issue_reputation` called twice |
 
-Test coverage ensures:
-- Each mode enforces the correct approver set
-- Each mode enforces the correct release caller set
-- TTL expiry prevents release with expired approvals
-- Duplicate approvals are rejected
-- Unauthorized callers are rejected
-- Approval clearing works correctly
+---
 
-## NatSpec Cross-References
+## 8. Cross-References
 
-The following NatSpec comments in the source code provide additional context:
-
-- `/// Defines who can approve milestone releases.` in `types.rs` (ReleaseAuthorization enum)
-- `/// Approves a milestone for release by the caller.` in `approvals.rs` (approve_milestone)
-- `/// Checks if a milestone has sufficient approvals for release.` in `approvals.rs` (check_approvals)
-- `/// Clears approval records for a milestone after successful release.` in `approvals.rs` (clear_approvals)
-- `/// Approves a milestone for release.` in `lib.rs` (approve_milestone_release)
-- `/// Releases a specific milestone, transferring funds to the freelancer.` in `lib.rs` (release_milestone)
+| Topic | Document |
+|-------|---------|
+| SAC token custody and transfer ordering | `docs/escrow/sac-custody.md` |
+| Balance conservation invariant | `docs/escrow/balance-conservation-invariant.md` |
+| Storage key schema and TTL policy | `docs/escrow/state-persistence.md`, `docs/escrow/storage-ttl.md` |
+| Emergency controls | `docs/escrow/emergency-controls.md` |
+| Protocol fee model | `docs/escrow/protocol-fees.md` |
+| Dispute resolution | `docs/escrow/disputes.md` |
+| Full ABI reference | `docs/escrow/abi-reference.md` |
+| Security analysis | `docs/escrow/SECURITY.md` |


### PR DESCRIPTION
Description:
  
  Summary
  
  Rewrites docs/escrow/authorization.md to serve as the authoritative reference
  for the escrow contract's authorization model. The previous file covered
  release modes in isolation; this version documents the full model an auditor
  needs to review the contract.
  
  Changes
  
  docs/escrow/authorization.md — full rewrite (461 lines, +116 net over
  previous).
  
  What's documented
  
  Principal roles — Admin, Client, Freelancer, and Arbiter with their storage
  fields (DataKey::Admin, Contract.client, etc.), scopes, and constraints.
  
  Entrypoint authorization table — every state-changing entrypoint in two groups:
  
  - Admin-gated (11 entrypoints): initialize, bind_settlement_token,
  pause/unpause, emergency controls, fee config, governed params, admin rotation.
  - Contract-lifecycle (11 entrypoints): create_contract, deposit_funds,
  approve_milestone_release, release_milestone, refund_unreleased_milestones,
  cancel_contract, finalize_contract, issue_reputation, client migration, dispute
  resolution.
  
  ReleaseAuthorization mode matrix — side-by-side table of all four modes
  (ClientOnly, ClientAndArbiter, ArbiterOnly, MultiSig) showing arbiter
  requirement, allowed approvers, approval count, and who may call
  release_milestone.
  
  Approval lifecycle — storage layout (DataKey::MilestoneApprovals in temporary
  storage), TTL constants (PENDING_APPROVAL_TTL_LEDGERS = 120,960 ledgers ≈ 7
  days), step-by-step annotated flow for approve_milestone_release →
  release_milestone, and fail-closed properties.
  
  15 authorization invariants (I1–I15) — each with a prose statement, exact
  source file and line citation, and test reference. Covers: initialization gate,
  client-only deposit, mode-restricted release callers/approvers, TTL expiry,
  approval consumption on release, duplicate rejection, arbiter requirements,
  client-only cancel/reputation, participant-restricted finalization, admin
  rotation timelock, pause-before-auth ordering, write-once token binding, and
  accounting invariant post-release.
  
  Worked MultiSig example — 10 annotated steps from initialize through
  finalize_contract, showing exact auth checks, fee arithmetic (floor(gross ×
  fee_bps / 10_000)), SAC transfer direction, and accounting invariant
  verification at each stage.
  
  Error quick-reference and cross-reference table to related docs.
  
  Verification
  
  - cargo fmt --all -- --check: ✅ exit 0
  - cargo test -p escrow: 156 passed / 187 failed / 7 ignored — result is
  identical before and after this change (confirmed via stash). The 187 failures
  are pre-existing on the dispute-payout-conservation-regressions base branch and
  are unrelated to this PR.
  - No source code was modified; this PR is documentation only.
  close #823