### PR TITLE
feat(escrow): implement bounded admin parameter setter with auth and events (#1327)

### DIFF
--- a/contracts/escrow/src/governance.rs
+++ b/contracts/escrow/src/governance.rs
@@ -8,7 +8,7 @@
 //! it performs settlement-token transfers.
 
 use crate::storage_validation;
-use crate::ttl::ADMIN_ROTATION_MIN_DELAY_LEDGERS;
+use crate::ttl::{self, ADMIN_ROTATION_MIN_DELAY_LEDGERS};
 use crate::{
     DataKey, Error, Escrow, EscrowArgs, EscrowClient, GovernedParameters, PendingAdminProposal,
     ReadinessChecklist, MAX_FEE_BPS, MAX_MAX_MILESTONES, MIN_MAX_MILESTONES,
@@ -256,20 +256,36 @@ impl Escrow {
     ///
     /// See [`docs/escrow/protocol-fees.md`](../../../docs/escrow/protocol-fees.md) for
     /// the full basis-point model and fee lifecycle.
+    ///
+    /// # Events
+    /// `(Symbol("governed_parameters"),)` → `(old_parameters, new_parameters, admin, timestamp)`
     pub fn set_governed_params(
         env: Env,
         admin: Address,
         protocol_fee_bps: u32,
         max_escrow_total_stroops: i128,
     ) -> bool {
-        if !env
-            .storage()
-            .persistent()
-            .get::<_, bool>(&crate::DataKey::Initialized)
-            .unwrap_or(false)
-        {
-            env.panic_with_error(Error::NotInitialized);
-        }
+        let new_parameters = GovernedParameters {
+            protocol_fee_bps,
+            max_escrow_total_stroops,
+        };
+        Self::set_governed_parameters(env, admin, new_parameters)
+    }
+
+    /// Admin-guarded setter for structured GovernedParameters.
+    ///
+    /// Validates bounds against compile-time constants (MAX_FEE_BPS, positive stroops),
+    /// enforces admin authorization, records old and new parameters in an event,
+    /// and marks the readiness checklist.
+    ///
+    /// # Events
+    /// `(Symbol("governed_parameters"),)` → `(old_parameters, new_parameters, admin, timestamp)`
+    pub fn set_governed_parameters(
+        env: Env,
+        admin: Address,
+        new_parameters: GovernedParameters,
+    ) -> bool {
+        Self::require_initialized(&env);
 
         let stored_admin: Address = env
             .storage()
@@ -282,22 +298,26 @@ impl Escrow {
         }
         admin.require_auth();
 
-        if protocol_fee_bps > MAX_FEE_BPS {
+        if new_parameters.protocol_fee_bps > MAX_FEE_BPS {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
-        storage_validation::validate_escrow_total_cap(&env, max_escrow_total_stroops);
-        if max_escrow_total_stroops <= 0 {
+        storage_validation::validate_escrow_total_cap(
+            &env,
+            new_parameters.max_escrow_total_stroops,
+        );
+        if new_parameters.max_escrow_total_stroops <= 0 {
             env.panic_with_error(Error::InvalidProtocolParameters);
         }
 
-        let params = GovernedParameters {
-            protocol_fee_bps,
-            max_escrow_total_stroops,
-        };
+        let old_parameters: Option<GovernedParameters> =
+            env.storage().persistent().get(&DataKey::GovernedParameters);
+
         env.storage()
             .persistent()
-            .set(&DataKey::GovernedParameters, &params);
+            .set(&DataKey::GovernedParameters, &new_parameters);
+
+        ttl::extend_governed_parameters_ttl(&env);
 
         let mut checklist: ReadinessChecklist = env
             .storage()
@@ -309,12 +329,27 @@ impl Escrow {
             .persistent()
             .set(&DataKey::ReadinessChecklist, &checklist);
 
+        env.events().publish(
+            (Symbol::new(&env, "governed_parameters"),),
+            (
+                old_parameters,
+                new_parameters,
+                admin,
+                env.ledger().timestamp(),
+            ),
+        );
+
         true
     }
 
-    /// Retrieve the current governed parameters.
+    /// Retrieve the current governed parameters with persistent TTL renewal.
     pub fn get_governed_parameters(env: Env) -> Option<GovernedParameters> {
-        env.storage().persistent().get(&DataKey::GovernedParameters)
+        let params: Option<GovernedParameters> =
+            env.storage().persistent().get(&DataKey::GovernedParameters);
+        if params.is_some() {
+            ttl::extend_governed_parameters_ttl(&env);
+        }
+        params
     }
 
     // ── Fee withdrawal rate-limiting ────────────────────────────────────────

--- a/contracts/escrow/src/ttl.rs
+++ b/contracts/escrow/src/ttl.rs
@@ -194,3 +194,14 @@ pub fn extend_participant_contract_index_ttl(env: &Env, key: &crate::DataKey) {
         .persistent()
         .extend_ttl(key, PERSISTENT_BUMP_THRESHOLD, PERSISTENT_TTL_LEDGERS);
 }
+
+/// Extend TTL for the governed parameters persistent storage entry.
+pub fn extend_governed_parameters_ttl(env: &Env) {
+    if env.storage().persistent().has(&DataKey::GovernedParameters) {
+        env.storage().persistent().extend_ttl(
+            &DataKey::GovernedParameters,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+}

--- a/contracts/escrow/tests/governance.rs
+++ b/contracts/escrow/tests/governance.rs
@@ -1,0 +1,263 @@
+#![cfg(test)]
+
+use escrow::{Error, Escrow, EscrowClient, GovernedParameters, MAX_FEE_BPS};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{Address, Env, FromVal, Symbol, TryFromVal};
+
+fn assert_err<T: core::fmt::Debug, E: core::fmt::Debug>(
+    result: Result<Result<T, E>, Result<soroban_sdk::Error, soroban_sdk::InvokeError>>,
+    expected: Error,
+) {
+    match result {
+        Err(Ok(e)) => {
+            let expected_err: soroban_sdk::Error = expected.into();
+            assert_eq!(e, expected_err, "contract error code mismatch");
+        }
+        other => panic!("expected Error::{:?}, got {:?}", expected, other),
+    }
+}
+
+#[test]
+fn test_in_bounds_set_by_admin_applied_and_event_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let new_params = GovernedParameters {
+        protocol_fee_bps: 500,
+        max_escrow_total_stroops: 10_000_000_000_000,
+    };
+
+    // Apply parameter setter
+    assert!(client.set_governed_parameters(&admin, &new_params));
+
+    // Verify read view reflects applied values
+    assert_eq!(client.get_governed_parameters(), Some(new_params.clone()));
+
+    // Verify readiness checklist is updated
+    let readiness = client.get_mainnet_readiness_info();
+    assert!(readiness.governed_params_set);
+
+    // Verify event emission
+    let events = env.events().all();
+    let gov_topic = Symbol::new(&env, "governed_parameters");
+    let matching_event = events.iter().find(|event| {
+        if event.1.is_empty() {
+            return false;
+        }
+        Symbol::try_from_val(&env, &event.1.get(0).unwrap())
+            .ok()
+            .as_ref()
+            == Some(&gov_topic)
+    });
+    assert!(
+        matching_event.is_some(),
+        "governed_parameters event expected"
+    );
+
+    let event = matching_event.unwrap();
+    let payload =
+        <(Option<GovernedParameters>, GovernedParameters, Address, u64)>::from_val(&env, &event.2);
+    assert_eq!(payload.0, None);
+    assert_eq!(payload.1, new_params);
+    assert_eq!(payload.2, admin);
+    assert_eq!(payload.3, env.ledger().timestamp());
+}
+
+#[test]
+fn test_out_of_bounds_parameters_rejected_with_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Fee bps > MAX_FEE_BPS (10_000)
+    let bad_fee_params = GovernedParameters {
+        protocol_fee_bps: MAX_FEE_BPS + 1,
+        max_escrow_total_stroops: 1_000_000_000,
+    };
+    let res = client.try_set_governed_parameters(&admin, &bad_fee_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Fee bps = u32::MAX
+    let max_u32_fee = GovernedParameters {
+        protocol_fee_bps: u32::MAX,
+        max_escrow_total_stroops: 1_000_000_000,
+    };
+    let res = client.try_set_governed_parameters(&admin, &max_u32_fee);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Zero max escrow stroops
+    let zero_cap_params = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: 0,
+    };
+    let res = client.try_set_governed_parameters(&admin, &zero_cap_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Negative max escrow stroops
+    let neg_cap_params = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: -1,
+    };
+    let res = client.try_set_governed_parameters(&admin, &neg_cap_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // i128::MIN max escrow stroops
+    let min_cap_params = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: i128::MIN,
+    };
+    let res = client.try_set_governed_parameters(&admin, &min_cap_params);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    // Also verify set_governed_params helper rejects out-of-bounds inputs
+    let res = client.try_set_governed_params(&admin, &(MAX_FEE_BPS + 1), &1_000_000_000);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    let res = client.try_set_governed_params(&admin, &100, &0);
+    assert_err(res, Error::InvalidProtocolParameters);
+
+    let res = client.try_set_governed_params(&admin, &100, &-100);
+    assert_err(res, Error::InvalidProtocolParameters);
+}
+
+#[test]
+fn test_non_admin_set_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let unauthorized_caller = Address::generate(&env);
+    client.initialize(&admin);
+
+    let valid_params = GovernedParameters {
+        protocol_fee_bps: 200,
+        max_escrow_total_stroops: 5_000_000_000_000,
+    };
+
+    // Caller does not match stored admin
+    let res = client.try_set_governed_parameters(&unauthorized_caller, &valid_params);
+    assert_err(res, Error::UnauthorizedRole);
+
+    let res = client.try_set_governed_params(&unauthorized_caller, &200, &5_000_000_000_000);
+    assert_err(res, Error::UnauthorizedRole);
+
+    // Uninitialized contract rejects set
+    let uninit_env = Env::default();
+    uninit_env.mock_all_auths();
+    let uninit_cid = uninit_env.register(Escrow, ());
+    let uninit_client = EscrowClient::new(&uninit_env, &uninit_cid);
+    let random_caller = Address::generate(&uninit_env);
+
+    let res = uninit_client.try_set_governed_parameters(&random_caller, &valid_params);
+    assert_err(res, Error::NotInitialized);
+
+    let res = uninit_client.try_set_governed_params(&random_caller, &200, &5_000_000_000_000);
+    assert_err(res, Error::NotInitialized);
+}
+
+#[test]
+fn test_read_view_reflects_updated_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Initial read view returns None before parameters are configured
+    assert_eq!(client.get_governed_parameters(), None);
+
+    // First update
+    let p1 = GovernedParameters {
+        protocol_fee_bps: 250,
+        max_escrow_total_stroops: 5_000_000_000_000,
+    };
+    assert!(client.set_governed_parameters(&admin, &p1));
+    assert_eq!(client.get_governed_parameters(), Some(p1));
+
+    // Second update
+    let p2 = GovernedParameters {
+        protocol_fee_bps: 750,
+        max_escrow_total_stroops: 25_000_000_000_000,
+    };
+    assert!(client.set_governed_parameters(&admin, &p2));
+    assert_eq!(client.get_governed_parameters(), Some(p2));
+}
+
+#[test]
+fn test_old_and_new_values_in_event_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Escrow, ());
+    let client = EscrowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let p1 = GovernedParameters {
+        protocol_fee_bps: 100,
+        max_escrow_total_stroops: 1_000_000_000_000,
+    };
+
+    // First write: old = None, new = p1
+    assert!(client.set_governed_parameters(&admin, &p1));
+
+    let events = env.events().all();
+    let gov_topic = Symbol::new(&env, "governed_parameters");
+
+    let event1 = events
+        .iter()
+        .filter(|e| {
+            !e.1.is_empty()
+                && Symbol::try_from_val(&env, &e.1.get(0).unwrap())
+                    .ok()
+                    .as_ref()
+                    == Some(&gov_topic)
+        })
+        .last()
+        .expect("Event 1 missing");
+
+    let payload1 =
+        <(Option<GovernedParameters>, GovernedParameters, Address, u64)>::from_val(&env, &event1.2);
+    assert_eq!(payload1.0, None);
+    assert_eq!(payload1.1, p1.clone());
+    assert_eq!(payload1.2, admin);
+
+    // Second write: old = Some(p1), new = p2
+    let p2 = GovernedParameters {
+        protocol_fee_bps: 300,
+        max_escrow_total_stroops: 8_000_000_000_000,
+    };
+    assert!(client.set_governed_parameters(&admin, &p2));
+
+    let events2 = env.events().all();
+    let event2 = events2
+        .iter()
+        .filter(|e| {
+            !e.1.is_empty()
+                && Symbol::try_from_val(&env, &e.1.get(0).unwrap())
+                    .ok()
+                    .as_ref()
+                    == Some(&gov_topic)
+        })
+        .last()
+        .expect("Event 2 missing");
+
+    let payload2 =
+        <(Option<GovernedParameters>, GovernedParameters, Address, u64)>::from_val(&env, &event2.2);
+    assert_eq!(payload2.0, Some(p1));
+    assert_eq!(payload2.1, p2);
+    assert_eq!(payload2.2, admin);
+}


### PR DESCRIPTION
## Summary of Changes

This pull request resolves #1327 by implementing a bounded, admin-guarded setter for escrow protocol parameters with strict range validation, explicit authorization, persistent TTL extension, and comprehensive event emission capturing old and new state.

### 🎯 Key Implementations

1. **Bounded Parameter Setter (`contracts/escrow/src/governance.rs`)**
   - Implemented `set_governed_parameters(env: Env, admin: Address, new_parameters: GovernedParameters) -> bool`.
   - Enforced initialization requirement (`require_initialized`), admin authorization (`admin.require_auth()`), and verified caller against stored admin (`DataKey::Admin`), returning typed error `Error::UnauthorizedRole` on mismatch.
   - Bound validation against compile-time limits (`protocol_fee_bps <= MAX_FEE_BPS`, `max_escrow_total_stroops > 0`), returning typed error `Error::InvalidProtocolParameters` on invalid ranges.
   - Updated `set_governed_params` to delegate to `set_governed_parameters`.
   - Updated `ReadinessChecklist::governed_params_set = true`.

2. **Audit Trail & Event Emission**
   - Emits event on update:
     - Topics: `(Symbol("governed_parameters"),)`
     - Data: `(old_parameters: Option<GovernedParameters>, new_parameters: GovernedParameters, admin: Address, timestamp: u64)`

3. **Persistent TTL Management (`contracts/escrow/src/ttl.rs`)**
   - Added `extend_governed_parameters_ttl(env: &Env)` using `PERSISTENT_BUMP_THRESHOLD` and `PERSISTENT_TTL_LEDGERS`.
   - `get_governed_parameters` automatically bumps TTL upon access.

4. **Exhaustive Unit & Edge Case Test Suite (`contracts/escrow/src/governance_test.rs`)**
   - `test_in_bounds_set_by_admin_applied_and_event_emitted`: Validates successful parameter application and event emission.
   - `test_out_of_bounds_parameters_rejected_with_typed_error`: Asserts out-of-bounds fee and non-positive escrow amounts fail with typed errors.
   - `test_non_admin_set_rejected`: Asserts non-admin calls are rejected with `Error::UnauthorizedRole`.
   - `test_read_view_reflects_updated_values`: Asserts `get_governed_parameters` accurately returns current state.
   - `test_old_and_new_values_in_event_payload`: Validates transition tracking (`None -> Some(p1) -> Some(p2)`) across sequential updates.

---

## 🧪 Verification & Testing

- `cargo check`: Exit code 0 (0 errors, 0 warnings).
- `cargo check --tests`: Exit code 0 (0 errors, 0 warnings).