### PR TITLE
Closes #749 — Extract require_active_contract helper

### DIFF
--- a/contracts/escrow/src/finalize.rs
+++ b/contracts/escrow/src/finalize.rs
@@ -45,6 +45,32 @@ impl Escrow {
         }
     }
 
+    /// Load a contract, verify it's in an active (mutable) state, and extend
+    /// its TTL. Rejects `Cancelled`, `Refunded`, and finalized contracts.
+    ///
+    /// This is the canonical preamble for all lifecycle entrypoints that need a
+    /// live, mutable contract. Calls `load_contract` from `storage.rs`, extends
+    /// the TTL, checks finalization, and rejects terminal statuses.
+    ///
+    /// # Panics
+    /// - `ContractNotFound` when `contract_id` is unknown.
+    /// - `AlreadyFinalized` when the contract has been finalized.
+    /// - `InvalidState` when the contract status is `Cancelled` or `Refunded`.
+    ///
+    /// # Returns
+    /// The loaded `Contract`.
+    pub(crate) fn require_active_contract(env: &Env, contract_id: u32) -> Contract {
+        let contract = crate::storage::load_contract(env, contract_id);
+        crate::ttl::extend_contract_ttl(env, contract_id);
+        Self::require_not_finalized(env, contract_id);
+        if contract.status == ContractStatus::Cancelled
+            || contract.status == ContractStatus::Refunded
+        {
+            env.panic_with_error(Error::InvalidState);
+        }
+        contract
+    }
+
     pub(crate) fn require_not_paused(env: &Env) {
         if env
             .storage()

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -813,16 +813,7 @@ impl Escrow {
         // Authenticate caller before any state-dependent logic
         caller.require_auth();
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-
-        // Extend TTL on contract read
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
+        let mut contract: Contract = Self::require_active_contract(&env, contract_id);
 
         // Verify contract is in Funded state before release (deposit transitions
         // Created → Funded when fully funded, so release must accept Funded).
@@ -1151,17 +1142,8 @@ impl Escrow {
             }
         }
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+        let mut contract: Contract = Self::require_active_contract(&env, contract_id);
         let was_disputed = contract.status == ContractStatus::Disputed;
-
-        // Extend TTL on contract read
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
 
         // Only allow refunds while the contract is still in an active,
         // unreleased state. Cancelled, Completed, and Refunded contracts
@@ -1753,14 +1735,7 @@ impl Escrow {
     /// * `InvalidStatusTransition` - If the contract is not `Created`/`Funded` or has already released funds.
     pub fn cancel_contract(env: Env, contract_id: u32, client: Address) -> bool {
         Self::require_not_paused(&env);
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-        ttl::extend_contract_ttl(&env, contract_id);
-
-        Self::require_not_finalized(&env, contract_id);
+        let mut contract: Contract = Self::require_active_contract(&env, contract_id);
 
         if client != contract.client {
             env.panic_with_error(EscrowError::UnauthorizedRole);
@@ -2153,14 +2128,7 @@ impl Escrow {
         Self::require_not_paused(&env);
         caller.require_auth();
 
-        let contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
-
-        ttl::extend_contract_ttl(&env, contract_id);
-        Self::require_not_finalized(&env, contract_id);
+        let contract: Contract = Self::require_active_contract(&env, contract_id);
 
         if caller != contract.freelancer {
             env.panic_with_error(EscrowError::UnauthorizedRole);
@@ -2529,14 +2497,7 @@ impl Escrow {
         Self::require_not_paused(&env);
         caller.require_auth();
 
-        let mut contract: Contract = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Contract(contract_id))
-            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
-
-        ttl::extend_contract_ttl(&env, contract_id);
-        Self::require_not_finalized(&env, contract_id);
+        let mut contract: Contract = Self::require_active_contract(&env, contract_id);
 
         // Verify caller is client or freelancer
         if caller != contract.client && caller != contract.freelancer {


### PR DESCRIPTION
Extracted repeated contract load + TTL extend + finalization check + terminal status rejection into centralized `require_active_contract` helper.

Reduces 5 entrypoints from inline preamble (44 lines) to single-line calls (5 lines).

Closes #749