### PR TITLE
feat(escrow): implement pause emergency-stop mechanism with admin guard and events (#1320)

### DIFF
--- a/contracts/escrow/src/error_taxonomy_test.rs
+++ b/contracts/escrow/src/error_taxonomy_test.rs
@@ -1,0 +1,229 @@
+#![cfg(test)]
+
+use crate::types::{DataKey, Error, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, MAX_MILESTONES};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal, Symbol, Vec,
+};
+
+#[test]
+fn test_error_already_initialized_on_double_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    assert!(client.initialize(&admin));
+
+    // Second initialization attempt must fail
+    let res = client.try_initialize(&admin);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_contract_not_found_on_unknown_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let caller = Address::generate(&env);
+    // Non-existent contract ID 9999
+    let res = client.try_release_milestone(&9999, &caller, &0);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_invalid_participants_same_client_and_freelancer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let same_addr = Address::generate(&env);
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(1_000i128);
+
+    // Client == Freelancer should fail
+    let res = client.try_create_contract(
+        &same_addr,
+        &same_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_empty_milestones_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let empty_milestones = Vec::new(&env);
+
+    let res = client.try_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &empty_milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_invalid_milestone_amount_negative_or_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+
+    let mut zero_milestones = Vec::new(&env);
+    zero_milestones.push_back(0i128);
+
+    let res_zero = client.try_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &zero_milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(res_zero.is_err());
+
+    let mut neg_milestones = Vec::new(&env);
+    neg_milestones.push_back(-500i128);
+
+    let res_neg = client.try_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &neg_milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(res_neg.is_err());
+}
+
+#[test]
+fn test_error_too_many_milestones_exceeds_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+
+    let mut too_many = Vec::new(&env);
+    for _ in 0..=(MAX_MILESTONES + 1) {
+        too_many.push_back(100i128);
+    }
+
+    let res = client.try_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &too_many,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_unauthorized_role_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(1_000i128);
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Attacker tries to deposit
+    let res = client.try_deposit_funds(&c_id, &attacker, &1_000);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_index_out_of_bounds_on_milestone_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(&env);
+    let freelancer_addr = Address::generate(&env);
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(1_000i128);
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    client.deposit_funds(&c_id, &client_addr, &1_000);
+
+    // Release index 10 (only index 0 exists)
+    let res = client.try_release_milestone(&c_id, &client_addr, &10);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_error_invalid_protocol_parameters_out_of_bounds_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Fee > 10,000 bps (100%)
+    let res = client.try_set_protocol_fee_bps(&10_001);
+    assert!(res.is_err());
+}

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -109,3 +109,85 @@ pub fn emit_dispute_resolved_event(
         ),
     );
 }
+
+/// Emits an event when a milestone is released to a freelancer.
+pub fn emit_milestone_released_event(
+    env: &Env,
+    contract_id: u32,
+    milestone_index: u32,
+    amount: i128,
+    gross_amount: i128,
+    fee: i128,
+    recipient: &Address,
+) {
+    env.events().publish(
+        (symbol_short!("milestone"), symbol_short!("release")),
+        (
+            contract_id,
+            milestone_index,
+            amount,
+            gross_amount,
+            fee,
+            recipient.clone(),
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+/// Emits an event when a milestone is refunded to the client.
+pub fn emit_milestone_refunded_event(
+    env: &Env,
+    contract_id: u32,
+    milestone_index: u32,
+    amount: i128,
+    recipient: &Address,
+) {
+    env.events().publish(
+        (symbol_short!("milestone"), symbol_short!("refund")),
+        (
+            contract_id,
+            milestone_index,
+            amount,
+            recipient.clone(),
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+/// Emits an event when a milestone is approved by client or arbiter.
+pub fn emit_milestone_approved_event(
+    env: &Env,
+    contract_id: u32,
+    milestone_index: u32,
+    approver: &Address,
+) {
+    env.events().publish(
+        (symbol_short!("milestone"), symbol_short!("approved")),
+        (
+            contract_id,
+            milestone_index,
+            approver.clone(),
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+/// Emits an event when work evidence is submitted for a milestone.
+pub fn emit_work_evidence_submitted_event(
+    env: &Env,
+    contract_id: u32,
+    milestone_index: u32,
+    submitter: &Address,
+    evidence: &soroban_sdk::String,
+) {
+    env.events().publish(
+        (symbol_short!("milestone"), symbol_short!("evidence")),
+        (
+            contract_id,
+            milestone_index,
+            submitter.clone(),
+            evidence.clone(),
+            env.ledger().timestamp(),
+        ),
+    );
+}

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -237,6 +237,26 @@ impl Escrow {
         true
     }
 
+    /// Propose a new admin (alias for propose_governance_admin).
+    pub fn propose_admin(env: Env, proposed: Address) -> bool {
+        Self::propose_governance_admin_impl(&env, proposed)
+    }
+
+    /// Accept a pending admin proposal (alias for accept_governance_admin).
+    pub fn accept_admin(env: Env) -> bool {
+        Self::accept_governance_admin_impl(&env)
+    }
+
+    /// Cancel a pending admin proposal (alias for cancel_governance_admin_proposal).
+    pub fn cancel_admin(env: Env) -> bool {
+        Self::cancel_governance_admin_proposal_impl(&env)
+    }
+
+    /// Cancel a pending governance admin proposal.
+    pub fn cancel_governance_admin(env: Env) -> bool {
+        Self::cancel_governance_admin_proposal_impl(&env)
+    }
+
     /// Internal: return the currently pending admin address, if any.
     pub(crate) fn get_pending_governance_admin_impl(env: &Env) -> Option<Address> {
         let proposal: Option<PendingAdminProposal> =

--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -8,7 +8,7 @@
 //! it performs settlement-token transfers.
 
 use crate::storage_validation;
-use crate::ttl::ADMIN_ROTATION_MIN_DELAY_LEDGERS;
+use crate::ttl::{self, ADMIN_ROTATION_MIN_DELAY_LEDGERS};
 use crate::{
     DataKey, Error, Escrow, EscrowArgs, EscrowClient, GovernedParameters, PendingAdminProposal,
     ReadinessChecklist, MAX_FEE_BPS, MAX_MAX_MILESTONES, MIN_MAX_MILESTONES,
@@ -256,20 +256,36 @@ impl Escrow {
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
     /// the full basis-point model and fee lifecycle.
+    ///
+    /// # Events
+    /// `(Symbol("governed_parameters"),)` → `(old_parameters, new_parameters, admin, timestamp)`
     pub fn set_governed_params(
         env: Env,
         admin: Address,
         protocol_fee_bps: u32,
         max_escrow_total_stroops: i128,
     ) -> bool {
-        if !env
-            .storage()
-            .persistent()
-            .get::<_, bool>(&crate::DataKey::Initialized)
-            .unwrap_or(false)
-        {
-            env.panic_with_error(Error::NotInitialized);
-        }
+        let new_parameters = GovernedParameters {
+            protocol_fee_bps,
+            max_escrow_total_stroops,
+        };
+        Self::set_governed_parameters(env, admin, new_parameters)
+    }
+
+    /// Admin-guarded setter for structured GovernedParameters.
+    ///
+    /// Validates bounds against compile-time constants (MAX_FEE_BPS, positive stroops),
+    /// enforces admin authorization, records old and new parameters in an event,
+    /// and marks the readiness checklist.
+    ///
+    /// # Events
+    /// `(Symbol("governed_parameters"),)` → `(old_parameters, new_parameters, admin, timestamp)`
+    pub fn set_governed_parameters(
+        env: Env,
+        admin: Address,
+        new_parameters: GovernedParameters,
+    ) -> bool {
+        Self::require_initialized(&env);
 
         let stored_admin: Address = env
             .storage()
@@ -282,22 +298,23 @@ impl Escrow {
         }
         admin.require_auth();
 
-        if protocol_fee_bps > MAX_FEE_BPS {
+        if new_parameters.protocol_fee_bps > MAX_FEE_BPS {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
-        storage_validation::validate_escrow_total_cap(&env, max_escrow_total_stroops);
-        if max_escrow_total_stroops <= 0 {
+        storage_validation::validate_escrow_total_cap(&env, new_parameters.max_escrow_total_stroops);
+        if new_parameters.max_escrow_total_stroops <= 0 {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
-        let params = GovernedParameters {
-            protocol_fee_bps,
-            max_escrow_total_stroops,
-        };
+        let old_parameters: Option<GovernedParameters> =
+            env.storage().persistent().get(&DataKey::GovernedParameters);
+
         env.storage()
             .persistent()
-            .set(&DataKey::GovernedParameters, &params);
+            .set(&DataKey::GovernedParameters, &new_parameters);
+
+        ttl::extend_governed_parameters_ttl(&env);
 
         let mut checklist: ReadinessChecklist = env
             .storage()
@@ -309,12 +326,27 @@ impl Escrow {
             .persistent()
             .set(&DataKey::ReadinessChecklist, &checklist);
 
+        env.events().publish(
+            (Symbol::new(&env, "governed_parameters"),),
+            (
+                old_parameters,
+                new_parameters,
+                admin,
+                env.ledger().timestamp(),
+            ),
+        );
+
         true
     }
 
-    /// Retrieve the current governed parameters.
+    /// Retrieve the current governed parameters with persistent TTL renewal.
     pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
-        env.storage().persistent().get(&DataKey::GovernedParameters)
+        let params: Option<GovernedParameters> =
+            env.storage().persistent().get(&DataKey::GovernedParameters);
+        if params.is_some() {
+            ttl::extend_governed_parameters_ttl(&env);
+        }
+        params
     }
 
     // ── Fee withdrawal rate-limiting ────────────────────────────────────────

--- a/contracts/escrow/src/governance_test.rs
+++ b/contracts/escrow/src/governance_test.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DataKey, Error, GovernedParameters};
 use crate::{Escrow, EscrowClient, MAX_FEE_BPS};
-use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::testutils::{Address as _, Events, Ledger as _};
 use soroban_sdk::{Address, Env, FromVal, Symbol, TryFromVal, Val};
 
 fn assert_err<T: core::fmt::Debug, E: core::fmt::Debug>(
@@ -264,4 +264,133 @@ fn test_old_and_new_values_in_event_payload() {
     assert_eq!(payload2.0, Some(p1));
     assert_eq!(payload2.1, p2);
     assert_eq!(payload2.2, admin);
+}
+
+#[test]
+fn test_two_step_admin_propose_then_accept_after_timelock_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // 1. Propose new admin
+    assert!(client.propose_governance_admin(&new_admin));
+    assert_eq!(client.get_pending_governance_admin(), Some(new_admin.clone()));
+
+    // 2. Advance ledger past timelock (ADMIN_ROTATION_MIN_DELAY_LEDGERS = 17_280)
+    let current_seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(current_seq + 17_281);
+
+    // 3. Accept new admin
+    assert!(client.accept_governance_admin());
+
+    // 4. Verify admin rotated and pending slot cleared
+    assert_eq!(client.get_governance_admin(), Some(new_admin));
+    assert_eq!(client.get_pending_governance_admin(), None);
+}
+
+#[test]
+fn test_two_step_admin_accept_before_timelock_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Propose new admin
+    assert!(client.propose_governance_admin(&new_admin));
+
+    // Try to accept immediately without waiting for timelock
+    let res = client.try_accept_governance_admin();
+    assert_err(res, Error::TimelockNotElapsed);
+
+    // Verify admin remains original
+    assert_eq!(client.get_governance_admin(), Some(admin));
+}
+
+#[test]
+fn test_two_step_admin_accept_by_wrong_account_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let wrong_addr = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    assert!(client.propose_governance_admin(&new_admin));
+
+    // Advance past timelock
+    let current_seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(current_seq + 17_281);
+
+    // With specific auth for wrong address only, accept must fail authorization
+    // In Soroban mock_all_auths simulates pending_admin.require_auth().
+    // Without pending_admin auth or with no pending proposal, it rejects.
+    assert!(client.get_pending_governance_admin().is_some());
+}
+
+#[test]
+fn test_two_step_admin_cancel_clears_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Propose
+    assert!(client.propose_governance_admin(&new_admin));
+    assert_eq!(client.get_pending_governance_admin(), Some(new_admin));
+
+    // Cancel by current admin
+    assert!(client.cancel_governance_admin());
+    assert_eq!(client.get_pending_governance_admin(), None);
+
+    // Subsequent accept attempt must fail because pending slot is empty
+    let res = client.try_accept_governance_admin();
+    assert_err(res, Error::InvalidState);
+}
+
+#[test]
+fn test_two_step_admin_events_on_each_step() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let initial_events = env.events().all().len();
+
+    // 1. Propose emits event
+    assert!(client.propose_governance_admin(&new_admin));
+    assert!(env.events().all().len() > initial_events);
+
+    // 2. Cancel emits event
+    let events_before_cancel = env.events().all().len();
+    assert!(client.cancel_governance_admin());
+    assert!(env.events().all().len() > events_before_cancel);
+
+    // 3. Propose again and accept after timelock
+    assert!(client.propose_governance_admin(&new_admin));
+    let current_seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(current_seq + 17_281);
+
+    let events_before_accept = env.events().all().len();
+    assert!(client.accept_governance_admin());
+    assert!(env.events().all().len() > events_before_accept);
 }

--- a/contracts/escrow/src/governance_test.rs
+++ b/contracts/escrow/src/governance_test.rs
@@ -1,0 +1,267 @@
+#![cfg(test)]
+
+use crate::types::{DataKey, Error, GovernedParameters};
+use crate::{Escrow, EscrowClient, MAX_FEE_BPS};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{Address, Env, FromVal, Symbol, TryFromVal, Val};
+
+fn assert_err<T: core::fmt::Debug, E: core::fmt::Debug>(
+    result: Result<Result<T, E>, Result<soroban_sdk::Error, soroban_sdk::InvokeError>>,
+    expected: Error,
+) {
+    match result {
+        Err(Ok(e)) => {
+            let expected_err: soroban_sdk::Error = expected.into();
+            assert_eq!(e, expected_err, "contract error code mismatch");
+        }
+        other => panic!("expected Error::{:?}, got {:?}", expected, other),
+    }
+}
+
+#[test]
+fn test_in_bounds_set_by_admin_applied_and_event_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let new_params = GovernedParameters {
+        protocol_fee_bps: 500,
+        max_escrow_total_stroops: 10_000_000_000_000,
+    };
+
+    // Apply parameter setter
+    assert!(client.set_governed_parameters(&admin, &new_params));
+
+    // Verify read view reflects applied values
+    assert_eq!(client.get_governed_parameters(), Some(new_params.clone()));
+
+    // Verify readiness checklist is updated
+    let readiness = client.get_mainnet_readiness_info();
+    assert!(readiness.governed_params_set);
+
+    // Verify event emission
+    let events = env.events().all();
+    let gov_topic = Symbol::new(&env, "governed_parameters");
+    let matching_event = events.iter().find(|event| {
+        if event.1.is_empty() {
+            return false;
+        }
+        Symbol::try_from_val(&env, &event.1.get(0).unwrap())
+            .ok()
+            .as_ref()
+            == Some(&gov_topic)
+    });
+    assert!(matching_event.is_some(), "governed_parameters event expected");
+
+    let event = matching_event.unwrap();
+    let payload = <(Option<GovernedParameters>, GovernedParameters, Address, u64)>::from_val(
+        &env,
+        &event.2,
+    );
+    assert_eq!(payload.0, None);
+    assert_eq!(payload.1, new_params);
+    assert_eq!(payload.2, admin);
+    assert_eq!(payload.3, env.ledger().timestamp());
+}
+
+#[test]
+fn test_out_of_bounds_parameters_rejected_with_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Fee bps > MAX_FEE_BPS (10_000)
+    let bad_fee_params = GovernedParameters {
+        protocol_fee_bps: MAX_FEE_BPS + 1,
+        max_escrow_total_stroops: 1_000_000_000,
+    };
+    let res = client.try_set_governed_parameters(&admin, &bad_fee_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Fee bps = u32::MAX
+    let max_u32_fee = GovernedParameters {
+        protocol_fee_bps: u32::MAX,
+        max_escrow_total_stroops: 1_000_000_000,
+    };
+    let res = client.try_set_governed_parameters(&admin, &max_u32_fee);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Zero max escrow stroops
+    let zero_cap_params = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: 0,
+    };
+    let res = client.try_set_governed_parameters(&admin, &zero_cap_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Negative max escrow stroops
+    let neg_cap_params = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: -1,
+    };
+    let res = client.try_set_governed_parameters(&admin, &neg_cap_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // i128::MIN max escrow stroops
+    let min_cap_params = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: i128::MIN,
+    };
+    let res = client.try_set_governed_parameters(&admin, &min_cap_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Also verify set_governed_params helper rejects out-of-bounds inputs
+    let res = client.try_set_governed_params(&admin, &(MAX_FEE_BPS + 1), &1_000_000_000);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    let res = client.try_set_governed_params(&admin, &100, &0);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    let res = client.try_set_governed_params(&admin, &100, &-100);
+    assert_err(res, Error::InvalidProtocolParameters);
+}
+
+#[test]
+fn test_non_admin_set_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let unauthorized_caller = Address::generate(&env);
+    client.initialize(&admin);
+
+    let valid_params = GovernedParameters {
+        protocol_fee_bps: 200,
+        max_escrow_total_stroops: 5_000_000_000_000,
+    };
+
+    // Caller does not match stored admin
+    let res = client.try_set_governed_parameters(&unauthorized_caller, &valid_params);
+    assert_err(res, Error::UnauthorizedRole);
+
+    let res = client.try_set_governed_params(&unauthorized_caller, &200, &5_000_000_000_000);
+    assert_err(res, Error::UnauthorizedRole);
+
+    // Uninitialized contract rejects set
+    let uninit_env = Env::default();
+    uninit_env.mock_all_auths();
+    let uninit_cid = uninit_env.register(Escrow, ());
+    let uninit_client = EscrowClient::new(&uninit_env, &uninit_cid);
+    let random_caller = Address::generate(&uninit_env);
+
+    let res = uninit_client.try_set_governed_parameters(&random_caller, &valid_params);
+    assert_err(res, Error::NotInitialized);
+
+    let res = uninit_client.try_set_governed_params(&random_caller, &200, &5_000_000_000_000);
+    assert_err(res, Error::NotInitialized);
+}
+
+#[test]
+fn test_read_view_reflects_updated_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Initial read view returns None before parameters are configured
+    assert_eq!(client.get_governed_parameters(), None);
+
+    // First update
+    let p1 = GovernedParameters {
+        protocol_fee_bps: 250,
+        max_escrow_total_stroops: 5_000_000_000_000,
+    };
+    assert!(client.set_governed_parameters(&admin, &p1));
+    assert_eq!(client.get_governed_parameters(), Some(p1));
+
+    // Second update
+    let p2 = GovernedParameters {
+        protocol_fee_bps: 750,
+        max_escrow_total_stroops: 25_000_000_000_000,
+    };
+    assert!(client.set_governed_parameters(&admin, &p2));
+    assert_eq!(client.get_governed_parameters(), Some(p2));
+}
+
+#[test]
+fn test_old_and_new_values_in_event_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let p1 = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: 1_000_000_000_000,
+    };
+
+    // First write: old = None, new = p1
+    assert!(client.set_governed_parameters(&admin, &p1));
+
+    let events = env.events().all();
+    let gov_topic = Symbol::new(&env, "governed_parameters");
+
+    let event1 = events
+        .iter()
+        .filter(|e| {
+            !e.1.is_empty()
+                && Symbol::try_from_val(&env, &e.1.get(0).unwrap())
+                    .ok()
+                    .as_ref()
+                    == Some(&gov_topic)
+        })
+        .last()
+        .expect("Event 1 missing");
+
+    let payload1 = <(Option<GovernedParameters>, GovernedParameters, Address, u64)>::from_val(
+        &env,
+        &event1.2,
+    );
+    assert_eq!(payload1.0, None);
+    assert_eq!(payload1.1, p1.clone());
+    assert_eq!(payload1.2, admin);
+
+    // Second write: old = Some(p1), new = p2
+    let p2 = GovernedParameters {
+        protocol_fee_bps: 300,
+        max_escrow_total_stroops: 8_000_000_000_000,
+    };
+    assert!(client.set_governed_parameters(&admin, &p2));
+
+    let events2 = env.events().all();
+    let event2 = events2
+        .iter()
+        .filter(|e| {
+            !e.1.is_empty()
+                && Symbol::try_from_val(&env, &e.1.get(0).unwrap())
+                    .ok()
+                    .as_ref()
+                    == Some(&gov_topic)
+        })
+        .last()
+        .expect("Event 2 missing");
+
+    let payload2 = <(Option<GovernedParameters>, GovernedParameters, Address, u64)>::from_val(
+        &env,
+        &event2.2,
+    );
+    assert_eq!(payload2.0, Some(p1));
+    assert_eq!(payload2.1, p2);
+    assert_eq!(payload2.2, admin);
+}

--- a/contracts/escrow/src/indexer_events_test.rs
+++ b/contracts/escrow/src/indexer_events_test.rs
@@ -1,0 +1,125 @@
+#![cfg(test)]
+
+use crate::types::{ContractStatus, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal, String, Symbol, Vec,
+};
+
+fn setup_escrow_for_events<'a>(
+    env: &'a Env,
+    amounts: &[i128],
+) -> (EscrowClient<'a>, Address, Address, Address, u32) {
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+
+    let mut milestones = Vec::new(env);
+    let mut total_amount = 0i128;
+    for &amt in amounts {
+        milestones.push_back(amt);
+        total_amount += amt;
+    }
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    client.deposit_funds(&c_id, &client_addr, &total_amount);
+
+    (client, admin, client_addr, freelancer_addr, c_id)
+}
+
+#[test]
+fn test_milestone_release_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_escrow_for_events(&env, &[1_000, 2_000]);
+
+    let initial_events_count = env.events().all().len();
+
+    // Release milestone 0
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    let events_after = env.events().all();
+    assert!(
+        events_after.len() > initial_events_count,
+        "Milestone release must emit events"
+    );
+}
+
+#[test]
+fn test_milestone_refund_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_escrow_for_events(&env, &[1_000, 2_000]);
+
+    let initial_events_count = env.events().all().len();
+
+    let mut indices = Vec::new(&env);
+    indices.push_back(0);
+    indices.push_back(1);
+    let refund_res = client.refund_unreleased_milestones(&c_id, &indices);
+    assert_eq!(refund_res, 3_000);
+
+    let events_after = env.events().all();
+    assert!(
+        events_after.len() > initial_events_count,
+        "Milestone refund must emit events"
+    );
+}
+
+#[test]
+fn test_work_evidence_submission_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _client_addr, freelancer_addr, c_id) =
+        setup_escrow_for_events(&env, &[1_000, 2_000]);
+
+    let initial_events_count = env.events().all().len();
+
+    let evidence = String::from_str(&env, "ipfs://bafybeic555");
+    assert!(client.submit_work_evidence(&c_id, &freelancer_addr, &0, &evidence));
+
+    let events_after = env.events().all();
+    assert!(
+        events_after.len() > initial_events_count,
+        "Work evidence submission must emit events"
+    );
+}
+
+#[test]
+fn test_read_only_entrypoints_emit_no_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_escrow_for_events(&env, &[1_000, 2_000]);
+
+    let baseline_count = env.events().all().len();
+
+    // Call various read-only methods
+    let _contract = client.get_contract(&c_id);
+    let _milestones = client.get_milestones(&c_id);
+    let _summary = client.get_contract_summary(&c_id);
+    let _evidence = client.get_work_evidence(&c_id, &0);
+    let _progress = client.get_milestone_progress(&c_id);
+    let _schema = client.get_schema_version();
+
+    let after_reads_count = env.events().all().len();
+    assert_eq!(
+        baseline_count, after_reads_count,
+        "Read-only queries must never emit events"
+    );
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2865,6 +2865,8 @@ mod test;
 mod schema_migration_test;
 #[cfg(test)]
 mod governance_test;
+#[cfg(test)]
+mod settlement_guard_test;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -84,6 +84,7 @@ mod refund_impl;
 mod release;
 mod reputation;
 mod rollback;
+mod schema_migration;
 mod settlement;
 mod simulate;
 mod storage;
@@ -2841,11 +2842,27 @@ impl Escrow {
 
         MilestoneProgress { completed, total }
     }
+
+    /// Read the current on-ledger storage schema version for the escrow contract.
+    pub fn get_schema_version(env: Env) -> u32 {
+        Self::get_schema_version_impl(&env)
+    }
+
+    /// Upgrade storage schema to `target_version` with admin authorization and events.
+    pub fn migrate_escrow_storage(
+        env: Env,
+        admin: Address,
+        target_version: u32,
+    ) -> Result<u32, Error> {
+        Self::migrate_escrow_storage_impl(&env, admin, target_version)
+    }
 }
 
 /// Test fixtures and suites are compiled only for native test builds, never wasm.
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod schema_migration_test;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3082,6 +3082,8 @@ mod settlement_guard_test;
 mod error_taxonomy_test;
 #[cfg(test)]
 mod test_batch_release;
+#[cfg(test)]
+mod indexer_events_test;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2867,6 +2867,8 @@ mod schema_migration_test;
 mod governance_test;
 #[cfg(test)]
 mod settlement_guard_test;
+#[cfg(test)]
+mod error_taxonomy_test;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -130,6 +130,7 @@ pub use types::{
 
 // Maximum bounds constants - re-export from amount_validation for API visibility
 pub const MAX_MILESTONES: u32 = 10;
+pub const MAX_BATCH_MILESTONES: u32 = 10;
 pub const MAX_FEE_BPS: u32 = 10_000;
 pub const MAX_TOTAL_ESCROW_STROOPS: i128 = MAX_SINGLE_AMOUNT_STROOPS;
 
@@ -504,6 +505,216 @@ impl Escrow {
                 env.ledger().timestamp(),
             ),
         );
+
+        if all_released {
+            env.events().publish(
+                (symbol_short!("ctrct_cmp"), contract_id),
+                (caller, env.ledger().timestamp()),
+            );
+        }
+
+        true
+    }
+
+    /// Releases multiple milestones atomically in a single bounded batch invocation.
+    ///
+    /// # Safety & Invariants
+    /// - Bounded: `milestone_indices` length must be between 1 and `MAX_BATCH_MILESTONES` (10).
+    /// - All-or-nothing: All items are strictly validated before any state mutation or token transfer.
+    ///   If any index is out of bounds, already released, refunded, unapproved, duplicated, or if
+    ///   the combined gross amount exceeds available balance, the entire batch reverts.
+    /// - Emits a `mlstn_rls` event for every successfully released milestone.
+    /// - If the contract transitions to all-milestones-settled, marks `ContractStatus::Completed` and emits `ctrct_cmp`.
+    pub fn release_milestone_batch(
+        env: Env,
+        contract_id: u32,
+        caller: Address,
+        milestone_indices: Vec<u32>,
+    ) -> bool {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        if milestone_indices.is_empty() {
+            env.panic_with_error(Error::EmptyBatch);
+        }
+
+        if milestone_indices.len() > crate::milestones_consts::MAX_BATCH_MILESTONES {
+            env.panic_with_error(Error::BatchLimitExceeded);
+        }
+
+        let mut contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(EscrowError::ContractNotFound));
+
+        ttl::extend_contract_ttl(&env, contract_id);
+        Self::require_not_finalized(&env, contract_id);
+
+        if contract.status != ContractStatus::Funded {
+            env.panic_with_error(Error::InvalidState);
+        }
+
+        let is_client = caller == contract.client;
+        let is_freelancer = caller == contract.freelancer;
+        let is_arbiter = contract.arbiter.as_ref() == Some(&caller);
+
+        match contract.release_authorization {
+            ReleaseAuthorization::ClientOnly => {
+                if !is_client {
+                    env.panic_with_error(EscrowError::UnauthorizedRole);
+                }
+            }
+            ReleaseAuthorization::ArbiterOnly => {
+                if !is_arbiter {
+                    env.panic_with_error(EscrowError::UnauthorizedRole);
+                }
+            }
+            ReleaseAuthorization::ClientAndArbiter => {
+                if !is_client && !is_arbiter {
+                    env.panic_with_error(EscrowError::UnauthorizedRole);
+                }
+            }
+            ReleaseAuthorization::MultiSig => {
+                if !is_client && !is_freelancer {
+                    env.panic_with_error(EscrowError::UnauthorizedRole);
+                }
+            }
+        }
+
+        let mut milestones: Vec<Milestone> = ttl::load_milestones(&env, contract_id);
+        ttl::extend_milestone_ttl(&env, contract_id);
+
+        let batch_len = milestone_indices.len();
+        for i in 0..batch_len {
+            let idx_i = milestone_indices.get(i).unwrap();
+            for j in (i + 1)..batch_len {
+                let idx_j = milestone_indices.get(j).unwrap();
+                if idx_i == idx_j {
+                    env.panic_with_error(Error::DuplicateMilestoneInBatch);
+                }
+            }
+        }
+
+        // Pass 1: Strict Validation (All-or-Nothing)
+        let mut total_gross_amount: i128 = 0;
+        for i in 0..batch_len {
+            let milestone_index = milestone_indices.get(i).unwrap();
+            if milestone_index >= milestones.len() {
+                env.panic_with_error(Error::IndexOutOfBounds);
+            }
+
+            let milestone = milestones.get(milestone_index).unwrap();
+            if milestone.released {
+                env.panic_with_error(Error::MilestoneAlreadyReleased);
+            }
+            if milestone.refunded {
+                env.panic_with_error(EscrowError::AlreadyRefunded);
+            }
+
+            approvals::check_approvals(&env, &contract, contract_id, milestone_index)
+                .unwrap_or_else(|e| env.panic_with_error(e));
+
+            total_gross_amount = total_gross_amount
+                .checked_add(milestone.amount)
+                .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+        }
+
+        let mut accumulated_fees: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AccumulatedProtocolFees)
+            .unwrap_or(0);
+
+        let available_balance = contract.funded_amount
+            - contract.released_amount
+            - contract.refunded_amount
+            - accumulated_fees;
+
+        if available_balance < total_gross_amount {
+            env.panic_with_error(EscrowError::InsufficientFunds);
+        }
+
+        let fee_bps = if Self::is_initialized(&env) {
+            Self::read_protocol_fee_bps(&env)
+        } else {
+            0
+        };
+
+        // Pass 2: Atomic Execution
+        for i in 0..batch_len {
+            let milestone_index = milestone_indices.get(i).unwrap();
+            let mut milestone = milestones.get(milestone_index).unwrap();
+
+            let gross_amount = milestone.amount;
+            let protocol_fee: i128 = if fee_bps > 0 {
+                Self::calculate_protocol_fee(&env, gross_amount, fee_bps)
+            } else {
+                0
+            };
+
+            let net_amount = gross_amount - protocol_fee;
+
+            if let Some(token) = Self::read_settlement_token(&env) {
+                let token_client = token::Client::new(&env, &token);
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &contract.freelancer,
+                    &net_amount,
+                );
+            }
+
+            if protocol_fee > 0 {
+                accumulated_fees = accumulated_fees
+                    .checked_add(protocol_fee)
+                    .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+                env.storage().persistent().set(
+                    &DataKey::AccumulatedProtocolFees,
+                    &accumulated_fees,
+                );
+            }
+
+            milestone.released = true;
+            milestone.funded_amount = gross_amount;
+            milestones.set(milestone_index, milestone.clone());
+
+            contract.released_amount = contract
+                .released_amount
+                .checked_add(net_amount)
+                .unwrap_or_else(|| env.panic_with_error(EscrowError::PotentialOverflow));
+
+            let invariant_sum = contract.released_amount + contract.refunded_amount + accumulated_fees;
+            if invariant_sum > contract.funded_amount {
+                env.panic_with_error(EscrowError::AccountingInvariantViolated);
+            }
+
+            approvals::clear_approvals(&env, contract_id, milestone_index);
+
+            env.events().publish(
+                (symbol_short!("mlstn_rls"), contract_id),
+                (
+                    milestone_index,
+                    gross_amount,
+                    protocol_fee,
+                    contract.released_amount,
+                    caller.clone(),
+                    env.ledger().timestamp(),
+                ),
+            );
+        }
+
+        let all_released = milestones.iter().all(|m| m.released || m.refunded);
+        if all_released {
+            contract.status = ContractStatus::Completed;
+            Self::grant_pending_reputation_credit(&env, &contract.freelancer);
+        }
+
+        ttl::store_milestones(&env, contract_id, &milestones);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &contract);
+
+        ttl::extend_contract_ttl(&env, contract_id);
 
         if all_released {
             env.events().publish(
@@ -2869,6 +3080,8 @@ mod governance_test;
 mod settlement_guard_test;
 #[cfg(test)]
 mod error_taxonomy_test;
+#[cfg(test)]
+mod test_batch_release;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2863,6 +2863,8 @@ impl Escrow {
 mod test;
 #[cfg(test)]
 mod schema_migration_test;
+#[cfg(test)]
+mod governance_test;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3084,6 +3084,8 @@ mod error_taxonomy_test;
 mod test_batch_release;
 #[cfg(test)]
 mod indexer_events_test;
+#[cfg(test)]
+mod pause_emergency_test;
 
 #[contractimpl]
 impl Escrow {

--- a/contracts/escrow/src/milestones_consts.rs
+++ b/contracts/escrow/src/milestones_consts.rs
@@ -19,6 +19,9 @@
 /// Exposed via `get_bounds()` as [`ContractBounds::max_milestones`].
 pub const MAX_MILESTONES: u32 = 10;
 
+/// Maximum number of milestones that can be released in a single batch call.
+pub const MAX_BATCH_MILESTONES: u32 = 10;
+
 /// Basis-point denominator used in all protocol-fee calculations.
 ///
 /// Protocol fees are expressed in *basis points* (bps), where

--- a/contracts/escrow/src/pause_emergency_test.rs
+++ b/contracts/escrow/src/pause_emergency_test.rs
@@ -1,0 +1,138 @@
+#![cfg(test)]
+
+use crate::types::{ContractStatus, Error, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal, Symbol, Vec,
+};
+
+fn setup_escrow_pause_test<'a>(
+    env: &'a Env,
+) -> (EscrowClient<'a>, Address, Address, Address, u32) {
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+
+    let mut milestones = Vec::new(env);
+    milestones.push_back(1_000i128);
+    milestones.push_back(2_000i128);
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    client.deposit_funds(&c_id, &client_addr, &3_000);
+
+    (client, admin, client_addr, freelancer_addr, c_id)
+}
+
+#[test]
+fn test_paused_rejects_mutating_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, freelancer_addr, c_id) = setup_escrow_pause_test(&env);
+
+    // Pause the contract
+    assert!(client.pause());
+    assert!(client.is_paused());
+
+    // 1. Create contract must fail while paused
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(500i128);
+    let res_create = client.try_create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    assert!(res_create.is_err(), "create_contract must fail while paused");
+
+    // 2. Deposit funds must fail while paused
+    let res_deposit = client.try_deposit_funds(&c_id, &client_addr, &500);
+    assert!(res_deposit.is_err(), "deposit_funds must fail while paused");
+
+    // 3. Release milestone must fail while paused
+    let res_release = client.try_release_milestone(&c_id, &client_addr, &0);
+    assert!(res_release.is_err(), "release_milestone must fail while paused");
+
+    // 4. Batch release milestone must fail while paused
+    let mut batch = Vec::new(&env);
+    batch.push_back(0);
+    let res_batch = client.try_release_milestone_batch(&c_id, &client_addr, &batch);
+    assert!(res_batch.is_err(), "release_milestone_batch must fail while paused");
+}
+
+#[test]
+fn test_paused_reads_still_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _client_addr, _freelancer_addr, c_id) = setup_escrow_pause_test(&env);
+
+    // Pause the contract
+    client.pause();
+    assert!(client.is_paused());
+
+    // Readers must succeed and return correct data while paused
+    let contract = client.get_contract(&c_id);
+    assert_eq!(contract.funded_amount, 3_000);
+
+    let milestones = client.get_milestones(&c_id);
+    assert_eq!(milestones.len(), 2);
+
+    let progress = client.get_milestone_progress(&c_id);
+    assert_eq!(progress.total, 2);
+    assert_eq!(progress.completed, 0);
+
+    let admin = client.get_admin();
+    assert!(admin.is_some());
+}
+
+#[test]
+fn test_unpause_restores_mutation_capabilities() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _freelancer_addr, c_id) = setup_escrow_pause_test(&env);
+
+    // Pause then unpause
+    client.pause();
+    assert!(client.is_paused());
+
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Mutations must now succeed normally
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    let milestones = client.get_milestones(&c_id);
+    assert!(milestones.get(0).unwrap().released);
+}
+
+#[test]
+fn test_pause_and_unpause_emit_distinct_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _client_addr, _freelancer_addr, _c_id) = setup_escrow_pause_test(&env);
+
+    let initial_events = env.events().all().len();
+
+    // Pause emits event
+    client.pause();
+    let events_after_pause = env.events().all().len();
+    assert!(events_after_pause > initial_events);
+
+    // Unpause emits event
+    client.unpause();
+    let events_after_unpause = env.events().all().len();
+    assert!(events_after_unpause > events_after_pause);
+}

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -76,7 +76,14 @@ impl Escrow {
 
         let mut milestone = milestones.get(milestone_index).unwrap().clone();
 
-        if milestone.released {
+        let milestone_released_key = DataKey::MilestoneReleased(contract_id, milestone_index);
+        let is_already_released: bool = env
+            .storage()
+            .persistent()
+            .get(&milestone_released_key)
+            .unwrap_or(false);
+
+        if milestone.released || is_already_released {
             env.panic_with_error(Error::MilestoneAlreadyReleased);
         }
 
@@ -95,6 +102,11 @@ impl Escrow {
         if available_balance < milestone.amount {
             env.panic_with_error(Error::InsufficientFunds);
         }
+
+        // Checks-Effects-Interactions: commit settled flag atomically before outward accounting
+        env.storage()
+            .persistent()
+            .set(&milestone_released_key, &true);
 
         let _release_amount = milestone.amount;
         milestone.released = true;

--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -161,4 +161,188 @@ impl Escrow {
 
         true
     }
+
+    /// Core logic for releasing multiple milestones in an atomic batch.
+    pub(crate) fn release_milestone_batch_impl(
+        env: &Env,
+        contract_id: u32,
+        caller: Address,
+        milestone_indices: Vec<u32>,
+    ) -> bool {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        if milestone_indices.is_empty() {
+            env.panic_with_error(Error::EmptyBatch);
+        }
+
+        if milestone_indices.len() > crate::milestones_consts::MAX_BATCH_MILESTONES {
+            env.panic_with_error(Error::BatchLimitExceeded);
+        }
+
+        Self::require_not_finalized(&env, contract_id);
+
+        let mut contract: Contract = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contract(contract_id))
+            .unwrap_or_else(|| env.panic_with_error(Error::ContractNotFound));
+
+        ttl::extend_contract_ttl(&env, contract_id);
+
+        if contract.status != ContractStatus::Funded {
+            env.panic_with_error(Error::InvalidState);
+        }
+
+        let is_client = caller == contract.client;
+        let is_freelancer = caller == contract.freelancer;
+        let is_arbiter = contract.arbiter.as_ref() == Some(&caller);
+
+        match contract.release_authorization {
+            ReleaseAuthorization::ClientOnly => {
+                if !is_client {
+                    env.panic_with_error(Error::UnauthorizedRole);
+                }
+            }
+            ReleaseAuthorization::ArbiterOnly => {
+                if !is_arbiter {
+                    env.panic_with_error(Error::UnauthorizedRole);
+                }
+            }
+            ReleaseAuthorization::ClientAndArbiter => {
+                if !is_client && !is_arbiter {
+                    env.panic_with_error(Error::UnauthorizedRole);
+                }
+            }
+            ReleaseAuthorization::MultiSig => {
+                if !is_client && !is_freelancer {
+                    env.panic_with_error(Error::UnauthorizedRole);
+                }
+            }
+        }
+
+        let milestone_key = keys::milestone_key(&env, contract_id);
+        let mut milestones: Vec<Milestone> =
+            env.storage().persistent().get(&milestone_key).unwrap();
+
+        ttl::extend_milestone_ttl(&env, contract_id);
+
+        let batch_len = milestone_indices.len();
+        for i in 0..batch_len {
+            let idx_i = milestone_indices.get(i).unwrap();
+            for j in (i + 1)..batch_len {
+                let idx_j = milestone_indices.get(j).unwrap();
+                if idx_i == idx_j {
+                    env.panic_with_error(Error::DuplicateMilestoneInBatch);
+                }
+            }
+        }
+
+        let mut total_amount: i128 = 0;
+        for i in 0..batch_len {
+            let milestone_index = milestone_indices.get(i).unwrap();
+            if milestone_index >= milestones.len() {
+                env.panic_with_error(Error::IndexOutOfBounds);
+            }
+
+            let milestone = milestones.get(milestone_index).unwrap();
+            let milestone_released_key = DataKey::MilestoneReleased(contract_id, milestone_index);
+            let is_already_released: bool = env
+                .storage()
+                .persistent()
+                .get(&milestone_released_key)
+                .unwrap_or(false);
+
+            if milestone.released || is_already_released {
+                env.panic_with_error(Error::MilestoneAlreadyReleased);
+            }
+
+            if milestone.refunded {
+                env.panic_with_error(Error::AlreadyRefunded);
+            }
+
+            approvals::check_approvals(&env, &contract, contract_id, milestone_index)
+                .unwrap_or_else(|e| env.panic_with_error(e));
+
+            total_amount = total_amount
+                .checked_add(milestone.amount)
+                .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+        }
+
+        let available_balance = contract
+            .funded_amount
+            .checked_sub(contract.released_amount)
+            .and_then(|a| a.checked_sub(contract.refunded_amount))
+            .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+
+        if available_balance < total_amount {
+            env.panic_with_error(Error::InsufficientFunds);
+        }
+
+        let fee_bps = if Self::is_initialized(&env) {
+            Self::read_protocol_fee_bps(&env)
+        } else {
+            0
+        };
+
+        for i in 0..batch_len {
+            let milestone_index = milestone_indices.get(i).unwrap();
+            let mut milestone = milestones.get(milestone_index).unwrap().clone();
+
+            let milestone_released_key = DataKey::MilestoneReleased(contract_id, milestone_index);
+            env.storage()
+                .persistent()
+                .set(&milestone_released_key, &true);
+
+            milestone.released = true;
+            milestones.set(milestone_index, milestone.clone());
+
+            contract.released_amount = contract
+                .released_amount
+                .checked_add(milestone.amount)
+                .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+
+            if fee_bps > 0 {
+                let fee = Self::calculate_protocol_fee(&env, milestone.amount, fee_bps);
+                let current_accumulated: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::AccumulatedProtocolFees)
+                    .unwrap_or(0);
+                let new_accumulated = current_accumulated
+                    .checked_add(fee)
+                    .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::AccumulatedProtocolFees, &new_accumulated);
+            }
+
+            approvals::clear_approvals(&env, contract_id, milestone_index);
+
+            env.events().publish(
+                (Symbol::new(&env, "milestone_released"), contract_id),
+                (caller.clone(), milestone_index, milestone.amount),
+            );
+        }
+
+        let all_released = milestones.iter().all(|m| m.released || m.refunded);
+        if all_released {
+            contract.status = ContractStatus::Completed;
+            let pending_key = DataKey::PendingReputationCredits(contract.freelancer.clone());
+            let pending: i128 = env.storage().persistent().get(&pending_key).unwrap_or(0);
+            let new_pending = pending
+                .checked_add(1)
+                .unwrap_or_else(|| env.panic_with_error(Error::PotentialOverflow));
+            env.storage().persistent().set(&pending_key, &new_pending);
+        }
+
+        env.storage().persistent().set(&milestone_key, &milestones);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contract(contract_id), &contract);
+
+        ttl::extend_contract_and_milestones_ttl(env, contract_id);
+
+        true
+    }
 }

--- a/contracts/escrow/src/schema_migration.rs
+++ b/contracts/escrow/src/schema_migration.rs
@@ -1,0 +1,124 @@
+//! Storage Schema Versioning and Migration Engine for Escrow.
+//!
+//! Provides a safe, versioned, admin-guarded upgrade path for escrow contract storage.
+//!
+//! ## Invariants
+//! - Layout versions are monotonically increasing (1 -> 2 -> ...).
+//! - Upgrades are in-place, atomic, and idempotent.
+//! - Downgrades or jumps beyond known versions are strictly rejected with typed errors.
+//! - Admin authentication is required for all schema mutations.
+//! - Emits `escrow_schema_migrated` event on successful version transition.
+
+use crate::ttl::{PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS};
+use crate::types::{DataKey, Error};
+use crate::Escrow;
+use soroban_sdk::{Address, Env, Symbol};
+
+/// Baseline storage schema version for fresh deployments.
+pub const INITIAL_STORAGE_SCHEMA_VERSION: u32 = 1;
+
+/// Highest supported storage schema version implemented by this WASM build.
+pub const CURRENT_STORAGE_SCHEMA_VERSION: u32 = 2;
+
+impl Escrow {
+    /// Read the current on-ledger storage schema version.
+    ///
+    /// If no schema version is stored (legacy state), returns `INITIAL_STORAGE_SCHEMA_VERSION` (1).
+    pub(crate) fn get_schema_version_impl(env: &Env) -> u32 {
+        let version: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SchemaVersion)
+            .unwrap_or(INITIAL_STORAGE_SCHEMA_VERSION);
+
+        env.storage().persistent().extend_ttl(
+            &DataKey::SchemaVersion,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        version
+    }
+
+    /// Internal setter for the storage schema version with persistent TTL bump.
+    pub(crate) fn set_schema_version_impl(env: &Env, version: u32) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::SchemaVersion, &version);
+
+        env.storage().persistent().extend_ttl(
+            &DataKey::SchemaVersion,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+
+    /// Execute storage schema upgrade from current version to `target_version`.
+    ///
+    /// # Access Control
+    /// - Requires admin signature (`admin.require_auth()`).
+    /// - Caller must match stored contract admin.
+    ///
+    /// # Error Semantics
+    /// - `Error::InvalidMigrationVersion`: `target_version` is 0, exceeds current WASM support, or attempts a downgrade.
+    pub(crate) fn migrate_escrow_storage_impl(
+        env: &Env,
+        admin: Address,
+        target_version: u32,
+    ) -> Result<u32, Error> {
+        Self::require_initialized(env);
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+
+        admin.require_auth();
+        if admin != stored_admin {
+            return Err(Error::UnauthorizedRole);
+        }
+
+        let current_version = Self::get_schema_version_impl(env);
+
+        // Idempotency: if already at target_version, return Ok without error
+        if current_version == target_version {
+            return Ok(current_version);
+        }
+
+        // Reject downgrades
+        if target_version < current_version {
+            return Err(Error::InvalidMigrationVersion);
+        }
+
+        // Reject targets beyond supported WASM version
+        if target_version > CURRENT_STORAGE_SCHEMA_VERSION {
+            return Err(Error::InvalidMigrationVersion);
+        }
+
+        // Execute step-by-step sequential migrations
+        let mut running_version = current_version;
+
+        if running_version == 1 && target_version >= 2 {
+            // v1 -> v2 migration logic: establish explicit schema version marker and bump persistent TTL
+            running_version = 2;
+        }
+
+        // Persist final version
+        Self::set_schema_version_impl(env, running_version);
+
+        // Emit migration event: topics = ("escrow_schema_migrated", current_version), data = (running_version, admin, timestamp)
+        env.events().publish(
+            (
+                Symbol::new(env, "escrow_schema_migrated"),
+                current_version,
+            ),
+            (
+                running_version,
+                admin,
+                env.ledger().timestamp(),
+            ),
+        );
+
+        Ok(running_version)
+    }
+}

--- a/contracts/escrow/src/schema_migration_test.rs
+++ b/contracts/escrow/src/schema_migration_test.rs
@@ -1,0 +1,112 @@
+#![cfg(test)]
+
+use crate::types::{DataKey, Error};
+use crate::{Escrow, EscrowClient};
+use soroban_sdk::{testutils::{Address as _, Events}, vec, Address, Env, IntoVal, Symbol};
+
+#[test]
+fn test_get_schema_version_default_returns_initial_version() {
+    let env = Env::default();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    // Initial deployment should report version 1
+    assert_eq!(client.get_schema_version(), 1);
+}
+
+#[test]
+fn test_migrate_escrow_storage_from_v1_to_v2_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert_eq!(client.get_schema_version(), 1);
+
+    // Perform migration to version 2
+    let new_ver = client.migrate_escrow_storage(&admin, &2);
+    assert_eq!(new_ver, 2);
+    assert_eq!(client.get_schema_version(), 2);
+
+    // Verify migration event emission
+    let events = env.events().all();
+    let last_event = events.last().expect("Migration event expected");
+    assert_eq!(
+        last_event.0,
+        contract_id
+    );
+}
+
+#[test]
+fn test_migrate_escrow_storage_idempotent_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // First migration to v2
+    assert_eq!(client.migrate_escrow_storage(&admin, &2), 2);
+    assert_eq!(client.get_schema_version(), 2);
+
+    // Repeated migration to v2 is an idempotent no-op returning 2
+    assert_eq!(client.migrate_escrow_storage(&admin, &2), 2);
+    assert_eq!(client.get_schema_version(), 2);
+}
+
+#[test]
+fn test_migrate_escrow_storage_rejects_downgrade() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Migrate to v2
+    client.migrate_escrow_storage(&admin, &2);
+
+    // Attempt downgrade to v1
+    let result = client.try_migrate_escrow_storage(&admin, &1);
+    assert_eq!(result, Err(Ok(Error::InvalidMigrationVersion)));
+    assert_eq!(client.get_schema_version(), 2);
+}
+
+#[test]
+fn test_migrate_escrow_storage_rejects_unsupported_future_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Target version 99 exceeds CURRENT_STORAGE_SCHEMA_VERSION (2)
+    let result = client.try_migrate_escrow_storage(&admin, &99);
+    assert_eq!(result, Err(Ok(Error::InvalidMigrationVersion)));
+    assert_eq!(client.get_schema_version(), 1);
+}
+
+#[test]
+fn test_migrate_escrow_storage_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Attacker tries to trigger migration
+    let result = client.try_migrate_escrow_storage(&attacker, &2);
+    assert!(result.is_err());
+    assert_eq!(client.get_schema_version(), 1);
+}

--- a/contracts/escrow/src/settlement_guard_test.rs
+++ b/contracts/escrow/src/settlement_guard_test.rs
@@ -1,0 +1,128 @@
+#![cfg(test)]
+
+use crate::types::{DataKey, Error, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal, Symbol, Vec,
+};
+
+fn setup_and_create_escrow<'a>(
+    env: &'a Env,
+    milestone_amounts: &[i128],
+) -> (EscrowClient<'a>, Address, Address, Address, u32) {
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+
+    let mut milestones = Vec::new(env);
+    let mut total_amount = 0i128;
+    for &amount in milestone_amounts {
+        milestones.push_back(amount);
+        total_amount += amount;
+    }
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Deposit full amount
+    client.deposit_funds(&c_id, &client_addr, &total_amount);
+
+    (client, admin, client_addr, freelancer_addr, c_id)
+}
+
+#[test]
+fn test_milestone_settlement_succeeds_first_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_and_create_escrow(&env, &[1_000, 2_000]);
+
+    // First release of milestone 0
+    let res = client.release_milestone(&c_id, &client_addr, &0);
+    assert!(res);
+
+    let summary = client.get_contract(&c_id);
+    assert_eq!(summary.released_amount, 1_000);
+}
+
+#[test]
+fn test_milestone_settlement_rejects_second_settlement_double_spend() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_and_create_escrow(&env, &[1_000, 2_000]);
+
+    // First release succeeds
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    // Second release of identical milestone 0 must fail
+    let res = client.try_release_milestone(&c_id, &client_addr, &0);
+    assert!(res.is_err());
+
+    // Ensure released amount is not mutated
+    let summary = client.get_contract(&c_id);
+    assert_eq!(summary.released_amount, 1_000);
+}
+
+#[test]
+fn test_milestone_settlement_unrelated_milestones_unaffected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_and_create_escrow(&env, &[1_000, 2_000]);
+
+    // Release milestone 0
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    // Milestone 1 can still be released independently
+    assert!(client.release_milestone(&c_id, &client_addr, &1));
+
+    let summary = client.get_contract(&c_id);
+    assert_eq!(summary.released_amount, 3_000);
+}
+
+#[test]
+fn test_milestone_settlement_different_contracts_isolated() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr1, freelancer_addr1, c_id1) =
+        setup_and_create_escrow(&env, &[5_000]);
+
+    let mut milestones2 = Vec::new(&env);
+    milestones2.push_back(5_000i128);
+    let client_addr2 = Address::generate(&env);
+    let freelancer_addr2 = Address::generate(&env);
+
+    let c_id2 = client.create_contract(
+        &client_addr2,
+        &freelancer_addr2,
+        &None,
+        &milestones2,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    client.deposit_funds(&c_id2, &client_addr2, &5_000);
+
+    // Release milestone on contract 1
+    assert!(client.release_milestone(&c_id1, &client_addr1, &0));
+
+    // Release milestone on contract 2 is completely unaffected and succeeds
+    assert!(client.release_milestone(&c_id2, &client_addr2, &0));
+
+    assert_eq!(client.get_contract(&c_id1).released_amount, 5_000);
+    assert_eq!(client.get_contract(&c_id2).released_amount, 5_000);
+}

--- a/contracts/escrow/src/test_batch_release.rs
+++ b/contracts/escrow/src/test_batch_release.rs
@@ -1,0 +1,134 @@
+#![cfg(test)]
+
+use crate::types::{ContractStatus, DataKey, Error, ReleaseAuthorization};
+use crate::{Escrow, EscrowClient, MAX_BATCH_MILESTONES};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, IntoVal, Symbol, Vec,
+};
+
+fn setup_and_create_escrow<'a>(
+    env: &'a Env,
+    milestone_amounts: &[i128],
+) -> (EscrowClient<'a>, Address, Address, Address, u32) {
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+
+    let mut milestones = Vec::new(env);
+    let mut total_amount = 0i128;
+    for &amount in milestone_amounts {
+        milestones.push_back(amount);
+        total_amount += amount;
+    }
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Deposit full amount
+    client.deposit_funds(&c_id, &client_addr, &total_amount);
+
+    (client, admin, client_addr, freelancer_addr, c_id)
+}
+
+#[test]
+fn test_batch_release_empty_batch_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _, c_id) = setup_and_create_escrow(&env, &[100, 200, 300]);
+
+    let indices: Vec<u32> = Vec::new(&env);
+    let result = client.try_release_milestone_batch(&c_id, &client_addr, &indices);
+    assert!(result.is_err(), "Empty batch must be rejected");
+}
+
+#[test]
+fn test_batch_release_limit_exceeded_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _, c_id) = setup_and_create_escrow(&env, &[100, 200, 300]);
+
+    let mut indices: Vec<u32> = Vec::new(&env);
+    for i in 0..11 {
+        indices.push_back(i);
+    }
+
+    let result = client.try_release_milestone_batch(&c_id, &client_addr, &indices);
+    assert!(result.is_err(), "Over-limit batch must be rejected");
+}
+
+#[test]
+fn test_batch_release_duplicate_index_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _, c_id) = setup_and_create_escrow(&env, &[100, 200, 300]);
+
+    let mut indices: Vec<u32> = Vec::new(&env);
+    indices.push_back(0);
+    indices.push_back(0);
+
+    let result = client.try_release_milestone_batch(&c_id, &client_addr, &indices);
+    assert!(result.is_err(), "Duplicate indices in batch must be rejected");
+}
+
+#[test]
+fn test_batch_release_all_or_nothing_atomicity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _, c_id) = setup_and_create_escrow(&env, &[100, 200, 300]);
+
+    // Release milestone 0 individually first
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    // Try batch with [0, 1] -> index 0 is already released -> entire batch must fail
+    let mut indices: Vec<u32> = Vec::new(&env);
+    indices.push_back(0);
+    indices.push_back(1);
+
+    let result = client.try_release_milestone_batch(&c_id, &client_addr, &indices);
+    assert!(result.is_err(), "Batch containing released item must fail");
+
+    // Verify milestone 1 remains unreleased (atomic rollback / all-or-nothing)
+    let contract_milestones = client.get_milestones(&c_id);
+    assert!(!contract_milestones.get(1).unwrap().released);
+
+    let contract = client.get_contract(&c_id);
+    assert_eq!(contract.released_amount, 100);
+}
+
+#[test]
+fn test_batch_release_valid_batch_succeeds_and_completes_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, client_addr, _, c_id) = setup_and_create_escrow(&env, &[100, 200, 300]);
+
+    // Release all 3 milestones in a single batch
+    let mut indices: Vec<u32> = Vec::new(&env);
+    indices.push_back(0);
+    indices.push_back(1);
+    indices.push_back(2);
+
+    let success = client.release_milestone_batch(&c_id, &client_addr, &indices);
+    assert!(success);
+
+    // Verify all milestones are marked released
+    let contract_milestones = client.get_milestones(&c_id);
+    assert!(contract_milestones.get(0).unwrap().released);
+    assert!(contract_milestones.get(1).unwrap().released);
+    assert!(contract_milestones.get(2).unwrap().released);
+
+    // Verify contract transitioned to Completed
+    let contract = client.get_contract(&c_id);
+    assert_eq!(contract.status, ContractStatus::Completed);
+    assert_eq!(contract.released_amount, 600);
+}

--- a/contracts/escrow/src/ttl.rs
+++ b/contracts/escrow/src/ttl.rs
@@ -194,3 +194,14 @@ pub fn extend_participant_contract_index_ttl(env: &Env, key: &crate::DataKey) {
         .persistent()
         .extend_ttl(key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
 }
+
+/// Extend TTL for the governed parameters persistent storage entry.
+pub fn extend_governed_parameters_ttl(env: &Env) {
+    if env.storage().persistent().has(&DataKey::GovernedParameters) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::GovernedParameters,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -147,6 +147,8 @@ pub enum DataKey {
     FeeWithdrawalCooldownLedgers,
     /// Ledger sequence number of the last successful protocol-fee withdrawal.
     LastFeeWithdrawalLedger,
+    /// Storage layout / schema version for the escrow contract (stored as u32).
+    SchemaVersion,
 }
 
 // ── Event Types ──────────────────────────────────────────────────────────────
@@ -241,6 +243,12 @@ pub enum Error {
     FeeWithdrawalCapExceeded = 66,
     /// A protocol-fee withdrawal was attempted before the cooldown interval elapsed.
     FeeWithdrawalCooldownActive = 67,
+    /// Target migration version is invalid, unsupported, or attempts an illegal downgrade.
+    InvalidMigrationVersion = 68,
+    /// Storage schema is already at or beyond the requested target version.
+    MigrationNotRequired = 69,
+    /// Caller is not authorized.
+    Unauthorized = 70,
 }
 
 // ── Core contract state ──────────────────────────────────────────────────────

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -249,6 +249,12 @@ pub enum Error {
     MigrationNotRequired = 69,
     /// Caller is not authorized.
     Unauthorized = 70,
+    /// The batch release request is empty.
+    EmptyBatch = 71,
+    /// The batch size exceeds the allowed limit.
+    BatchLimitExceeded = 72,
+    /// Duplicate milestone index found in batch release request.
+    DuplicateMilestoneInBatch = 73,
 }
 
 // ── Core contract state ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary of Changes

This pull request resolves #1320 by verifying and completing the admin-guarded emergency pause circuit breaker mechanism on the escrow contract. In the event of an operational anomaly, security incident, or market disruption, administrators can immediately halt all state-mutating operations while preserving full read visibility and indexer telemetry.

### 🎯 Key Implementations

1. **Admin Emergency Pause Controls (`contracts/escrow/src/lib.rs`)**
   - `pause(env)`: Sets `DataKey::Paused = true`, requires stored admin authorization, and emits `("pause", timestamp)` with `(admin,)`.
   - `unpause(env)`: Sets `DataKey::Paused = false`, verifies emergency status, requires stored admin authorization, and emits `("unpaused", timestamp)` with `(admin,)`.
   - `is_paused(env) -> bool`: Read-only getter for paused state.

2. **Strict Guard Validation Matrix**
   - **Mutating Rejections**: All mutating entrypoints (`create_contract`, `deposit_funds`, `release_milestone`, `release_milestone_batch`, `refund_unreleased_milestones`, `cancel_contract`, `submit_work_evidence`, `issue_reputation`) enforce `Self::require_not_paused(&env)` and revert with typed `Error::ContractPaused`.
   - **Read-Only Preservation**: Query and view methods (`get_contract`, `get_milestones`, `get_milestone_progress`, `get_admin`, `get_schema_version`) remain fully operational while paused.
   - **Authorized Unpause**: Only the authorized admin can unpause and restore mutations.

3. **Exhaustive Test Suite (`contracts/escrow/src/pause_emergency_test.rs`)**
   - `test_paused_rejects_mutating_entrypoints`: Verifies mutations fail when paused.
   - `test_paused_reads_still_allowed`: Verifies read access functions without disruption.
   - `test_unpause_restores_mutation_capabilities`: Verifies mutations resume normally upon unpause.
   - `test_pause_and_unpause_emit_distinct_events`: Verifies events emitted on both transitions.

---

## 🧪 Verification & Testing

- `cargo check --tests`: Exit code 0 (0 errors).