### PR TITLE
feat(reputation): add reset_reputation_config function (#881)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1876,6 +1876,56 @@ impl Escrow {
     /// * Pause/emergency gate runs BEFORE contract state read so paused
     ///   contracts cannot have reputation mutated while paused.
     /// * The comment-byte cap prevents unbounded on-chain storage growth.
+    /// Resets the reputation configuration to its default values.
+    ///
+    /// This function reverts the reputation parameters to the contract defaults:
+    /// - `min_rating`: 1
+    /// - `max_rating`: 5
+    /// - `max_comment_bytes`: 200
+    ///
+    /// # Authorization
+    ///
+    /// Caller must be the current contract admin.
+    ///
+    /// # Events
+    ///
+    /// Emits a `rep_cfg_reset` event with:
+    /// - `old_config` - The configuration before reset
+    /// - `default_config` - The default configuration applied
+    /// - `admin` - The admin who performed the reset
+    /// - `timestamp` - Current ledger timestamp
+    ///
+    /// # Errors
+    ///
+    /// * `NotInitialized` - Contract has not been initialized
+    /// * `Unauthorized` - Caller is not the admin
+    pub fn reset_reputation_config(env: Env) -> bool {
+        Self::require_initialized(&env);
+
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
+        admin.require_auth();
+
+        let old_config = Self::get_reputation_config(env.clone());
+        let default_config = ReputationConfig::default();
+
+        // Only reset if different from default
+        if old_config != default_config {
+            env.storage()
+                .persistent()
+                .set(&DataKey::ReputationConfigKey, &default_config);
+
+            env.events().publish(
+                (Symbol::new(&env, "rep_cfg_reset"),),
+                (old_config, default_config, admin, env.ledger().timestamp()),
+            );
+        }
+
+        true
+    }
     pub fn issue_reputation(
         env: Env,
         contract_id: u32,

--- a/contracts/escrow/src/test/reputation_config_setter.rs
+++ b/contracts/escrow/src/test/reputation_config_setter.rs
@@ -271,3 +271,100 @@ fn issue_reputation_uses_updated_comment_byte_cap() {
     let result = client.try_issue_reputation(&contract_id, &client_addr, &5u32, &comment);
     super::assert_contract_error(result, Error::CommentTooLong);
 }
+
+// ── reset_reputation_config ──────────────────────────────────────────────────
+
+#[test]
+fn reset_reputation_config_restores_defaults() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // Set custom config
+    assert!(client.set_reputation_config(&2u32, &8u32, &300u32));
+
+    // Verify custom config is applied
+    let config = client.get_reputation_config();
+    assert_eq!(config.min_rating, 2);
+    assert_eq!(config.max_rating, 8);
+    assert_eq!(config.max_comment_bytes, 300);
+
+    // Reset to defaults
+    assert!(client.reset_reputation_config());
+
+    // Verify defaults are restored
+    let config = client.get_reputation_config();
+    assert_eq!(config.min_rating, 1);
+    assert_eq!(config.max_rating, 5);
+    assert_eq!(config.max_comment_bytes, 200);
+}
+
+#[test]
+fn reset_reputation_config_requires_admin() {
+    let env = Env::default();
+    let escrow_address = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &escrow_address);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Override mock to only allow the attacker's auth, not admin's.
+    let attacker = Address::generate(&env);
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &attacker,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &escrow_address,
+            fn_name: "reset_reputation_config",
+            args: soroban_sdk::vec![&env],
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_reset_reputation_config();
+    assert!(result.is_err());
+
+    // Storage must remain untouched by the rejected call.
+    let config = client.get_reputation_config();
+    assert_eq!(config, ReputationConfig::default());
+}
+
+#[test]
+fn reset_reputation_config_works_when_already_default() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // Get initial (default) config
+    let initial_config = client.get_reputation_config();
+
+    // Reset should succeed even if already default
+    assert!(client.reset_reputation_config());
+
+    // Config should remain unchanged
+    let config = client.get_reputation_config();
+    assert_eq!(config, initial_config);
+}
+
+#[test]
+fn reset_reputation_config_emits_event() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // Set custom config first
+    client.set_reputation_config(&3u32, &7u32, &150u32);
+
+    let snap = env.events().all();
+    let event_count_before = snap.len();
+
+    client.reset_reputation_config();
+
+    let snap_after = env.events().all();
+    assert!(snap_after.len() > event_count_before);
+
+    // Check that the rep_cfg_reset event was emitted
+    let has_rep_cfg_reset = snap_after.iter().any(|e| {
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or(Val::VOID.into()))
+            .ok()
+            .as_ref()
+            == Some(&Symbol::new(&env, "rep_cfg_reset"))
+    });
+    assert!(has_rep_cfg_reset, "expected rep_cfg_reset event to be emitted");
+}


### PR DESCRIPTION
#Closes #881

## Summary
Adds an admin-only `reset_reputation_config` function to restore reputation configuration to defaults.

## Changes
- New `reset_reputation_config()` entrypoint
- Resets to: min_rating=1, max_rating=5, max_comment_bytes=200
- Emits `rep_cfg_reset` event with old config, default config, admin, and timestamp
- Admin auth required via `require_auth()`
- Comprehensive tests added for:
  - Default restoration
  - Admin-only enforcement
  - No-op when already default
  - Event emission

## Testing
- ✅ Tests added to `reputation_config_setter.rs`
- ✅ Admin auth enforced
- ✅ Event emission verified

## Checklist
- [x] Implementation matches description
- [x] Tests added and passing
- [x] Docs updated
- [x] Admin auth required
- [x] Clear rustdoc comments