### PR TITLE
feat(escrow): implement atomic milestone settlement reentrancy and double-spend guard (#1323)

### DIFF
--- a/contracts/escrow/src/release.rs
+++ b/contracts/escrow/src/release.rs
@@ -76,7 +76,14 @@ impl Escrow {
 
         let mut milestone = milestones.get(milestone_index).unwrap().clone();
 
-        if milestone.released {
+        let milestone_released_key = DataKey::MilestoneReleased(contract_id, milestone_index);
+        let is_already_released: bool = env
+            .storage()
+            .persistent()
+            .get(&milestone_released_key)
+            .unwrap_or(false);
+
+        if milestone.released || is_already_released {
             env.panic_with_error(Error::MilestoneAlreadyReleased);
         }
 
@@ -95,6 +102,11 @@ impl Escrow {
         if available_balance < milestone.amount {
             env.panic_with_error(Error::InsufficientFunds);
         }
+
+        // Checks-Effects-Interactions: commit settled flag atomically before outward accounting
+        env.storage()
+            .persistent()
+            .set(&milestone_released_key, &true);
 
         let _release_amount = milestone.amount;
         milestone.released = true;

--- a/contracts/escrow/tests/settlement_guard.rs
+++ b/contracts/escrow/tests/settlement_guard.rs
@@ -1,0 +1,122 @@
+use escrow::{Escrow, EscrowClient, ReleaseAuthorization};
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+fn setup_and_create_escrow<'a>(
+    env: &'a Env,
+    milestone_amounts: &[i128],
+) -> (EscrowClient<'a>, Address, Address, Address, u32) {
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let client_addr = Address::generate(env);
+    let freelancer_addr = Address::generate(env);
+
+    let mut milestones = Vec::new(env);
+    let mut total_amount = 0i128;
+    for &amount in milestone_amounts {
+        milestones.push_back(amount);
+        total_amount += amount;
+    }
+
+    let c_id = client.create_contract(
+        &client_addr,
+        &freelancer_addr,
+        &None,
+        &milestones,
+        &ReleaseAuthorization::ClientOnly,
+    );
+
+    // Deposit full amount
+    client.deposit_funds(&c_id, &client_addr, &total_amount);
+
+    (client, admin, client_addr, freelancer_addr, c_id)
+}
+
+#[test]
+fn test_milestone_settlement_succeeds_first_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_and_create_escrow(&env, &[1_000, 2_000]);
+
+    // First release of milestone 0
+    let res = client.release_milestone(&c_id, &client_addr, &0);
+    assert!(res);
+
+    let summary = client.get_contract(&c_id);
+    assert_eq!(summary.released_amount, 1_000);
+}
+
+#[test]
+fn test_milestone_settlement_rejects_second_settlement_double_spend() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_and_create_escrow(&env, &[1_000, 2_000]);
+
+    // First release succeeds
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    // Second release of identical milestone 0 must fail
+    let res = client.try_release_milestone(&c_id, &client_addr, &0);
+    assert!(res.is_err());
+
+    // Ensure released amount is not mutated
+    let summary = client.get_contract(&c_id);
+    assert_eq!(summary.released_amount, 1_000);
+}
+
+#[test]
+fn test_milestone_settlement_unrelated_milestones_unaffected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr, _freelancer_addr, c_id) =
+        setup_and_create_escrow(&env, &[1_000, 2_000]);
+
+    // Release milestone 0
+    assert!(client.release_milestone(&c_id, &client_addr, &0));
+
+    // Milestone 1 can still be released independently
+    assert!(client.release_milestone(&c_id, &client_addr, &1));
+
+    let summary = client.get_contract(&c_id);
+    assert_eq!(summary.released_amount, 3_000);
+}
+
+#[test]
+fn test_milestone_settlement_different_contracts_isolated() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, client_addr1, _freelancer_addr1, c_id1) =
+        setup_and_create_escrow(&env, &[5_000]);
+
+    let mut milestones2 = Vec::new(&env);
+    milestones2.push_back(5_000i128);
+    let client_addr2 = Address::generate(&env);
+    let freelancer_addr2 = Address::generate(&env);
+
+    let c_id2 = client.create_contract(
+        &client_addr2,
+        &freelancer_addr2,
+        &None,
+        &milestones2,
+        &ReleaseAuthorization::ClientOnly,
+    );
+    client.deposit_funds(&c_id2, &client_addr2, &5_000);
+
+    // Release milestone on contract 1
+    assert!(client.release_milestone(&c_id1, &client_addr1, &0));
+
+    // Release milestone on contract 2 is completely unaffected and succeeds
+    assert!(client.release_milestone(&c_id2, &client_addr2, &0));
+
+    assert_eq!(client.get_contract(&c_id1).released_amount, 5_000);
+    assert_eq!(client.get_contract(&c_id2).released_amount, 5_000);
+}


### PR DESCRIPTION
## Summary

Resolves #1323 by adding a persistent milestone settlement guard so a milestone cannot be released twice or re-entered into a second settlement path.

## Key changes

- Adds a storage-backed released marker keyed by contract id and milestone index.
- Checks both milestone state and the persistent settlement marker before payout.
- Marks the milestone as released before downstream accounting so repeated settlement attempts fail closed.
- Preserves existing release behavior and event shape for indexer compatibility.

## Tests

- First settlement succeeds and second settlement is rejected.
- Rejected repeat settlement does not mutate escrow balances.
- Guard is isolated across unrelated milestones and contracts.

## Branch hygiene note

The current PR diff appears to include inherited escrow hardening from adjacent branches. The intended review scope for this PR is the settlement guard in `release.rs` and its regression tests.