### PR TITLE
fix: decode PendingAdminProposal in get_pending_governance_admin with tests - Closes #533

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2414,6 +2414,61 @@ impl Escrow {
     /// Returns the ledger sequence at which the pending admin proposal was made.
     ///
     /// Returns `None` if there is no pending proposal. This allows off-chain
+    /// Propose a new governance admin. Stores the proposal with a timelock.
+    ///
+    /// Delegates to `propose_governance_admin_impl`. The stored admin must authorize.
+    ///
+    /// # Events
+    /// `(symbol_short!("admin"), Symbol("proposed"))` → `(admin, proposed, timestamp)`
+    pub fn propose_governance_admin(env: Env, proposed: Address) -> bool {
+        Self::propose_governance_admin_impl(&env, proposed)
+    }
+
+    /// Accept a pending governance admin proposal, enforcing the timelock.
+    ///
+    /// Delegates to `accept_governance_admin_impl`. The proposed admin must authorize.
+    ///
+    /// # Events
+    /// `(symbol_short!("admin"), Symbol("accepted"))` → `(old_admin, new_admin, timestamp)`
+    pub fn accept_governance_admin(env: Env) -> bool {
+        Self::accept_governance_admin_impl(&env)
+    }
+
+    /// Cancel a pending governance admin proposal, aborting a two-step transfer.
+    ///
+    /// Delegates to `cancel_governance_admin_proposal_impl`. Only the current admin may cancel.
+    ///
+    /// # Events
+    /// `(symbol_short!("admin"), Symbol("cancelled"))` → `(admin, cancelled_proposal, timestamp)`
+    pub fn cancel_governance_admin_proposal(env: Env) -> bool {
+        Self::cancel_governance_admin_proposal_impl(&env)
+    }
+
+    /// Returns the currently pending governance admin address, if any.
+    ///
+    /// Delegates to `get_pending_governance_admin_impl` which correctly decodes
+    /// the stored [`PendingAdminProposal`] struct and returns only the proposed
+    /// admin address. This ensures the same storage shape is used across
+    /// propose/accept/read paths.
+    ///
+    /// # Returns
+    /// * `Some(Address)` — the proposed governance admin address
+    /// * `None` — no pending proposal exists
+    pub fn get_pending_governance_admin(env: Env) -> Option<Address> {
+        Self::get_pending_governance_admin_impl(&env)
+    }
+
+    /// Returns the ledger sequence at which the pending admin proposal was made.
+    ///
+    /// Alias for [`get_pending_admin_proposed_at`]. This is the canonical typed
+    /// accessor for reading the timelock anchor ledger from a
+    /// [`PendingAdminProposal`] so off-chain indexers can compute the remaining
+    /// delay before the proposal can be accepted.
+    ///
+    /// Returns `None` if there is no pending proposal.
+    pub fn get_pending_governance_admin_proposed_at(env: Env) -> Option<u32> {
+        Self::get_pending_admin_proposed_at(env)
+    }
     /// indexers and governance dashboards to compute the remaining timelock
     /// before the proposal can be accepted via `accept_governance_admin`.
     pub fn get_pending_admin_proposed_at(env: Env) -> Option<u32> {

--- a/contracts/escrow/src/test/admin_auth_helper.rs
+++ b/contracts/escrow/src/test/admin_auth_helper.rs
@@ -115,6 +115,37 @@ fn resolve_emergency_succeeds_with_admin_auth() {
 // already prove that `load_and_auth_admin` routes through `require_auth()` —
 // the Soroban auth engine guarantees the panic when no auth is provided.
 
+// ─── Pending governance admin round-trip ──────────────────────────────────────────
+
+/// Propose a governance admin, then read it back via get_pending_governance_admin.
+#[test]
+fn pending_governance_admin_propose_and_read() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    assert!(client.initialize(&admin), "initialize must succeed");
+    assert!(client.get_pending_governance_admin().is_none(), "no pending before proposal");
+    let _ = client.propose_governance_admin(&new_admin);
+    let pending = client.get_pending_governance_admin();
+    assert_eq!(pending, Some(new_admin.clone()), "pending admin must match proposed");
+    assert!(client.get_pending_governance_admin_proposed_at().is_some(), "proposed_at must be Some");
+    assert_eq!(client.get_pending_governance_admin_proposed_at(), client.get_pending_admin_proposed_at(), "both accessors must agree");
+}
+
+#[test]
+fn pending_governance_admin_returns_none_when_absent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert!(client.get_pending_governance_admin().is_none(), "no pending without proposal");
+    assert!(client.get_pending_governance_admin_proposed_at().is_none(), "no proposed_at without proposal");
+}
 // ─── Idempotent / State invariant round-trips ─────────────────────────────────
 
 /// Emergency and pause flags are set and cleared atomically through the helper.

--- a/docs/escrow/governance-security.md
+++ b/docs/escrow/governance-security.md
@@ -15,6 +15,15 @@ resolve emergency mode.
 - `is_paused() -> bool`
 - `is_emergency() -> bool`
 
+- `get_pending_governance_admin() -> Option<Address>` — reads the proposed
+  address from the pending admin proposal (correctly decodes the
+  [`PendingAdminProposal`] struct, not a bare `Address`)
+- `get_pending_governance_admin_proposed_at() -> Option<u32>` — returns the
+  ledger sequence when the pending admin was proposed (alias for
+  `get_pending_admin_proposed_at`)
+- `get_pending_admin_proposed_at() -> Option<u32>` — returns the ledger sequence
+  when the pending admin was proposed
+
 All mutating admin controls require the stored admin's Soroban authorization.
 There is no live admin transfer entrypoint.
 


### PR DESCRIPTION
## Summary

Add typed public entrypoints for governance admin rotation and fix `get_pending_governance_admin` to correctly decode the stored `PendingAdminProposal` struct instead of reading a bare `Address`.

## Changes

### `contracts/escrow/src/lib.rs`

Added public wrapper functions that delegate to the existing `pub(crate)` implementations in `governance.rs`:
- **`propose_governance_admin(env, proposed)`** — propose a new governance admin with timelock
- **`accept_governance_admin(env)`** — accept pending proposal (timelock-gated)
- **`cancel_governance_admin_proposal(env)`** — cancel a pending proposal
- **`get_pending_governance_admin(env) -> Option<Address>`** — read the proposed admin address, correctly decoding `PendingAdminProposal` via delegation to `get_pending_governance_admin_impl`
- **`get_pending_governance_admin_proposed_at(env) -> Option<u32>`** — alias for `get_pending_admin_proposed_at`

### `contracts/escrow/src/test/admin_auth_helper.rs`

Added 2 tests:
- `pending_governance_admin_propose_and_read` — propose then read back the pending admin address and proposed_at ledger
- `pending_governance_admin_returns_none_when_absent` — verify None with no proposal

### `docs/escrow/governance-security.md`

Added documentation for the 3 new accessor functions.

## Why This Fix

`propose_governance_admin_impl` writes a `PendingAdminProposal { proposed, proposed_at_ledger }` struct under `DataKey::PendingAdmin`. Without this fix, off-chain callers would need to use the internal `_impl` function or risk decoding mismatch. The new public functions expose the correct typed access.

## Testing

- Tests cover: no proposal present → None, live proposal → round-trip of Address and proposed_at ledger
- Note: `cargo build`/`cargo test` on this Windows machine has a pre-existing linker issue ("link: extra operand") due to Visual Studio C++ tools configuration. CI on the upstream repo should build and test correctly.