### PR TITLE
feat(disputes): add simulate/dry-run

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -83,7 +83,7 @@ pub use types::{
     Contract, ContractBounds, ContractStatus, ContractSummary, DataKey, DepositMode,
     DisputeResolution, DisputeSplit, Error, GovernedParameters, Milestone, MilestoneApprovals,
     MilestoneSummary, PendingAdminProposal, ReadinessChecklist, ReleaseAuthorization, Reputation,
-    SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
+    SimulateDisputeOutcome, SplitAmounts, CONTRACT_SUMMARY_SCHEMA_VERSION,
 };
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
@@ -2319,6 +2319,108 @@ impl Escrow {
         );
 
         true
+    }
+
+    /// Simulates dispute resolution and returns the projected outcome without
+    /// writing storage or emitting events.
+    ///
+    /// This is the read-only dry-run counterpart to `resolve_dispute`. It
+    /// performs every pre-condition check that `resolve_dispute` performs —
+    /// initialization, pause gate, arbiter authorization, contract existence,
+    /// finalization guard, `Disputed`-state requirement, arbiter matching,
+    /// and payout arithmetic validation — and then returns the projected
+    /// payout split and final status **without** mutating persistent storage,
+    /// extending TTL, executing token transfers, or publishing events.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `contract_id` - The contract ID
+    /// * `arbiter` - The arbiter address (must match contract's assigned arbiter)
+    /// * `resolution` - The resolution decision (FullRefund, PartialRefund, FullPayout, or Split)
+    ///
+    /// # Returns
+    /// A [`SimulateDisputeOutcome`] containing:
+    /// - `client_payout` — amount that would be refunded to the client
+    /// - `freelancer_payout` — amount that would be released to the freelancer
+    /// - `final_status` — projected contract status after applying the resolution
+    /// - `new_refunded_amount` — projected `refunded_amount`
+    /// - `new_released_amount` — projected `released_amount`
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If `initialize` has not been called
+    /// * `ContractNotFound` - If contract doesn't exist
+    /// * `UnauthorizedRole` - If caller is not the assigned arbiter
+    /// * `InvalidStatusTransition` - If contract is not in Disputed state
+    /// * `InvalidDisputeSplit` - If custom split doesn't match available balance
+    /// * `AccountingInvariantViolated` - If accounting state is inconsistent
+    /// * `PotentialOverflow` - If amount calculations would overflow
+    /// * `ContractPaused` - If pause or emergency controls are active
+    /// * `AlreadyFinalized` - If contract has been finalized
+    ///
+    /// # Security
+    /// This entrypoint is read-only: it performs no storage writes, no TTL
+    /// extensions, no token transfers, and emits no events. It does not
+    /// contribute to keeping contract state alive and cannot be used as a
+    /// state-mutation vector.
+    pub fn simulate_dispute_resolution(
+        env: Env,
+        contract_id: u32,
+        arbiter: Address,
+        resolution: DisputeResolution,
+    ) -> SimulateDisputeOutcome {
+        // Identical pre-condition checks as `resolve_dispute`.
+        Self::require_initialized(&env);
+        Self::require_not_paused(&env);
+        arbiter.require_auth();
+
+        let contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        // NOTE: No TTL extension — this is a read-only simulation.
+
+        Self::require_not_finalized(&env, contract_id);
+
+        if contract.status != ContractStatus::Disputed {
+            env.panic_with_error(Error::InvalidStatusTransition);
+        }
+
+        match &contract.arbiter {
+            Some(contract_arbiter) if *contract_arbiter == arbiter => {}
+            _ => env.panic_with_error(Error::UnauthorizedRole),
+        }
+
+        let (client_payout, freelancer_payout) =
+            dispute::resolution_payouts(&contract, &resolution)
+                .unwrap_or_else(|e| env.panic_with_error(e));
+
+        let new_refunded_amount = contract
+            .refunded_amount
+            .checked_add(client_payout)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+        let new_released_amount = contract
+            .released_amount
+            .checked_add(freelancer_payout)
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+
+        // Compute projected final status using dispute helper.
+        // Build a projected contract view without mutating the original.
+        let projected = Contract {
+            refunded_amount: new_refunded_amount,
+            released_amount: new_released_amount,
+            ..contract
+        };
+        let final_status = dispute::final_status_after_resolution(&projected);
+
+        SimulateDisputeOutcome {
+            client_payout,
+            freelancer_payout,
+            final_status,
+            new_refunded_amount,
+            new_released_amount,
+        }
     }
 }
 

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -28,7 +28,7 @@ use crate::{
     Contract, ContractStatus, DisputeResolution, DisputeSplit, Error, Escrow, EscrowClient,
     ReleaseAuthorization, SimulateDisputeOutcome,
 };
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, vec, Address, Env};
 
 use crate::dispute::{final_status_after_resolution, resolution_payouts};
 
@@ -38,7 +38,7 @@ use crate::dispute::{final_status_after_resolution, resolution_payouts};
 
 fn make_env() -> Env {
     let env = Env::default();
-    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
     env
 }
 
@@ -47,6 +47,9 @@ fn make_client(env: &Env) -> EscrowClient<'_> {
     let client = EscrowClient::new(env, &id);
     let admin = Address::generate(env);
     client.initialize(&admin);
+    // Bind a settlement token so deposit_funds can transfer value.
+    let token = env.register_stellar_asset_contract(admin.clone());
+    client.bind_settlement_token(&admin, &token);
     client
 }
 
@@ -87,6 +90,9 @@ fn funded_contract_with_arbiter(
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
+    // Mint settlement tokens to the client so deposit_funds can transfer them.
+    let token = client.get_settlement_token().unwrap();
+    StellarAssetClient::new(env, &token).mint(&client_addr, &100_i128);
     assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
     (client_addr, freelancer_addr, arbiter_addr, contract_id)
 }
@@ -104,6 +110,9 @@ fn funded_contract_no_arbiter(env: &Env, client: &EscrowClient<'_>) -> (Address,
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
+    // Mint settlement tokens to the client so deposit_funds can transfer them.
+    let token = client.get_settlement_token().unwrap();
+    StellarAssetClient::new(env, &token).mint(&client_addr, &100_i128);
     assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
     (client_addr, freelancer_addr, contract_id)
 }
@@ -115,6 +124,19 @@ fn disputed_contract(env: &Env, client: &EscrowClient<'_>) -> (Address, Address,
         funded_contract_with_arbiter(env, client);
     assert!(client.raise_dispute(&contract_id, &client_addr));
     (client_addr, freelancer_addr, arbiter_addr, contract_id)
+}
+
+/// Mint settlement tokens and deposit into the escrow contract.
+fn mint_and_deposit(
+    env: &Env,
+    client: &EscrowClient<'_>,
+    contract_id: &u32,
+    depositor: &Address,
+    amount: &i128,
+) {
+    let token = client.get_settlement_token().unwrap();
+    StellarAssetClient::new(env, &token).mint(depositor, amount);
+    assert!(client.deposit_funds(contract_id, depositor, amount));
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +180,7 @@ fn resolution_payouts_partial_refund_applies_floor_rounded_30_pct_to_freelancer(
 #[test]
 fn resolution_payouts_split_accepts_exact_conserving_amounts() {
     let env = make_env();
-    // Zero available → (0, 0)
+    // Split (40, 60) exactly matches available 100
     assert_eq!(
         resolution_payouts(
             &payout_contract(&env, 100, 0, 0),
@@ -167,7 +189,7 @@ fn resolution_payouts_split_accepts_exact_conserving_amounts() {
                 freelancer_amount: 60,
             })
         ),
-        Ok((0, 0))
+        Ok((40, 60))
     );
     // One stroop → floor(1 * 30 / 100) = 0, client gets 1
     assert_eq!(
@@ -186,13 +208,13 @@ fn resolution_payouts_partial_refund_odd_amount_rounding() {
     let env = make_env();
     // (available, expected_client, expected_freelancer)
     let cases: &[(i128, i128, i128)] = &[
-        (7, 7, 0),
+        (7, 5, 2),
         (10, 7, 3),
-        (99, 69, 30),
+        (99, 70, 29),
         (100, 70, 30),
         (101, 71, 30),
-        (102, 71, 31),
-        (103, 72, 31),
+        (102, 72, 30),
+        (103, 73, 30),
     ];
     for (available, expected_client, expected_freelancer) in cases {
         let contract = payout_contract(&env, *available, 0, 0);
@@ -389,7 +411,7 @@ fn resolve_full_refund_conserves_and_marks_refunded() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    client.deposit_funds(&escrow_id, &client_addr, &200_i128);
+    mint_and_deposit(&env, &client, &escrow_id, &client_addr, &200_i128);
 
     client.raise_dispute(&escrow_id, &client_addr);
     client.resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::FullRefund);
@@ -420,7 +442,7 @@ fn resolve_full_payout_conserves_and_marks_completed() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    client.deposit_funds(&escrow_id, &client_addr, &150_i128);
+    mint_and_deposit(&env, &client, &escrow_id, &client_addr, &150_i128);
 
     client.raise_dispute(&escrow_id, &client_addr);
     client.resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::FullPayout);
@@ -451,7 +473,7 @@ fn resolve_partial_refund_conserves_70_30_split() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    client.deposit_funds(&escrow_id, &client_addr, &100_i128);
+    mint_and_deposit(&env, &client, &escrow_id, &client_addr, &100_i128);
 
     client.raise_dispute(&escrow_id, &client_addr);
     client.resolve_dispute(&escrow_id, &arbiter_addr, &DisputeResolution::PartialRefund);
@@ -480,7 +502,7 @@ fn resolve_split_conserves_custom_amounts() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    client.deposit_funds(&escrow_id, &client_addr, &100_i128);
+    mint_and_deposit(&env, &client, &escrow_id, &client_addr, &100_i128);
 
     client.raise_dispute(&escrow_id, &client_addr);
     let split = DisputeSplit {
@@ -583,8 +605,9 @@ fn raise_dispute_on_completed_contract_is_rejected() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
+    mint_and_deposit(&env, &client, &contract_id, &client_addr, &100_i128);
     // Release the only milestone to reach Completed state.
+    client.approve_milestone_release(&contract_id, &client_addr, &0);
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
     assert_eq!(
         client.get_contract(&contract_id).status,
@@ -673,9 +696,12 @@ fn raise_dispute_after_settle_is_rejected() {
         &milestones,
         &ReleaseAuthorization::ClientOnly,
     );
-    assert!(client.deposit_funds(&contract_id, &client_addr, &100_i128));
+    mint_and_deposit(&env, &client, &contract_id, &client_addr, &100_i128);
     // Release all milestones to settle the contract.
+    // Approve milestones before releasing (release requires approval).
+    client.approve_milestone_release(&contract_id, &client_addr, &0);
     assert!(client.release_milestone(&contract_id, &client_addr, &0));
+    client.approve_milestone_release(&contract_id, &client_addr, &1);
     assert!(client.release_milestone(&contract_id, &client_addr, &1));
     assert_eq!(
         client.get_contract(&contract_id).status,
@@ -741,10 +767,10 @@ fn raise_dispute_on_refunded_contract_is_rejected() {
         ContractStatus::Refunded
     );
 
-    // Cannot raise again.
+    // Cannot raise again — contract is Refunded, not Funded/PartiallyFunded.
     super::assert_contract_error(
         client.try_raise_dispute(&contract_id, &freelancer_addr),
-        Error::AlreadyFinalized,
+        Error::InvalidState,
     );
 }
 
@@ -1094,7 +1120,7 @@ fn simulate_matches_resolve_for_all_variants() {
             &milestones,
             &ReleaseAuthorization::ClientOnly,
         );
-        client.deposit_funds(&contract_id, &client_addr, &200_i128);
+        mint_and_deposit(&env, &client, &contract_id, &client_addr, &200_i128);
         client.raise_dispute(&contract_id, &client_addr);
 
         // Simulate.

--- a/contracts/escrow/src/test/dispute.rs
+++ b/contracts/escrow/src/test/dispute.rs
@@ -26,7 +26,7 @@
 
 use crate::{
     Contract, ContractStatus, DisputeResolution, DisputeSplit, Error, Escrow, EscrowClient,
-    ReleaseAuthorization,
+    ReleaseAuthorization, SimulateDisputeOutcome,
 };
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
@@ -762,4 +762,375 @@ fn resolve_after_finalize_is_rejected() {
         client.try_resolve_dispute(&contract_id, &arbiter_addr, &DisputeResolution::FullRefund),
         Error::AlreadyFinalized,
     );
+}
+
+// ---------------------------------------------------------------------------
+// Simulate / dry-run dispute resolution tests
+// ---------------------------------------------------------------------------
+
+/// Simulate FullRefund returns projected outcome (all refunded) without mutating state.
+#[test]
+fn simulate_full_refund_matches_real_outcome_and_is_read_only() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (_, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    // Read pre-simulation state.
+    let before = client.get_contract(&contract_id);
+    assert_eq!(before.status, ContractStatus::Disputed);
+
+    let outcome = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::FullRefund,
+    );
+
+    assert_eq!(outcome.client_payout, 100);
+    assert_eq!(outcome.freelancer_payout, 0);
+    assert_eq!(outcome.final_status, ContractStatus::Refunded);
+    assert_eq!(outcome.new_refunded_amount, 100);
+    assert_eq!(outcome.new_released_amount, 0);
+
+    // Verify state did NOT change.
+    let after = client.get_contract(&contract_id);
+    assert_eq!(after.status, ContractStatus::Disputed);
+    assert_eq!(after.refunded_amount, 0);
+    assert_eq!(after.released_amount, 0);
+}
+
+/// Simulate FullPayout returns projected outcome (all released) without mutating state.
+#[test]
+fn simulate_full_payout_matches_real_outcome_and_is_read_only() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (_, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    let outcome = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::FullPayout,
+    );
+
+    assert_eq!(outcome.client_payout, 0);
+    assert_eq!(outcome.freelancer_payout, 100);
+    assert_eq!(outcome.final_status, ContractStatus::Completed);
+    assert_eq!(outcome.new_refunded_amount, 0);
+    assert_eq!(outcome.new_released_amount, 100);
+
+    // State unchanged.
+    let after = client.get_contract(&contract_id);
+    assert_eq!(after.status, ContractStatus::Disputed);
+    assert_eq!(after.refunded_amount, 0);
+    assert_eq!(after.released_amount, 0);
+}
+
+/// Simulate PartialRefund returns projected 70/30 outcome without mutating state.
+#[test]
+fn simulate_partial_refund_matches_real_outcome_and_is_read_only() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (_, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    let outcome = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::PartialRefund,
+    );
+
+    // 70% client, 30% freelancer (floor): 100 * 30/100 = 30
+    assert_eq!(outcome.client_payout, 70);
+    assert_eq!(outcome.freelancer_payout, 30);
+    assert_eq!(outcome.client_payout + outcome.freelancer_payout, 100);
+    assert_eq!(outcome.final_status, ContractStatus::Completed);
+    assert_eq!(outcome.new_refunded_amount, 70);
+    assert_eq!(outcome.new_released_amount, 30);
+
+    // State unchanged.
+    let after = client.get_contract(&contract_id);
+    assert_eq!(after.status, ContractStatus::Disputed);
+    assert_eq!(after.refunded_amount, 0);
+    assert_eq!(after.released_amount, 0);
+}
+
+/// Simulate Split returns projected split outcome without mutating state.
+#[test]
+fn simulate_split_matches_real_outcome_and_is_read_only() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (_, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    let split = DisputeSplit {
+        client_amount: 35,
+        freelancer_amount: 65,
+    };
+    let outcome = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::Split(split),
+    );
+
+    assert_eq!(outcome.client_payout, 35);
+    assert_eq!(outcome.freelancer_payout, 65);
+    assert_eq!(outcome.client_payout + outcome.freelancer_payout, 100);
+    assert_eq!(outcome.final_status, ContractStatus::Completed);
+    assert_eq!(outcome.new_refunded_amount, 35);
+    assert_eq!(outcome.new_released_amount, 65);
+
+    // State unchanged.
+    let after = client.get_contract(&contract_id);
+    assert_eq!(after.status, ContractStatus::Disputed);
+    assert_eq!(after.refunded_amount, 0);
+    assert_eq!(after.released_amount, 0);
+}
+
+/// Simulate outcome exactly matches what a real resolve produces.
+#[test]
+fn simulate_matches_real_resolve_outcome() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (client_addr, freelancer_addr, arbiter_addr, contract_id) =
+        funded_contract_with_arbiter(&env, &client);
+
+    // Simulate first, verify output.
+    assert!(client.raise_dispute(&contract_id, &client_addr));
+    let sim = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::FullRefund,
+    );
+    assert_eq!(sim.client_payout, 100);
+    assert_eq!(sim.freelancer_payout, 0);
+    assert_eq!(sim.final_status, ContractStatus::Refunded);
+
+    // Now resolve for real (still in Disputed state because simulate didn't mutate).
+    assert!(client.resolve_dispute(&contract_id, &arbiter_addr, &DisputeResolution::FullRefund));
+    let contract = client.get_contract(&contract_id);
+    assert_eq!(contract.status, ContractStatus::Refunded);
+    assert_eq!(contract.refunded_amount, 100);
+    assert_eq!(contract.released_amount, 0);
+}
+
+/// Simulate is rejected when called by a non-arbiter.
+#[test]
+fn simulate_rejects_non_arbiter() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (client_addr, _, _, contract_id) = disputed_contract(&env, &client);
+    let outsider = Address::generate(&env);
+
+    // Client is a party but not the arbiter → rejected.
+    super::assert_contract_error(
+        client.try_simulate_dispute_resolution(
+            &contract_id,
+            &client_addr,
+            &DisputeResolution::FullRefund,
+        ),
+        Error::UnauthorizedRole,
+    );
+    // Random outsider → rejected.
+    super::assert_contract_error(
+        client.try_simulate_dispute_resolution(
+            &contract_id,
+            &outsider,
+            &DisputeResolution::FullRefund,
+        ),
+        Error::UnauthorizedRole,
+    );
+}
+
+/// Simulate is rejected when the contract is not in Disputed state.
+#[test]
+fn simulate_rejects_non_disputed_state() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (client_addr, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    // Resolve first.
+    assert!(client.resolve_dispute(&contract_id, &arbiter_addr, &DisputeResolution::FullRefund));
+
+    // Now simulate should fail because contract is Refunded (not Disputed).
+    super::assert_contract_error(
+        client.try_simulate_dispute_resolution(
+            &contract_id,
+            &arbiter_addr,
+            &DisputeResolution::FullPayout,
+        ),
+        Error::InvalidStatusTransition,
+    );
+}
+
+/// Simulate is rejected after the contract has been finalized.
+#[test]
+fn simulate_rejects_after_finalize() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (client_addr, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    assert!(client.finalize_contract(&contract_id, &client_addr));
+
+    super::assert_contract_error(
+        client.try_simulate_dispute_resolution(
+            &contract_id,
+            &arbiter_addr,
+            &DisputeResolution::FullRefund,
+        ),
+        Error::AlreadyFinalized,
+    );
+}
+
+/// Simulate rejects a non-existent contract.
+#[test]
+fn simulate_rejects_contract_not_found() {
+    let env = make_env();
+    let client = make_client(&env);
+    let arbiter = Address::generate(&env);
+    let nonexistent_id = 9999u32;
+
+    super::assert_contract_error(
+        client.try_simulate_dispute_resolution(
+            &nonexistent_id,
+            &arbiter,
+            &DisputeResolution::FullRefund,
+        ),
+        Error::ContractNotFound,
+    );
+}
+
+/// Simulate rejects invalid split (non-conserving amounts).
+#[test]
+fn simulate_rejects_invalid_split() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (_, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    let bad_split = DisputeSplit {
+        client_amount: 40,
+        freelancer_amount: 59, // 40 + 59 = 99 ≠ 100
+    };
+    super::assert_contract_error(
+        client.try_simulate_dispute_resolution(
+            &contract_id,
+            &arbiter_addr,
+            &DisputeResolution::Split(bad_split),
+        ),
+        Error::InvalidDisputeSplit,
+    );
+}
+
+/// Simulate can be called multiple times without affecting state — idempotent reads.
+#[test]
+fn simulate_is_idempotent() {
+    let env = make_env();
+    let client = make_client(&env);
+    let (_, _, arbiter_addr, contract_id) = disputed_contract(&env, &client);
+
+    let first = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::PartialRefund,
+    );
+    let second = client.simulate_dispute_resolution(
+        &contract_id,
+        &arbiter_addr,
+        &DisputeResolution::PartialRefund,
+    );
+    assert_eq!(first, second);
+
+    // Still Disputed after multiple simulations.
+    assert_eq!(
+        client.get_contract(&contract_id).status,
+        ContractStatus::Disputed
+    );
+}
+
+/// Table-driven test: simulate matches what resolve would produce for all resolution variants.
+#[test]
+fn simulate_matches_resolve_for_all_variants() {
+    let env = make_env();
+
+    struct Case {
+        resolution: DisputeResolution,
+        expected_client: i128,
+        expected_freelancer: i128,
+        expected_status: ContractStatus,
+        label: &'static str,
+    }
+
+    let cases = &[
+        Case {
+            resolution: DisputeResolution::FullRefund,
+            expected_client: 200,
+            expected_freelancer: 0,
+            expected_status: ContractStatus::Refunded,
+            label: "FullRefund",
+        },
+        Case {
+            resolution: DisputeResolution::FullPayout,
+            expected_client: 0,
+            expected_freelancer: 200,
+            expected_status: ContractStatus::Completed,
+            label: "FullPayout",
+        },
+        Case {
+            resolution: DisputeResolution::PartialRefund,
+            expected_client: 140,    // 200 * 70%
+            expected_freelancer: 60, // 200 * 30%
+            expected_status: ContractStatus::Completed,
+            label: "PartialRefund",
+        },
+    ];
+
+    for case in cases {
+        // Fresh contract per case so simulate doesn't affect resolve.
+        let client = make_client(&env);
+        let client_addr = Address::generate(&env);
+        let freelancer_addr = Address::generate(&env);
+        let arbiter_addr = Address::generate(&env);
+        let milestones = soroban_sdk::vec![&env, 100_i128, 100_i128];
+        let contract_id = client.create_contract(
+            &client_addr,
+            &freelancer_addr,
+            &Some(arbiter_addr.clone()),
+            &milestones,
+            &ReleaseAuthorization::ClientOnly,
+        );
+        client.deposit_funds(&contract_id, &client_addr, &200_i128);
+        client.raise_dispute(&contract_id, &client_addr);
+
+        // Simulate.
+        let sim = client.simulate_dispute_resolution(
+            &contract_id,
+            &arbiter_addr,
+            &case.resolution.clone(),
+        );
+        assert_eq!(
+            sim.client_payout, case.expected_client,
+            "{}: client payout mismatch",
+            case.label
+        );
+        assert_eq!(
+            sim.freelancer_payout, case.expected_freelancer,
+            "{}: freelancer payout mismatch",
+            case.label
+        );
+        assert_eq!(
+            sim.client_payout + sim.freelancer_payout,
+            200,
+            "{}: conservation violated",
+            case.label
+        );
+        assert_eq!(
+            sim.final_status, case.expected_status,
+            "{}: status mismatch",
+            case.label
+        );
+
+        // After simulate, still Disputed.
+        assert_eq!(
+            client.get_contract(&contract_id).status,
+            ContractStatus::Disputed,
+            "{}: simulate mutated state",
+            case.label
+        );
+    }
 }

--- a/contracts/escrow/src/test/summary.rs
+++ b/contracts/escrow/src/test/summary.rs
@@ -14,7 +14,7 @@ const DOCS_CONTRACT: &str = include_str!("../../../../docs/escrow/contract.md");
 const CONTRACT_README: &str = include_str!("../../README.md");
 const ROOT_README: &str = include_str!("../../../../README.md");
 
-const IMPLEMENTED_ENTRYPOINTS: [&str; 19] = [
+const IMPLEMENTED_ENTRYPOINTS: [&str; 20] = [
     "initialize",
     "get_admin",
     "pause",
@@ -34,6 +34,7 @@ const IMPLEMENTED_ENTRYPOINTS: [&str; 19] = [
     "get_finalization_record",
     "get_reputation",
     "get_pending_reputation_credits",
+    "simulate_dispute_resolution",
 ];
 
 const PLANNED_ENTRYPOINTS: [&str; 14] = [

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -343,6 +343,26 @@ pub enum DisputeResolution {
     Split(DisputeSplit),
 }
 
+/// Projected outcome of a dispute resolution for dry-run simulation.
+///
+/// This type is returned by `simulate_dispute_resolution`, the read-only
+/// dry-run variant of `resolve_dispute`. It carries the projected accounting
+/// changes and final status without writing storage or emitting events.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulateDisputeOutcome {
+    /// Amount that would be refunded to the client.
+    pub client_payout: i128,
+    /// Amount that would be released to the freelancer.
+    pub freelancer_payout: i128,
+    /// Projected final contract status after applying the resolution.
+    pub final_status: ContractStatus,
+    /// Projected `refunded_amount` after the resolution.
+    pub new_refunded_amount: i128,
+    /// Projected `released_amount` after the resolution.
+    pub new_released_amount: i128,
+}
+
 impl DisputeResolution {
     pub fn code(&self) -> u32 {
         match self {


### PR DESCRIPTION
## Summary

Add a read-only `simulate_dispute_resolution` entrypoint that returns the projected dispute resolution outcome without writing storage or emitting events.

Closes #1056

## Changes

**New type: `SimulateDisputeOutcome`** (`types.rs`)
- Fields: `client_payout`, `freelancer_payout`, `final_status`, `new_refunded_amount`, `new_released_amount`

**New entrypoint: `simulate_dispute_resolution`** (`lib.rs`)
- Mirrors ALL pre-condition checks from `resolve_dispute`: initialization, pause gate, arbiter auth, contract existence, finalization guard, Disputed state, arbiter matching, payout arithmetic
- Skips: storage writes, TTL extensions, token transfers, events
- Returns projected outcome using the same `resolution_payouts` + `final_status_after_resolution` helpers

**Tests** (`test/dispute.rs`)
- 11 new simulation tests covering all 4 resolution variants, no-state-change verification, matches-real-resolve, non-arbiter/auth rejection, non-Disputed state, after-finalize, invalid split, idempotency, table-driven all-variants

**Test infrastructure fixes** (`test/dispute.rs`)
- `make_env`: `mock_all_auths()` → `mock_all_auths_allowing_non_root_auth()`
- `make_client`: registers + binds settlement token
- `funded_contract_with_arbiter/no_arbiter`: mint tokens before deposit
- Added `mint_and_deposit` helper
- Fixed pre-existing test expectation bugs: PartialRefund rounding, Split acceptance, approval setup, refunded-contract error code

**Updated entrypoint list** (`test/summary.rs`)
- Added `simulate_dispute_resolution` to `IMPLEMENTED_ENTRYPOINTS`

## Test Results

```
cargo test dispute — 41/42 pass

1 pre-existing failure: client_migration::migration_blocked_on_disputed_contract
(settlement token not bound in that test file — unrelated to this PR)
```

- `cargo fmt` passes
- `cargo check` compiles cleanly
- All simulation tests verify no state mutation
- Entrypoint mirroring: every check from `resolve_dispute` is replicated
