### PR TITLE
Emit missing events for milestone approvals and reputation issuance

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -187,9 +187,9 @@ impl Escrow {
     //    interface, the call panics and the bind is rejected with
     //    `InvalidSettlementToken`.
     // 2. Rejects `env.current_contract_address()` (the escrow contract itself)
-    //    with `SettlementTokenIsSelf` — binding self creates a circular custody
+    //    with `SettlementTokenIsSelf` â€” binding self creates a circular custody
     //    reference.
-    // 3. Rejects the stored admin address with `SettlementTokenIsAdmin` —
+    // 3. Rejects the stored admin address with `SettlementTokenIsAdmin` â€”
     //    conflating governance authority with the settlement token role is a
     //    privilege-separation violation.
     //
@@ -201,8 +201,8 @@ impl Escrow {
     // state is finalized *before* any `token::Client::transfer` call.  A
     // malicious token contract that re-enters the escrow during a transfer will
     // observe the already-mutated state and cannot double-spend or front-run
-    // the operation.  The probe itself performs no state mutation — it only
-    // reads the token balance — so it cannot be used as a reentrancy vector.
+    // the operation.  The probe itself performs no state mutation â€” it only
+    // reads the token balance â€” so it cannot be used as a reentrancy vector.
     //
     // See [`docs/escrow/sac-custody.md`](../../../docs/escrow/sac-custody.md) for the
     // full custody model, accounting invariant, and lifecycle sequence diagram.
@@ -251,15 +251,15 @@ impl Escrow {
             env.panic_with_error(EscrowError::SettlementTokenAlreadyBound);
         }
 
-        // ── Pre-bind probe (issue #723) ─────────────────────────────────────
+        // â”€â”€ Pre-bind probe (issue #723) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         //
-        // Reject the escrow contract's own address — binding self would create
+        // Reject the escrow contract's own address â€” binding self would create
         // a circular custody reference and brick every transfer path.
         if token == env.current_contract_address() {
             env.panic_with_error(EscrowError::SettlementTokenAlreadyBound);
         }
 
-        // Reject the admin address — conflating governance authority with the
+        // Reject the admin address â€” conflating governance authority with the
         // settlement token role is a privilege-separation violation.
         if token == stored_admin {
             env.panic_with_error(EscrowError::SettlementTokenAlreadyBound);
@@ -273,7 +273,7 @@ impl Escrow {
         // This is safe because:
         // - `balance` is a read-only entrypoint (no state mutation on the
         //   token contract).
-        // - We have not yet written anything to storage — a panic here leaves
+        // - We have not yet written anything to storage â€” a panic here leaves
         //   no partial state.
         // - The probe cannot be used for reentrancy: it calls `balance`, not
         //   `transfer`, and the escrow has no callback the token could invoke.
@@ -290,7 +290,7 @@ impl Escrow {
         );
         true
     }
-    // ── Contract Creation & Funding ──────────────────────────────────────────
+    // â”€â”€ Contract Creation & Funding â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Creates a new escrow contract with the specified participants and milestone amounts.
 
@@ -310,7 +310,7 @@ impl Escrow {
         deposit::apply_validated_deposit(&env, contract_id, caller, validated)
     }
 
-    // ── Client Migrations ────────────────────────────────────────────────────
+    // â”€â”€ Client Migrations â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     pub fn propose_client_migration(
         env: Env,
@@ -335,7 +335,7 @@ impl Escrow {
         Self::get_pending_client_migration_impl(&env, contract_id)
     }
 
-    // ── Milestone Releases & Refunds ──────────────────────────────────────────
+    // â”€â”€ Milestone Releases & Refunds â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     pub fn approve_milestone_release(
         env: Env,
@@ -346,7 +346,14 @@ impl Escrow {
         Self::require_not_paused(&env);
         Self::require_not_finalized(&env, contract_id);
         approvals::approve_milestone(&env, contract_id, milestone_index, &caller)
-            .unwrap_or_else(|e| env.panic_with_error(e))
+            .unwrap_or_else(|e| env.panic_with_error(e));
+
+        // 🔔 NEW EVENT: Emit approval event after successful storage write.
+        env.events().publish(
+            (symbol_short!("mlstn_app"), contract_id),
+            (milestone_index, caller.clone(), env.ledger().timestamp()),
+        );
+        true
     }
 
     pub fn release_milestone(
@@ -542,7 +549,7 @@ impl Escrow {
     // This is the recommended cheap pre-flight readiness check before calling
     // `deposit_funds`, which panics when no settlement token has been bound.
     // Integrators that only need to know *whether* the escrow can accept
-    // deposits — without caring about the specific token address — should use
+    // deposits â€” without caring about the specific token address â€” should use
     // this instead of fetching and discarding the `Address` from
     // `get_settlement_token`.
     //
@@ -556,7 +563,7 @@ impl Escrow {
         Self::read_settlement_token(&env).is_some()
     }
 
-    // ── Initialization ───────────────────────────────────────────────────────
+    // â”€â”€ Initialization â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Initializes the escrow contract with the operational admin.
     //
@@ -657,7 +664,7 @@ impl Escrow {
     // * [`EscrowError::LimitOutOfRange`] if `max_settlement` is outside bounds.
     //
     // # Events
-    // `("limits", "max_settlement")` → `(max_settlement: u32, timestamp: u64)`
+    // `("limits", "max_settlement")` â†’ `(max_settlement: u32, timestamp: u64)`
     pub fn set_max_settlement(env: Env, max_settlement: u32) -> bool {
         Self::require_initialized(&env);
         let admin: Address = env
@@ -693,7 +700,7 @@ impl Escrow {
 
     // Returns protocol-wide hard-coded limits as a [`ContractBounds`] struct.
     //
-    // This is a read-only accessor — it does **not** require authorization
+    // This is a read-only accessor â€” it does **not** require authorization
     // and succeeds even before `initialize` has been called.
     //
     // # Fields
@@ -831,10 +838,10 @@ impl Escrow {
     /// Duplicate approvals from the same party are rejected.
     ///
     /// Required approvers per mode:
-    /// - `ClientOnly` — client only
-    /// - `ArbiterOnly` — arbiter only
-    /// - `ClientAndArbiter` — client or arbiter (one is enough)
-    /// - `MultiSig` — both client and freelancer must approve
+    /// - `ClientOnly` â€” client only
+    /// - `ArbiterOnly` â€” arbiter only
+    /// - `ClientAndArbiter` â€” client or arbiter (one is enough)
+    /// - `MultiSig` â€” both client and freelancer must approve
     ///
     /// # Errors
     /// * `ContractPaused` - If the contract is paused while not in emergency mode
@@ -863,7 +870,7 @@ impl Escrow {
 
     /// Releases a specific milestone, transferring the net payout to the freelancer.
     ///
-    /// Executes `SAC::transfer(from: escrow_address, to: freelancer, milestone.amount − fee)`.
+    /// Executes `SAC::transfer(from: escrow_address, to: freelancer, milestone.amount âˆ’ fee)`.
     /// The protocol fee is retained inside the contract under
     /// `DataKey::AccumulatedProtocolFees` and stays commingled with the escrow balance
     /// until `withdraw_protocol_fees` is called.
@@ -881,7 +888,7 @@ impl Escrow {
     /// both of those addresses have approved the same milestone.
     ///
     /// Approvals are cleared from temporary storage after a successful release.
-    /// Missing or expired approvals are fail-closed — they produce
+    /// Missing or expired approvals are fail-closed â€” they produce
     /// `InsufficientApprovals` and the call panics without mutating state.
     ///
     /// See `approve_milestone_release`, `get_milestone_approvals`, and
@@ -1207,7 +1214,7 @@ impl Escrow {
     // * `env` - The contract environment
     //
     // # Returns
-    // The next contract ID to be allocated (always ≥ 1)
+    // The next contract ID to be allocated (always â‰¥ 1)
     //
     // # Examples
     // ```
@@ -1353,7 +1360,7 @@ impl Escrow {
     // Retrieves approval status for a milestone.
     //
     // Returns `None` when no approval record exists or when the TTL has
-    // elapsed. Treat `None` and an all-`false` struct identically — neither
+    // elapsed. Treat `None` and an all-`false` struct identically â€” neither
     // unblocks `release_milestone`.
     //
     // On a successful read, this entrypoint renews the temporary approval
@@ -1438,7 +1445,7 @@ impl Escrow {
         Self::get_authorization_records(env, contract_id, start, limit)
     }
 
-    // ── Pause / unpause ──────────────────────────────────────────────────────
+    // â”€â”€ Pause / unpause â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Pause all state-changing escrow operations.
     //
@@ -1460,7 +1467,7 @@ impl Escrow {
 
     // Unpause operations, clearing the `Paused` flag.
     //
-    // Blocked while `Emergency` is active — use `resolve_emergency` instead.
+    // Blocked while `Emergency` is active â€” use `resolve_emergency` instead.
     // Requires the stored admin's authorization.
     //
     // # Events
@@ -1494,7 +1501,7 @@ impl Escrow {
             .unwrap_or(false)
     }
 
-    // ── Emergency pause ──────────────────────────────────────────────────────
+    // â”€â”€ Emergency pause â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Activate emergency pause, setting both `Emergency` and `Paused` flags.
     //
@@ -1594,7 +1601,7 @@ impl Escrow {
             .unwrap_or(false)
     }
 
-    // ── Cancel contract ──────────────────────────────────────────────────────
+    // â”€â”€ Cancel contract â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     pub fn get_mainnet_readiness_info(env: Env) -> MainnetReadinessInfo {
         let checklist = Self::load_checklist(&env);
@@ -1608,7 +1615,7 @@ impl Escrow {
         }
     }
 
-    // ─── Configurable limits ──────────────────────────────────────────────────
+    // â”€â”€â”€ Configurable limits â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Set the max escrow stroops limit. Admin only. Rejects out-of-range values.
     pub fn set_max_escrow_stroops(env: Env, max_escrow_stroops: i128) -> bool {
@@ -1673,7 +1680,7 @@ impl Escrow {
             .unwrap_or(DEFAULT_MAX_ARBITERS)
     }
 
-    // ─── Contract lifecycle ───────────────────────────────────────────────────
+    // â”€â”€â”€ Contract lifecycle â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Cancels a contract before any milestone has been released.
     ///
@@ -1749,9 +1756,9 @@ impl Escrow {
         true
     }
 
-    // ── Dispute management ────────────────────────────────────────────────────
+    // â”€â”€ Dispute management â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-    // ── Reputation ───────────────────────────────────────────────────────────
+    // â”€â”€ Reputation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Returns the current reputation validation parameters (rating bounds and
     // comment-length cap).
@@ -1954,6 +1961,16 @@ impl Escrow {
             ttl::PERSISTENT_TTL_LEDGERS,
         );
 
+        // 🔔 NEW EVENT: Emit reputation issued event after all state updates.
+        env.events().publish(
+            (symbol_short!("rep_issd"), contract_id),
+            (
+                contract.freelancer.clone(),
+                rating,
+                env.ledger().timestamp(),
+            ),
+        );
+
         true
     }
 
@@ -1978,19 +1995,19 @@ impl Escrow {
             .get(&DataKey::Reputation(address))
     }
 
-    // Returns the freelancer's average rating scaled to basis points (×10 000),
+    // Returns the freelancer's average rating scaled to basis points (Ã—10 000),
     // or `None` if no reputation record exists or no contracts have been completed.
     //
     // # Scaling
     // `result = total_rating * 10_000 / completed_contracts`
     //
     // A raw rating of 5 on a single contract returns `50_000` (5.0000 on a
-    // 1–5 scale).  Clients divide by `10_000` to recover the decimal value.
+    // 1â€“5 scale).  Clients divide by `10_000` to recover the decimal value.
     //
     // Checked arithmetic is used throughout; division by zero is impossible
     // because `None` is returned whenever `completed_contracts == 0`.
     pub fn get_average_rating(env: Env, address: Address) -> Option<i128> {
-        // Basis-point scaling factor (×10 000 preserves four decimal places).
+        // Basis-point scaling factor (Ã—10 000 preserves four decimal places).
         const SCALE: i128 = 10_000;
 
         let rep: types::Reputation = env
@@ -2082,16 +2099,16 @@ impl Escrow {
     // * `evidence`    - Deliverable reference; max 256 bytes
     //
     // # Errors
-    // * `NotInitialized`     — `initialize` has not been called
-    // * `ContractPaused` / `EmergencyActive` — pause/emergency gate
-    // * `ContractNotFound`   — unknown `contract_id`
-    // * `AlreadyFinalized`   — contract has been finalized
-    // * `UnauthorizedRole`   — `caller` is not the freelancer
-    // * `InvalidState`       — contract is not `Funded`
-    // * `IndexOutOfBounds`   — `milestone_index` exceeds milestone count
-    // * `MilestoneAlreadyReleased` — milestone is already released
-    // * `AlreadyRefunded`    — milestone has been refunded
-    // * `EvidenceTooLong`    — evidence string exceeds 256 bytes
+    // * `NotInitialized`     â€” `initialize` has not been called
+    // * `ContractPaused` / `EmergencyActive` â€” pause/emergency gate
+    // * `ContractNotFound`   â€” unknown `contract_id`
+    // * `AlreadyFinalized`   â€” contract has been finalized
+    // * `UnauthorizedRole`   â€” `caller` is not the freelancer
+    // * `InvalidState`       â€” contract is not `Funded`
+    // * `IndexOutOfBounds`   â€” `milestone_index` exceeds milestone count
+    // * `MilestoneAlreadyReleased` â€” milestone is already released
+    // * `AlreadyRefunded`    â€” milestone has been refunded
+    // * `EvidenceTooLong`    â€” evidence string exceeds 256 bytes
     pub fn submit_work_evidence(
         env: Env,
         contract_id: u32,
@@ -2107,14 +2124,14 @@ impl Escrow {
 
         let contract: Contract = Self::require_active_contract(&env, contract_id);
 
-        // ── Caller gate ──────────────────────────────────────────────────────
+        // â”€â”€ Caller gate â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         // Only the contract's freelancer may submit evidence. Reject the
         // client, any arbiter, and all third parties outright.
         if caller != contract.freelancer {
             env.panic_with_error(EscrowError::UnauthorizedRole);
         }
 
-        // ── Contract-state gate ──────────────────────────────────────────────
+        // â”€â”€ Contract-state gate â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         // Evidence submissions are only meaningful while the contract is
         // actively funded and awaiting milestone release. Any settled,
         // cancelled, or otherwise terminal state must be rejected so that the
@@ -2123,8 +2140,8 @@ impl Escrow {
             env.panic_with_error(EscrowError::InvalidState);
         }
 
-        // ── Evidence string validation ───────────────────────────────────────
-        // Reject empty strings — a zero-length evidence reference has no
+        // â”€â”€ Evidence string validation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+        // Reject empty strings â€” a zero-length evidence reference has no
         // semantic value and is likely a caller bug.
         if evidence.len() == 0 {
             env.panic_with_error(Error::EmptyEvidence);
@@ -2262,9 +2279,9 @@ impl Escrow {
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    // ── Finalization ─────────────────────────────────────────────────────────
+    // â”€â”€ Finalization â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-    // ── Governance ───────────────────────────────────────────────────────────
+    // â”€â”€ Governance â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Returns the total accumulated protocol fees in stroops.
     //
@@ -2294,7 +2311,7 @@ impl Escrow {
     // full custody model, accounting invariant, and security notes on commingled fees.
     //
     // See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
-    // the complete fee lifecycle — basis-point model, accrual, withdrawal authorization,
+    // the complete fee lifecycle â€” basis-point model, accrual, withdrawal authorization,
     // worked examples, and the release-to-withdrawal sequence diagram.
     //
     // Requires the stored admin's authorization. Only an amount up to the
@@ -2312,13 +2329,13 @@ impl Escrow {
     /// the entire treasury in a single call:
     ///
     /// - **Per-withdrawal cap** (stored under [`DataKey::FeeWithdrawalCap`],
-    ///   default 5 000 bps = 50 %): the requested `amount` must not exceed
+    ///   default 5â€¯000â€¯bps = 50â€¯%): the requested `amount` must not exceed
     ///   `accumulated * cap_bps / 10_000`.  An admin can never withdraw more
     ///   than the configured fraction of the accumulated fees in one
     ///   transaction.
     /// - **Cooldown interval** (stored under
-    ///   [`DataKey::FeeWithdrawalCooldownLedgers`], default 17 280 ledgers =
-    ///   1 day): at least this many ledgers must have elapsed since the last
+    ///   [`DataKey::FeeWithdrawalCooldownLedgers`], default 17â€¯280 ledgers =
+    ///   1â€¯day): at least this many ledgers must have elapsed since the last
     ///   successful withdrawal recorded in
     ///   [`DataKey::LastFeeWithdrawalLedger`].
     ///
@@ -2327,27 +2344,27 @@ impl Escrow {
     /// Partial withdrawals are exact: [`DataKey::AccumulatedProtocolFees`] is
     /// decremented by exactly `amount`, so the unconsumed remainder carries
     /// forward to the next withdrawal.  The cap is evaluated against the
-    /// *current* accumulated balance at call time — subsequent fee accruals
+    /// *current* accumulated balance at call time â€” subsequent fee accruals
     /// increase the allowable withdrawal size.
     ///
     /// # Errors
-    /// * [`EscrowError::ContractPaused`] — contract is paused or in emergency.
-    /// * [`EscrowError::NotInitialized`] — `initialize` has not been called.
-    /// * [`EscrowError::UnauthorizedRole`] — `admin` didn't authorize.
-    /// * [`EscrowError::AmountMustBePositive`] — amount ≤ 0 or exceeds
+    /// * [`EscrowError::ContractPaused`] â€” contract is paused or in emergency.
+    /// * [`EscrowError::NotInitialized`] â€” `initialize` has not been called.
+    /// * [`EscrowError::UnauthorizedRole`] â€” `admin` didn't authorize.
+    /// * [`EscrowError::AmountMustBePositive`] â€” amount â‰¤ 0 or exceeds
     ///   `MAX_SINGLE_AMOUNT_STROOPS`.
-    /// * [`EscrowError::InsufficientAccumulatedFees`] — amount > accumulated.
-    /// * [`EscrowError::FeeWithdrawalCapExceeded`] — exceeds the per-withdrawal
+    /// * [`EscrowError::InsufficientAccumulatedFees`] â€” amount > accumulated.
+    /// * [`EscrowError::FeeWithdrawalCapExceeded`] â€” exceeds the per-withdrawal
     ///   fraction cap.
-    /// * [`EscrowError::FeeWithdrawalCooldownActive`] — cooldown has not
+    /// * [`EscrowError::FeeWithdrawalCooldownActive`] â€” cooldown has not
     ///   elapsed since the last withdrawal.
     ///
     /// # Events
-    /// `("fee", "withdraw")` → `(admin, to, amount, timestamp)`
+    /// `("fee", "withdraw")` â†’ `(admin, to, amount, timestamp)`
     pub fn withdraw_protocol_fees(env: Env, amount: i128, to: Address) -> bool {
         Self::require_initialized(&env);
 
-        // Block withdrawal while paused or in emergency — consistent with all
+        // Block withdrawal while paused or in emergency â€” consistent with all
         // other mutating entrypoints in this contract.
         if env
             .storage()
@@ -2384,8 +2401,8 @@ impl Escrow {
             env.panic_with_error(EscrowError::InsufficientAccumulatedFees);
         }
 
-        // ── Per-withdrawal cap (basis points) ──────────────────────────────
-        // Default 5 000 bps = 50 % of accumulated fees per withdrawal.
+        // â”€â”€ Per-withdrawal cap (basis points) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+        // Default 5â€¯000 bps = 50â€¯% of accumulated fees per withdrawal.
         let cap_bps: u32 = env
             .storage()
             .persistent()
@@ -2405,7 +2422,7 @@ impl Escrow {
             }
         }
 
-        // ── Cooldown check ─────────────────────────────────────────────────
+        // â”€â”€ Cooldown check â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         let cooldown_ledgers: u32 = env
             .storage()
             .persistent()
@@ -2432,7 +2449,7 @@ impl Escrow {
             None => env.panic_with_error(Error::SettlementTokenNotConfigured),
         };
 
-        // ── Record last withdrawal ledger BEFORE transfer (CEI) ────────────
+        // â”€â”€ Record last withdrawal ledger BEFORE transfer (CEI) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         env.storage()
             .persistent()
             .set(&DataKey::LastFeeWithdrawalLedger, &env.ledger().sequence());
@@ -2467,21 +2484,21 @@ impl Escrow {
     /// Delegates to `propose_governance_admin_impl`. The stored admin must authorize.
     ///
     /// # Events
-    /// `(symbol_short!("admin"), Symbol("proposed"))` → `(admin, proposed, timestamp)`
+    /// `(symbol_short!("admin"), Symbol("proposed"))` â†’ `(admin, proposed, timestamp)`
 
     /// Accept a pending governance admin proposal, enforcing the timelock.
     ///
     /// Delegates to `accept_governance_admin_impl`. The proposed admin must authorize.
     ///
     /// # Events
-    /// `(symbol_short!("admin"), Symbol("accepted"))` → `(old_admin, new_admin, timestamp)`
+    /// `(symbol_short!("admin"), Symbol("accepted"))` â†’ `(old_admin, new_admin, timestamp)`
 
     /// Cancel a pending governance admin proposal, aborting a two-step transfer.
     ///
     /// Delegates to `cancel_governance_admin_proposal_impl`. Only the current admin may cancel.
     ///
     /// # Events
-    /// `(symbol_short!("admin"), Symbol("cancelled"))` → `(admin, cancelled_proposal, timestamp)`
+    /// `(symbol_short!("admin"), Symbol("cancelled"))` â†’ `(admin, cancelled_proposal, timestamp)`
     pub fn cancel_governance_admin_proposal(env: Env) -> bool {
         Self::cancel_governance_admin_proposal_impl(&env)
     }
@@ -2494,8 +2511,8 @@ impl Escrow {
     /// propose/accept/read paths.
     ///
     /// # Returns
-    /// * `Some(Address)` — the proposed governance admin address
-    /// * `None` — no pending proposal exists
+    /// * `Some(Address)` â€” the proposed governance admin address
+    /// * `None` â€” no pending proposal exists
     pub fn get_pending_governance_admin(env: Env) -> Option<Address> {
         Self::get_pending_governance_admin_impl(&env)
     }
@@ -2523,7 +2540,7 @@ impl Escrow {
 
     /// Accept an existing governance admin proposal.
 
-    // ── Protocol fee helpers ─────────────────────────────────────────────────
+    // â”€â”€ Protocol fee helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Reads the stored protocol fee in basis points (0 = no fee).
     //
@@ -2539,7 +2556,7 @@ impl Escrow {
     // Computes the protocol fee for a given `amount` at `fee_bps` basis points.
     //
     // Uses integer **floor division**: `fee = amount * fee_bps / 10_000`.
-    // The result always rounds down — it never rounds up — so the freelancer
+    // The result always rounds down â€” it never rounds up â€” so the freelancer
     // receives at least `amount - fee` stroops and the protocol receives at most
     // the floored value.  Callers must ensure `fee <= amount` holds; this is
     // guaranteed for any `fee_bps` in `[0, 10_000]` and a non-negative `amount`.
@@ -2569,7 +2586,7 @@ impl Escrow {
         product / PROTOCOL_FEE_BPS_DENOMINATOR as i128
     }
 
-    // ── Internal guards ──────────────────────────────────────────────────────
+    // â”€â”€ Internal guards â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     // Panics with `NotInitialized` unless `initialize` has been called.
     pub(crate) fn require_initialized(env: &Env) {
@@ -2671,7 +2688,7 @@ impl Escrow {
             (contract_id, caller.clone()),
         );
 
-        // `dsp_index` / `raised` — dedicated indexer event for dispute state changes.
+        // `dsp_index` / `raised` â€” dedicated indexer event for dispute state changes.
         //
         // Topics : `(symbol_short!("dsp_index"), symbol_short!("raised"))`
         // Data   : `(contract_id: u32, caller: Address, funded_amount: i128,
@@ -2788,7 +2805,7 @@ impl Escrow {
             (contract_id, resolution.code()),
         );
 
-        // `dsp_index` / `settled` — dedicated indexer event for dispute resolution.
+        // `dsp_index` / `settled` â€” dedicated indexer event for dispute resolution.
         //
         // Topics : `(symbol_short!("dsp_index"), symbol_short!("settled"))`
         // Data   : `(contract_id: u32, resolution_code: u32, client_payout: i128,
@@ -2812,7 +2829,7 @@ impl Escrow {
     ///
     /// Read-only and side-effect-free on the unknown-contract path. Unlike other
     /// getters, this does not panic with `ContractNotFound` for an unknown
-    /// `contract_id` — it returns a progress struct with `completed: 0` and
+    /// `contract_id` â€” it returns a progress struct with `completed: 0` and
     /// `total: 0` instead, since it is meant as a cheap probe rather than a
     /// strict existence check.
     pub fn get_milestone_progress(env: Env, contract_id: u32) -> MilestoneProgress {

--- a/contracts/escrow/src/test/event_assertions.rs
+++ b/contracts/escrow/src/test/event_assertions.rs
@@ -1,0 +1,215 @@
+#![cfg(test)]
+
+//! Tests for the newly added events: `mlstn_app` (milestone approval) and
+//! `rep_issd` (reputation issuance).
+
+use soroban_sdk::String;
+use soroban_sdk::{testutils::Events as _, Address, Env, Symbol, TryIntoVal, Val, Vec};
+
+use crate::test::EscrowFixture;
+use crate::ReleaseAuthorization;
+
+/// Helper to collect all events with a given primary topic and contract ID.
+/// Returns a vector of `(milestone_index, raw_payload)`.
+fn events_with_topic_and_contract(
+    env: &Env,
+    contract_address: &Address,
+    topic: Symbol,
+    contract_id: u32,
+) -> Vec<(u32, Val)> {
+    let mut out = Vec::new(env);
+    for (addr, topics, data) in env.events().all().iter() {
+        if &addr != contract_address {
+            continue;
+        }
+        if topics.len() < 2 {
+            continue;
+        }
+        let t0: Symbol = topics.get(0).unwrap().try_into_val(env).unwrap();
+        if t0 != topic {
+            continue;
+        }
+        let cid: u32 = topics.get(1).unwrap().try_into_val(env).unwrap();
+        if cid != contract_id {
+            continue;
+        }
+        let milestone_index = if topics.len() >= 3 {
+            topics.get(2).unwrap().try_into_val(env).unwrap()
+        } else {
+            0u32
+        };
+        out.push_back((milestone_index, data.clone()));
+    }
+    out
+}
+
+#[test]
+fn approve_milestone_release_emits_mlstn_app_exactly_once() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let contract_id = fixture.escrow_id;
+    let milestone_index = 0u32;
+
+    fixture
+        .escrow()
+        .approve_milestone_release(&contract_id, &fixture.client, &milestone_index);
+
+    let topic = Symbol::new(&fixture.env, "mlstn_app");
+    let events = events_with_topic_and_contract(
+        &fixture.env,
+        &fixture.escrow_address,
+        topic.clone(),
+        contract_id,
+    );
+    assert_eq!(events.len(), 1, "Expected exactly one mlstn_app event");
+
+    let (idx, payload) = events.get(0).unwrap();
+    assert_eq!(idx, milestone_index);
+    let decoded: (u32, Address, u64) = payload.try_into_val(&fixture.env).unwrap();
+    assert_eq!(decoded.0, milestone_index);
+    assert_eq!(decoded.1, fixture.client);
+    // Check that timestamp equals the ledger timestamp (which may be 0 in tests)
+    assert_eq!(decoded.2, fixture.env.ledger().timestamp());
+}
+
+#[test]
+fn approve_milestone_release_failure_does_not_emit() {
+    let fixture = EscrowFixture::builder()
+        .release_authorization(ReleaseAuthorization::ClientOnly)
+        .funded()
+        .build();
+    let contract_id = fixture.escrow_id;
+    let milestone_index = 0u32;
+
+    let res = fixture.escrow().try_approve_milestone_release(
+        &contract_id,
+        &fixture.freelancer,
+        &milestone_index,
+    );
+    assert!(res.is_err(), "Expected error for unauthorized approval");
+
+    let topic = Symbol::new(&fixture.env, "mlstn_app");
+    let events =
+        events_with_topic_and_contract(&fixture.env, &fixture.escrow_address, topic, contract_id);
+    assert_eq!(
+        events.len(),
+        0,
+        "No approval event should be emitted on failure"
+    );
+}
+
+#[test]
+fn issue_reputation_emits_rep_issd_exactly_once() {
+    let fixture = EscrowFixture::builder().completed().build();
+    let contract_id = fixture.escrow_id;
+    let rating = 5u32;
+    let comment = String::from_str(&fixture.env, "Great work!");
+
+    fixture
+        .escrow()
+        .issue_reputation(&contract_id, &fixture.client, &rating, &comment);
+
+    let topic = Symbol::new(&fixture.env, "rep_issd");
+    let events = events_with_topic_and_contract(
+        &fixture.env,
+        &fixture.escrow_address,
+        topic.clone(),
+        contract_id,
+    );
+    assert_eq!(events.len(), 1, "Expected exactly one rep_issd event");
+
+    let (idx, payload) = events.get(0).unwrap();
+    assert_eq!(idx, 0);
+    let decoded: (Address, u32, u64) = payload.try_into_val(&fixture.env).unwrap();
+    assert_eq!(decoded.0, fixture.freelancer);
+    assert_eq!(decoded.1, rating);
+    assert_eq!(decoded.2, fixture.env.ledger().timestamp());
+}
+
+#[test]
+fn issue_reputation_failure_does_not_emit() {
+    let fixture = EscrowFixture::builder().funded().build(); // not Completed
+    let contract_id = fixture.escrow_id;
+    let rating = 5u32;
+    let comment = String::from_str(&fixture.env, "Good");
+
+    let res =
+        fixture
+            .escrow()
+            .try_issue_reputation(&contract_id, &fixture.client, &rating, &comment);
+    assert!(
+        res.is_err(),
+        "Expected error because contract is not Completed"
+    );
+
+    let topic = Symbol::new(&fixture.env, "rep_issd");
+    let events =
+        events_with_topic_and_contract(&fixture.env, &fixture.escrow_address, topic, contract_id);
+    assert_eq!(
+        events.len(),
+        0,
+        "No reputation event should be emitted on failure"
+    );
+}
+
+#[test]
+fn read_only_calls_emit_no_events() {
+    let fixture = EscrowFixture::builder().funded().build();
+    let env = &fixture.env;
+    let contract_id = fixture.escrow_id;
+
+    fixture.escrow().get_contract(&contract_id);
+    fixture.escrow().get_milestones(&contract_id);
+    fixture.escrow().get_contract_summary(&contract_id);
+
+    let app_topic = Symbol::new(env, "mlstn_app");
+    let issd_topic = Symbol::new(env, "rep_issd");
+    let app_events =
+        events_with_topic_and_contract(env, &fixture.escrow_address, app_topic, contract_id);
+    let issd_events =
+        events_with_topic_and_contract(env, &fixture.escrow_address, issd_topic, contract_id);
+    assert_eq!(
+        app_events.len(),
+        0,
+        "mlstn_app should not be emitted on read-only calls"
+    );
+    assert_eq!(
+        issd_events.len(),
+        0,
+        "rep_issd should not be emitted on read-only calls"
+    );
+}
+
+#[test]
+fn new_event_topics_do_not_collide() {
+    let existing = [
+        "admin",
+        "cancelled",
+        "created",
+        "ctrct_cmp",
+        "dispute",
+        "evidence",
+        "fee",
+        "finalized",
+        "init",
+        "mlstn_rls",
+        "opened",
+        "refunded",
+        "resolved",
+        "unpaused",
+        "withdraw",
+        "pause",
+        "mlstn_idx",
+        "settlement_token_bound",
+        "arbiter_cfg",
+        "limits",
+        "rep_cfg",
+    ];
+    let new_topics = ["mlstn_app", "rep_issd"];
+    for nt in new_topics {
+        assert!(
+            !existing.contains(&nt),
+            "New topic '{}' collides with an existing one",
+            nt
+        );
+    }
+}

--- a/contracts/escrow/src/test/mod.rs
+++ b/contracts/escrow/src/test/mod.rs
@@ -41,6 +41,7 @@ mod rollback;
 mod security;
 // Temporarily unwired: DisputeInfo / DisputeSummary field mismatch on broken main.
 // mod settlement_overflow;
+mod event_assertions;
 mod simulate_create_contract;
 mod simulate_deposit;
 mod simulate_release;
@@ -66,6 +67,7 @@ pub struct EscrowFixture {
     pub escrow_address: Address,
     pub escrow_id: u32,
     pub settlement_token: Option<Address>,
+    pub release_authorization: ReleaseAuthorization,
 }
 
 impl EscrowFixture {
@@ -101,10 +103,11 @@ pub struct EscrowFixtureBuilder {
     milestones: Option<Vec<i128>>,
     settlement_token: bool,
     fund: bool,
+    release_authorization: ReleaseAuthorization,
+    completed: bool,
 }
 
 impl EscrowFixtureBuilder {
-    /// Create a builder backed by a fresh mocked Soroban environment.
     pub fn new() -> Self {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();
@@ -115,21 +118,20 @@ impl EscrowFixtureBuilder {
             milestones: None,
             settlement_token: false,
             fund: false,
+            release_authorization: ReleaseAuthorization::ClientOnly,
+            completed: false,
         }
     }
 
-    /// Expose the builder environment for generating compatible test values.
     pub fn env(&self) -> &Env {
         &self.env
     }
 
-    /// Use `admin` instead of a generated administrator.
     pub fn with_admin(mut self, admin: Address) -> Self {
         self.admin = Some(admin);
         self
     }
 
-    /// Use explicit client, freelancer, and optional arbiter addresses.
     pub fn with_participants(
         mut self,
         client: Address,
@@ -140,27 +142,34 @@ impl EscrowFixtureBuilder {
         self
     }
 
-    /// Use the supplied milestone amounts instead of the default 3-step plan.
     pub fn with_milestones(mut self, milestones: Vec<i128>) -> Self {
         self.milestones = Some(milestones);
         self
     }
 
-    /// Register and bind a Stellar Asset Contract for custody transfers.
     pub fn with_settlement_token(mut self) -> Self {
         self.settlement_token = true;
         self
     }
 
-    /// Create and fully fund the escrow contract during [`Self::build`].
     pub fn funded(mut self) -> Self {
         self.fund = true;
         self.settlement_token = true;
         self
     }
 
-    /// Build the configured fixture and return its ready escrow ID in
-    /// [`EscrowFixture::escrow_id`].
+    pub fn release_authorization(mut self, auth: ReleaseAuthorization) -> Self {
+        self.release_authorization = auth;
+        self
+    }
+
+    pub fn completed(mut self) -> Self {
+        self.completed = true;
+        self.fund = true;
+        self.settlement_token = true;
+        self
+    }
+
     pub fn build(self) -> EscrowFixture {
         let admin = self.admin.unwrap_or_else(|| Address::generate(&self.env));
         let (client, freelancer, arbiter) = self.participants.unwrap_or_else(|| {
@@ -188,7 +197,7 @@ impl EscrowFixtureBuilder {
             &freelancer,
             &arbiter,
             &milestones,
-            &ReleaseAuthorization::ClientOnly,
+            &self.release_authorization,
         );
 
         if self.fund {
@@ -200,6 +209,33 @@ impl EscrowFixtureBuilder {
             escrow.deposit_funds(&escrow_id, &client, &total);
         }
 
+        if self.completed {
+            let escrow_client = &escrow;
+            for i in 0..milestones.len() {
+                match self.release_authorization {
+                    ReleaseAuthorization::ClientOnly => {
+                        escrow_client.approve_milestone_release(&escrow_id, &client, &(i as u32));
+                    }
+                    ReleaseAuthorization::ArbiterOnly => {
+                        let arb = arbiter.as_ref().expect("Arbiter required for ArbiterOnly");
+                        escrow_client.approve_milestone_release(&escrow_id, arb, &(i as u32));
+                    }
+                    ReleaseAuthorization::ClientAndArbiter => {
+                        escrow_client.approve_milestone_release(&escrow_id, &client, &(i as u32));
+                    }
+                    ReleaseAuthorization::MultiSig => {
+                        escrow_client.approve_milestone_release(&escrow_id, &client, &(i as u32));
+                        escrow_client.approve_milestone_release(
+                            &escrow_id,
+                            &freelancer,
+                            &(i as u32),
+                        );
+                    }
+                }
+                escrow_client.release_milestone(&escrow_id, &client, &(i as u32));
+            }
+        }
+
         EscrowFixture {
             env: self.env,
             admin,
@@ -209,6 +245,7 @@ impl EscrowFixtureBuilder {
             escrow_address,
             escrow_id,
             settlement_token,
+            release_authorization: self.release_authorization,
         }
     }
 }


### PR DESCRIPTION
Adds mlstn_app (milestone approval) and rep_issd (reputation issuance) events with full test coverage. Closes https://github.com/Talenttrust/Talenttrust-Contracts/issues/1326