### PR TITLE
Reject role-overlapping addresses in propose_client_migration

### DIFF
--- a/contracts/escrow/README.md
+++ b/contracts/escrow/README.md
@@ -22,6 +22,7 @@ Then open `target/doc/escrow/index.html`.
 - Cancel non-completed contracts by the stored client or freelancer.
 - Finalize completed or disputed contracts with immutable close metadata.
 - Pause and emergency controls managed by a single initialized admin.
+- Propose and accept client migrations with strict role-overlap checks.
 
 ## Current Public Entrypoints
 
@@ -44,6 +45,11 @@ Then open `target/doc/escrow/index.html`.
 - `get_finalization_record(contract_id) -> Option<FinalizationRecord>`
 - `get_reputation(freelancer) -> Option<ReputationRecord>`
 - `get_pending_reputation_credits(freelancer) -> u32`
+- `propose_client_migration(contract_id, current_client, new_client) -> bool`
+- `accept_client_migration(contract_id, new_client) -> bool`
+- `cancel_client_migration(contract_id, current_client) -> bool`
+- `has_pending_client_migration(contract_id) -> bool`
+- `get_pending_client_migration(contract_id) -> PendingClientMigration`
 
 ### Protocol Fee Read API
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -234,6 +234,11 @@ pub enum EscrowError {
     InvalidProtocolParameters = 44,
     /// The withdrawal amount exceeds the maximum allowed per operation.
     InvalidWithdrawalAmount = 45,
+    /// The proposed migration target overlaps with an existing contract role
+    /// (client, freelancer, arbiter, or the escrow contract itself), which
+    /// would collapse independent authorization parties and defeat the
+    /// release-authorization and dispute models.
+    RoleOverlap = 46,
 }
 
 impl Escrow {

--- a/contracts/escrow/src/migration.rs
+++ b/contracts/escrow/src/migration.rs
@@ -41,11 +41,36 @@ impl Escrow {
             .is_some()
     }
 
+    /// Validate that `candidate` does not overlap with any existing contract
+    /// role (client, freelancer, arbiter) or the escrow contract's own address.
+    ///
+    /// Role overlap would collapse two independent authorization parties into
+    /// one, defeating the release-authorization and dispute models.
+    ///
+    /// # Panics
+    /// Panics with [`EscrowError::RoleOverlap`] when the candidate matches any
+    /// existing role or the contract's own address.
+    pub(crate) fn require_no_role_overlap(env: &Env, contract: &Contract, candidate: &Address) {
+        if *candidate == contract.client
+            || *candidate == contract.freelancer
+            || contract.arbiter.as_ref() == Some(candidate)
+            || *candidate == env.current_contract_address()
+        {
+            env.panic_with_error(EscrowError::RoleOverlap);
+        }
+    }
+
     /// Propose a client migration for an existing contract.
     ///
     /// The current client must authorize the call. The proposed client address
-    /// must not be the freelancer or the current client. The pending migration
+    /// must not overlap with any existing contract role (client, freelancer,
+    /// arbiter) or the escrow contract's own address. The pending migration
     /// is stored in temporary storage with TTL.
+    ///
+    /// # Errors
+    /// * [`EscrowError::UnauthorizedRole`] — caller is not the current client.
+    /// * [`EscrowError::RoleOverlap`] — proposed address overlaps an existing role.
+    /// * [`EscrowError::InvalidState`] — a pending migration already exists.
     pub(crate) fn propose_client_migration_impl(
         env: &Env,
         contract_id: u32,
@@ -61,9 +86,7 @@ impl Escrow {
         if current_client != contract.client {
             env.panic_with_error(EscrowError::UnauthorizedRole);
         }
-        if new_client == contract.client || new_client == contract.freelancer {
-            env.panic_with_error(EscrowError::InvalidParticipant);
-        }
+        Self::require_no_role_overlap(env, &contract, &new_client);
         Self::require_migration_allowed(&env, contract.status);
         if Self::pending_migration_exists(&env, contract_id) {
             env.panic_with_error(EscrowError::InvalidState);
@@ -92,6 +115,16 @@ impl Escrow {
     }
 
     /// Accept a live pending client migration and update the contract.
+    ///
+    /// Re-validates role-overlap invariants against the **current** contract
+    /// state, since roles may have changed between proposal and acceptance.
+    ///
+    /// # Errors
+    /// * [`EscrowError::InvalidState`] — no live pending migration, or the
+    ///   proposing client no longer matches `contract.client`.
+    /// * [`EscrowError::UnauthorizedRole`] — caller is not the proposed client.
+    /// * [`EscrowError::RoleOverlap`] — the proposed client now overlaps with
+    ///   a contract role that changed after the proposal was created.
     pub(crate) fn accept_client_migration_impl(
         env: &Env,
         contract_id: u32,
@@ -116,9 +149,19 @@ impl Escrow {
             env.panic_with_error(EscrowError::InvalidState);
         }
 
-        let key = Escrow::pending_migration_key(contract_id);
-        let pending: PendingClientMigration = read_if_live(&env, &key)
-            .unwrap_or_else(|| env.panic_with_error(EscrowError::InvalidState));
+        // Re-check role overlap at acceptance time: roles may have changed
+        // between proposal and acceptance (e.g. arbiter was set, freelancer
+        // address was updated via another mechanism).
+        Self::require_no_role_overlap(env, &contract, &new_client);
+
+        // Persist the updated client address
+        contract.client = new_client.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &contract);
+
+        // Clear the pending migration record
+        remove_transient(&env, &key);
 
         env.events().publish(
             (Symbol::new(&env, "client_migration_accepted"), contract_id),

--- a/contracts/escrow/src/test/client_migration.rs
+++ b/contracts/escrow/src/test/client_migration.rs
@@ -382,7 +382,7 @@ fn migration_blocked_on_disputed_contract() {
 // ---------------------------------------------------------------------------
 
 /// Proposing the freelancer collapses the two roles and must be rejected
-/// with `InvalidParticipant`.
+/// with `RoleOverlap`.
 #[test]
 fn cannot_propose_freelancer_as_new_client() {
     let env = Env::default();
@@ -393,12 +393,12 @@ fn cannot_propose_freelancer_as_new_client() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &freelancer_addr),
-        EscrowError::InvalidParticipant,
+        EscrowError::RoleOverlap,
     );
 }
 
 /// Proposing the current client as themselves must be rejected with
-/// `InvalidParticipant`.
+/// `RoleOverlap`.
 #[test]
 fn cannot_propose_current_client_as_new_client() {
     let env = Env::default();
@@ -409,7 +409,7 @@ fn cannot_propose_current_client_as_new_client() {
 
     assert_contract_error(
         client.try_propose_client_migration(&id, &client_addr, &client_addr),
-        EscrowError::InvalidParticipant,
+        EscrowError::RoleOverlap,
     );
 }
 
@@ -573,4 +573,215 @@ fn pending_migration_expiry_matches_ttl_constant() {
         pending.requested_at_ledger, ledger_before,
         "requested_at_ledger must equal the ledger at proposal time"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Test 11 – Arbiter role overlap is rejected at proposal time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cannot_propose_arbiter_as_new_client() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &super::default_milestones(&env),
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+
+    assert_contract_error(
+        client.try_propose_client_migration(&id, &client_addr, &arbiter_addr),
+        EscrowError::RoleOverlap,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12 – Escrow contract's own address is rejected at proposal time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cannot_propose_escrow_contract_as_new_client() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = register_client(&env);
+
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let escrow_contract_addr = client.address.clone();
+
+    assert_contract_error(
+        client.try_propose_client_migration(&id, &client_addr, &escrow_contract_addr),
+        EscrowError::RoleOverlap,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 13 – Acceptance rejects if role overlap occurs between proposal and acceptance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accept_rejects_if_freelancer_changed_to_match_proposed_client() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Set max_entry_ttl high enough so the proposal can be stored without hitting the cap.
+    let initial = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+    });
+
+    let client = register_client(&env);
+    let (client_addr, freelancer_addr, id) = create_contract(&env, &client);
+    let new_client = Address::generate(&env);
+
+    // Proposal succeeds initially
+    assert!(client.propose_client_migration(&id, &client_addr, &new_client));
+
+    // Force-change freelancer role in contract storage to match the proposed client address
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = DataKey::Contract(id);
+        let mut contract: Contract = env.storage().persistent().get(&key).unwrap();
+        contract.freelancer = new_client.clone();
+        env.storage().persistent().set(&key, &contract);
+    });
+
+    // Acceptance must fail now because proposed client is the freelancer
+    assert_contract_error(
+        client.try_accept_client_migration(&id, &new_client),
+        EscrowError::RoleOverlap,
+    );
+}
+
+#[test]
+fn accept_rejects_if_arbiter_changed_to_match_proposed_client() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Set max_entry_ttl high enough so the proposal can be stored without hitting the cap.
+    let initial = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+    });
+
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let new_client = Address::generate(&env);
+
+    // Proposal succeeds initially (no arbiter set)
+    assert!(client.propose_client_migration(&id, &client_addr, &new_client));
+
+    // Force-set arbiter role in contract storage to match the proposed client address
+    let escrow_addr = client.address.clone();
+    env.as_contract(&escrow_addr, || {
+        let key = DataKey::Contract(id);
+        let mut contract: Contract = env.storage().persistent().get(&key).unwrap();
+        contract.arbiter = Some(new_client.clone());
+        env.storage().persistent().set(&key, &contract);
+    });
+
+    // Acceptance must fail now because proposed client is the arbiter
+    assert_contract_error(
+        client.try_accept_client_migration(&id, &new_client),
+        EscrowError::RoleOverlap,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 14 – Valid proposal with distinct arbiter set succeeds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn valid_proposal_with_arbiter_set_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let initial = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+    });
+
+    let client = register_client(&env);
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let arbiter_addr = Address::generate(&env);
+    let id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &Some(arbiter_addr.clone()),
+        &super::default_milestones(&env),
+        &crate::ReleaseAuthorization::ClientOnly,
+    );
+
+    let new_client = Address::generate(&env);
+
+    // Propose client migration
+    assert!(client.propose_client_migration(&id, &client_addr, &new_client));
+
+    // Accept client migration
+    assert!(client.accept_client_migration(&id, &new_client));
+
+    // Check that client has been updated
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.client, new_client);
+}
+
+// ---------------------------------------------------------------------------
+// Test 15 – Verify accept actually writes updated client to contract storage (non-ignored)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn propose_and_accept_actually_updates_contract_client() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let initial = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        sequence_number: initial.sequence_number,
+        timestamp: initial.timestamp,
+        protocol_version: initial.protocol_version,
+        network_id: initial.network_id.clone(),
+        base_reserve: initial.base_reserve,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+        max_entry_ttl: PENDING_MIGRATION_TTL_LEDGERS * 4,
+    });
+
+    let client = register_client(&env);
+    let (client_addr, _freelancer_addr, id) = create_contract(&env, &client);
+    let new_client = Address::generate(&env);
+
+    assert!(client.propose_client_migration(&id, &client_addr, &new_client));
+    assert!(client.accept_client_migration(&id, &new_client));
+
+    // contract.client must be updated
+    let contract = client.get_contract(&id);
+    assert_eq!(contract.client, new_client);
 }

--- a/docs/escrow/ERROR_CATALOG.md
+++ b/docs/escrow/ERROR_CATALOG.md
@@ -394,7 +394,21 @@ This document is a single reference mapping each error **code** to:
 
 ---
 
+## Code 46: `RoleOverlap` ✅ Live
+
+**Entrypoint(s)**:
+- `propose_client_migration`
+- `accept_client_migration`
+
+**Trigger condition**:
+- The proposed client address overlaps with the current client, the freelancer, the arbiter (if configured), or the escrow contract's own address.
+
+**Precise condition**:
+- `if candidate == contract.client || candidate == contract.freelancer || contract.arbiter.as_ref() == Some(candidate) || candidate == env.current_contract_address() { panic_with_error(RoleOverlap) }`
+
+---
+
 ## Cross-links
 
 - Public entrypoint security notes and assumptions: [`SECURITY.md`](./SECURITY.md)
-- Enum definitions: `contracts/escrow/src/types.rs` (`Error` is `#[repr(u32)]`)
+- Enum definitions: `contracts/escrow/src/lib.rs` (`EscrowError` is `#[repr(u32)]`)


### PR DESCRIPTION
##closes #738 
:

```markdown
# Pull Request: Reject role-overlapping addresses in propose_client_migration

## Description
Resolves #738

Harden the client migration flows in `propose_client_migration` and `accept_client_migration` against role-overlap attacks. Previously, the contract accepted migration to arbitrary target addresses without validating them against other critical contract roles. Allowing the proposed client to collapse with the freelancer, the arbiter, or the escrow contract's own address would compromise the release authorization and dispute models. 

This PR introduces a dedicated error variant, implements comprehensive role-overlap validation checks at both proposal and acceptance stages, and fixes a critical pre-existing storage write bug.

---

## Changes

### 1. Escrow Contract Error Enum
- **Added `EscrowError::RoleOverlap` (discriminant `46`)** to [`contracts/escrow/src/lib.rs`](file:///c:/Users/cisat/.antigravity-ide/Talenttrust-Contracts-1/contracts/escrow/src/lib.rs#L237): Specifically distinguishes role-overlap validations from generic participant or state errors.

### 2. Migration Invariant Enforcements
- **Extracted `require_no_role_overlap` helper** in [`contracts/escrow/src/migration.rs`](file:///c:/Users/cisat/.antigravity-ide/Talenttrust-Contracts-1/contracts/escrow/src/migration.rs#L44):
  Checks that the proposed client address does not match:
  - The current client (`contract.client`)
  - The contract freelancer (`contract.freelancer`)
  - The contract arbiter (`contract.arbiter`)
  - The escrow contract's own address (`env.current_contract_address()`)
- **Updated `propose_client_migration_impl`**: Integrates the new validation helper to reject overlapping targets on proposal.
- **Hardened `accept_client_migration_impl`**:
  - Re-evaluates role-overlap invariants at acceptance time since contract roles (like the arbiter) can change between the proposal and acceptance phases.
  - Removed a duplicate `read_if_live` check.
  - **Fixed a critical pre-existing bug**: Actually persists the updated client address (`contract.client = new_client`) back to contract storage.

### 3. Verification & Tests
- Updated existing tests in [`client_migration.rs`](file:///c:/Users/cisat/.antigravity-ide/Talenttrust-Contracts-1/contracts/escrow/src/test/client_migration.rs) to expect `RoleOverlap` instead of `InvalidParticipant`.
- Added 6 new unit tests:
  - `cannot_propose_arbiter_as_new_client`
  - `cannot_propose_escrow_contract_as_new_client`
  - `accept_rejects_if_freelancer_changed_to_match_proposed_client`
  - `accept_rejects_if_arbiter_changed_to_match_proposed_client`
  - `valid_proposal_with_arbiter_set_succeeds`
  - `propose_and_accept_actually_updates_contract_client`

### 4. Documentation
- Updated [`docs/escrow/ERROR_CATALOG.md`](file:///c:/Users/cisat/.antigravity-ide/Talenttrust-Contracts-1/docs/escrow/ERROR_CATALOG.md) to document Code 46: `RoleOverlap` and its trigger conditions.
- Updated [`contracts/escrow/README.md`](file:///c:/Users/cisat/.antigravity-ide/Talenttrust-Contracts-1/contracts/escrow/README.md) to list the migration-related public entrypoints.

---

## Validation
Runs the unit tests via cargo (using the GNU toolchain overrides where necessary on host targets):
```bash
cargo fmt --all -- --check
cargo test --manifest-path contracts/escrow/Cargo.toml
```

## Branch and Commit
- Branch name: `enhancement/contracts-migration-role-overlap`
- Commit message: `fix(escrow): reject role-overlapping client in migration proposal`
```