### PR TITLE
refactor(escrow): replace magic numbers with named constants

### DIFF
--- a/contracts/escrow/src/contracts.rs
+++ b/contracts/escrow/src/contracts.rs
@@ -148,7 +148,7 @@ impl Escrow {
             max_milestones: MAX_MILESTONES,
             max_single_milestone_stroops: crate::MAX_SINGLE_AMOUNT_STROOPS,
             max_total_escrow_stroops: MAX_TOTAL_ESCROW_STROOPS,
-            max_fee_bps: 10_000,
+            max_fee_bps: crate::milestones_consts::MAX_FEE_BPS,
             max_settlement: Self::effective_max_settlement(&env),
         }
     }

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -40,7 +40,7 @@ impl Escrow {
         admin.require_auth();
 
         storage_validation::validate_protocol_fee_bps(&env, new_bps);
-        if new_bps > 10_000 {
+        if new_bps > crate::milestones_consts::MAX_FEE_BPS {
             env.panic_with_error(EscrowError::InvalidProtocolParameters);
         }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -793,7 +793,10 @@ impl Escrow {
             .unwrap_or_else(|| env.panic_with_error(EscrowError::NotInitialized));
         admin.require_auth();
 
-        if freelancer_bps > 10_000 || client_bps > 10_000 || freelancer_bps + client_bps != 10_000 {
+        if freelancer_bps > crate::milestones_consts::MAX_FEE_BPS
+            || client_bps > crate::milestones_consts::MAX_FEE_BPS
+            || freelancer_bps + client_bps != crate::milestones_consts::PROTOCOL_FEE_BPS_DENOMINATOR
+        {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
@@ -874,7 +877,7 @@ impl Escrow {
             max_milestones: MAX_MILESTONES,
             max_single_milestone_stroops: MAX_SINGLE_AMOUNT_STROOPS,
             max_total_escrow_stroops: MAX_TOTAL_ESCROW_STROOPS,
-            max_fee_bps: 10_000,
+            max_fee_bps: MAX_FEE_BPS,
             max_settlement: Self::effective_max_settlement(&env),
         }
     }

--- a/contracts/escrow/src/milestones_consts.rs
+++ b/contracts/escrow/src/milestones_consts.rs
@@ -96,6 +96,21 @@ pub const MAX_WORK_EVIDENCE_BYTES: u32 = 1_000;
 /// Minimum byte length for a work evidence string (inclusive).
 pub const MIN_WORK_EVIDENCE_BYTES: u32 = 1;
 
+/// Maximum allowed value for the configurable maximum rating parameter in
+/// reputation configuration (`set_reputation_config`).
+///
+/// This is the upper bound that an admin can set for `max_rating`;
+/// the actual rating scale for `issue_reputation` is always 1–5
+/// (see [`MAX_RATING`]).  The ceiling of **10** gives governance
+/// flexibility without allowing unbounded ratings.
+pub const MAX_REPUTATION_CONFIG_RATING_CEILING: u32 = 10;
+
+/// Maximum allowed value for the configurable maximum comment bytes parameter
+/// in reputation configuration (`set_reputation_config`).
+///
+/// This caps how large the `max_comment_bytes` field can be set by admin.
+pub const MAX_REPUTATION_CONFIG_COMMENT_BYTES_CEILING: u32 = 1_000;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,6 +127,10 @@ mod tests {
         assert_eq!(MAX_RATING, 5);
         assert_eq!(MAX_COMMENT_BYTES, 200);
         assert_eq!(MIN_COMMENT_BYTES, 1);
+        assert_eq!(MAX_WORK_EVIDENCE_BYTES, 1_000);
+        assert_eq!(MIN_WORK_EVIDENCE_BYTES, 1);
+        assert_eq!(MAX_REPUTATION_CONFIG_RATING_CEILING, 10);
+        assert_eq!(MAX_REPUTATION_CONFIG_COMMENT_BYTES_CEILING, 1_000);
     }
 
     /// MAX_FEE_BPS must equal the denominator — charging 100 % is the ceiling.

--- a/contracts/escrow/src/storage_validation.rs
+++ b/contracts/escrow/src/storage_validation.rs
@@ -9,7 +9,8 @@
 //! top of the corresponding entrypoint, before any state mutation occurs.
 
 use crate::milestones_consts::{
-    MAX_FEE_BPS, MAX_MILESTONES, MAX_RATING, MIN_COMMENT_BYTES, MIN_RATING,
+    MAX_FEE_BPS, MAX_MILESTONES, MAX_RATING, MAX_REPUTATION_CONFIG_RATING_CEILING,
+    MAX_REPUTATION_CONFIG_COMMENT_BYTES_CEILING, MIN_COMMENT_BYTES, MIN_RATING,
 };
 use crate::{Error, EscrowError};
 use soroban_sdk::Env;
@@ -49,9 +50,9 @@ pub(crate) fn validate_reputation_config_params(
 ) {
     if min_rating < MIN_RATING
         || max_rating < min_rating
-        || max_rating > 10
+        || max_rating > MAX_REPUTATION_CONFIG_RATING_CEILING
         || max_comment_bytes < MIN_COMMENT_BYTES
-        || max_comment_bytes > 1_000
+        || max_comment_bytes > MAX_REPUTATION_CONFIG_COMMENT_BYTES_CEILING
     {
         env.panic_with_error(Error::InvalidProtocolParameters);
     }


### PR DESCRIPTION
issue fixed
#1063 Replace magic numbers in escrow with named constants 

close #1063 