### PR TITLE
refactor(disputes): name magic numbers in DisputeConfig defaults

### DIFF
--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -18,6 +18,25 @@ pub const PARTIAL_REFUND_FREELANCER_PERCENT: i128 = 30;
 /// Percent base used with [`PARTIAL_REFUND_FREELANCER_PERCENT`].
 pub const PARTIAL_REFUND_PERCENT_BASE: i128 = 100;
 
+// ---------------------------------------------------------------------------
+// DisputeConfig default basis-point constants
+// ---------------------------------------------------------------------------
+
+/// Default freelancer share of a partial-refund dispute resolution, in basis points.
+///
+/// `3_000 bps = 30 %`. This is stored in [`DisputeConfig::partial_refund_freelancer_bps`]
+/// when no explicit arbiter configuration has been set via `set_arbiter_config`. The
+/// counterpart (client share) is [`DEFAULT_DISPUTE_CLIENT_BPS`] = 7_000 bps = 70 %.
+pub const DEFAULT_DISPUTE_FREELANCER_BPS: u32 = 3_000;
+
+/// Default client share of a partial-refund dispute resolution, in basis points.
+///
+/// `7_000 bps = 70 %`. The pair `(DEFAULT_DISPUTE_FREELANCER_BPS, DEFAULT_DISPUTE_CLIENT_BPS)`
+/// must sum to `10_000 bps (100 %)`. This constant is used as the default value of
+/// [`DisputeConfig::partial_refund_client_bps`] when the arbiter has not explicitly
+/// configured a dispute split via `set_arbiter_config`.
+pub const DEFAULT_DISPUTE_CLIENT_BPS: u32 = 7_000;
+
 #[soroban_sdk::contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DisputeInfo {

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -591,8 +591,8 @@ pub struct DisputeConfig {
 impl Default for DisputeConfig {
     fn default() -> Self {
         DisputeConfig {
-            partial_refund_freelancer_bps: 3000,
-            partial_refund_client_bps: 7000,
+            partial_refund_freelancer_bps: crate::dispute::DEFAULT_DISPUTE_FREELANCER_BPS,
+            partial_refund_client_bps: crate::dispute::DEFAULT_DISPUTE_CLIENT_BPS,
         }
     }
 }


### PR DESCRIPTION
## Overview
This PR replaces the unexplained literal basis-point values (3000, 7000) in `DisputeConfig::default()` with documented named constants, improving code readability and maintainability.

## Related Issue
Closes #1058

## Changes
[ADD] `contracts/escrow/src/dispute.rs` — Two new named constants with rustdoc:
- `DEFAULT_DISPUTE_FREELANCER_BPS` (3_000 bps = 30%)
- `DEFAULT_DISPUTE_CLIENT_BPS` (7_000 bps = 70%)

[MODIFY] `contracts/escrow/src/types.rs` — `DisputeConfig::default()` now references the named constants instead of inline literals.

## Verification Results
Behaviour unchanged; values identical.
Tests still pass.

## Acceptance Criteria
| Status | Criterion |
|--------|-----------|
| ✅ | Magic numbers extracted into named constants |
| ✅ | Each constant has rustdoc explaining its purpose and unit |
| ✅ | Values identical (3_000 and 7_000 bps) |
| ✅ | Behaviour unchanged |
